### PR TITLE
Exporting fields instead of methods on RuleInfo struct

### DIFF
--- a/lint/rule_info.go
+++ b/lint/rule_info.go
@@ -2,39 +2,11 @@ package lint
 
 // ruleInfo stores information of a rule.
 type RuleInfo struct {
-	name        string     // rule name in the set.
-	description string     // a short description of this rule.
-	url         string     // a link to a document for more details.
-	fileTypes   []FileType // types of files that this rule targets to.
-	category    Category   // category of problems this rule produces.
-}
+	Name        string     // rule name in the set.
+	Description string     // a short description of this rule.
+	Url         string     // a link to a document for more details.
+	FileTypes   []FileType // types of files that this rule targets to.
+	Category    Category   // category of problems this rule produces.
 
-func NewRuleInfo(name, description, url string, fileTypes []FileType, category Category) RuleInfo {
-	return RuleInfo{
-		name:        name,
-		description: description,
-		url:         url,
-		fileTypes:   fileTypes,
-		category:    category,
-	}
-}
-
-func (r RuleInfo) Name() string {
-	return r.name
-}
-
-func (r RuleInfo) Description() string {
-	return r.description
-}
-
-func (r RuleInfo) URL() string {
-	return r.url
-}
-
-func (r RuleInfo) FileTypes() []FileType {
-	return r.fileTypes
-}
-
-func (r RuleInfo) Category() Category {
-	return r.category
+	noPositional bool // Prevent positional composite literal instantiation
 }

--- a/lint/rules.go
+++ b/lint/rules.go
@@ -34,10 +34,10 @@ func (r *Rules) Copy() *Rules {
 // in the registry.
 func (r *Rules) Register(rules ...Rule) error {
 	for _, rl := range rules {
-		if _, found := r.ruleMap[rl.Info().Name()]; found {
+		if _, found := r.ruleMap[rl.Info().Name]; found {
 			return ErrDuplicateName
 		}
-		r.ruleMap[rl.Info().Name()] = rl
+		r.ruleMap[rl.Info().Name] = rl
 	}
 	return nil
 }

--- a/lint/rules_test.go
+++ b/lint/rules_test.go
@@ -13,8 +13,8 @@ func TestRulesRegister(t *testing.T) {
 	r1 := new(mocks.Rule)
 	r2 := new(mocks.Rule)
 
-	r1.On("Info").Return(lint.NewRuleInfo("a", "", "", nil, lint.CategorySuggestion))
-	r2.On("Info").Return(lint.NewRuleInfo("b", "", "", nil, lint.CategorySuggestion))
+	r1.On("Info").Return(lint.RuleInfo{Name: "a"})
+	r2.On("Info").Return(lint.RuleInfo{Name: "b"})
 
 	rules, _ := lint.NewRules()
 	err := rules.Register(r1, r2)
@@ -35,8 +35,8 @@ func TestRulesRegister_Duplicate(t *testing.T) {
 	r1 := new(mocks.Rule)
 	r2 := new(mocks.Rule)
 
-	r1.On("Info").Return(lint.NewRuleInfo("a", "", "", nil, lint.CategorySuggestion))
-	r2.On("Info").Return(lint.NewRuleInfo("a", "", "", nil, lint.CategorySuggestion))
+	r1.On("Info").Return(lint.RuleInfo{Name: "a"})
+	r2.On("Info").Return(lint.RuleInfo{Name: "a"})
 
 	rules, _ := lint.NewRules()
 	err := rules.Register(r1, r2)

--- a/lint/run_test.go
+++ b/lint/run_test.go
@@ -27,8 +27,8 @@ func TestRunAll(t *testing.T) {
 
 	r1.On("Lint", req).Return(resp1, nil)
 	r2.On("Lint", req).Return(resp2, nil)
-	r1.On("Info").Return(lint.NewRuleInfo("a", "", "", nil, lint.CategorySuggestion))
-	r2.On("Info").Return(lint.NewRuleInfo("b", "", "", nil, lint.CategorySuggestion))
+	r1.On("Info").Return(lint.RuleInfo{Name: "a"})
+	r2.On("Info").Return(lint.RuleInfo{Name: "b"})
 
 	rules, _ := lint.NewRules(r1, r2)
 	gotResp, err := lint.Run(*rules, req)


### PR DESCRIPTION
Goal here is to allow developers to specify named arguments to instantiate the rule info struct. I've added an unexported field at the bottom to prevent positional composite literals, so that we can safely extend the struct with more fields if we need to.