### PR TITLE
Added print command.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,47 +1,59 @@
 # API Linter
+
 API linter checks APIs defined in protobuf files. It follows [Google API Design Guide](https://cloud.google.com/apis/design/).
 
 ## Requirements
+
 * Install `git` from [https://git-scm.com](https://git-scm.com/);
 * Install `go` from [https://golang.org/doc/install](https://golang.org/doc/install);
 * Install `protoc` by following this [guide](http://google.github.io/proto-lens/installing-protoc.html);
 
 ## Installation
+
 * Download `api-linter` using `git`:
+
 ```sh
 git clone git@github.com:googleapis/api-linter.git $HOME/Downloads/api-linter
 ```
+
 or
-```
+
+```sh
 git clone https://github.com/googleapis/api-linter.git $HOME/Downloads/api-linter
 ```
+
 * Install `api-linter` using `go install`:
+
 ```sh
 cd $HOME/Downloads/api-linter/cmd/api-linter
 go install
 ```
+
 * Update the `PATH` environment to include `$HOME/go/bin`.
 
 ## Usage
-Run `api-linter help` to see the usage. Or run `api-linter help checkproto` to see how to check API protobuf files:
+
+Run `api-linter help` to see usage details. Or run `api-linter help check` to see how to check API protobuf files:
+
 ```sh
 NAME:
-   api-linter checkproto - Check protobuf files that define an API
+   api-linter check - Check protobuf files that define an API
 
 USAGE:
-   api-linter checkproto [command options] files...
+   api-linter check [command options] files...
 
 OPTIONS:
-   --cfg value          configuration file path
-   --out value          output file path (default: stdout)
-   --fmt value          output format (default: "yaml")
-   --protoc value       protocol compiler path (default: "protoc")
-   --proto_path value   the directory in which for protoc to search for imports (default: ".")
+   --cfg value         configuration file path
+   --out value         output file path (default: stdout)
+   --fmt value         output format (default: "yaml")
+   --protoc value      protocol compiler path (default: "protoc")
+   --proto_path value  the directory in which for protoc to search for imports (default: ".")
 ```
 
 See this [example](cmd/api-linter/examples/example.sh).
 
 ## Rule Configuration
+
 The linter contains a list of [core rules](rules), and by default, they are all enabled. However, one can disable a rule by using a configuration file or in-file(line) comments.
 
 ### Disable a rule using a configuration file
@@ -49,6 +61,7 @@ The linter contains a list of [core rules](rules), and by default, they are all 
 Example:
 
 Disable rule `core::proto_version` for any `.proto` files.
+
 ```json
 [
    {
@@ -60,13 +73,13 @@ Disable rule `core::proto_version` for any `.proto` files.
 ]
 ```
 
-
 ### Disable a rule using in-file(line) comments
 
 Example:
 
-1. Disable rule `core::naming_formats::field_names` entirely for a file in the file comments.
-```
+* Disable rule `core::naming_formats::field_names` entirely for a file in the file comments.
+
+```protobuf
 // file comments
 // (-- api-linter: core::naming_formats::field_names=disabled --)
 
@@ -80,8 +93,9 @@ message Example {
 }
 ```
 
-2. Disable rule `core::naming_formats::field_names` only for a field in its leading or trailing comments.
-```
+* Disable rule `core::naming_formats::field_names` only for a field in its leading or trailing comments.
+
+```protobuf
 syntax = "proto3";
 
 package google.api.linter.examples;
@@ -95,9 +109,11 @@ message Example {
 ```
 
 ## Contributing
+
 Pull requests are welcome. For major changes, please open an issue first to discuss what you would like to change.
 
 Please make sure to update tests as appropriate.
 
 ## License
+
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ go install
 
 Run `api-linter help` to see usage details. Or run `api-linter help check` to see how to check API protobuf files:
 
-```sh
+```text
 NAME:
    api-linter check - Check protobuf files that define an API
 

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -12,12 +12,12 @@ import (
 func runCLI(rules []lint.Rule, configs lint.RuntimeConfigs, args []string) error {
 	app := cli.NewApp()
 	app.Name = "api-linter"
-	app.Usage = "A linter for APIs"
+	app.Usage = "A linter for APIs defined in protocol buffers."
 	app.Version = "0.1"
 	app.Commands = []cli.Command{
 		{
-			Name:      "checkproto",
-			Aliases:   []string{"cp"},
+			Name:      "check",
+			Aliases:   []string{"c"},
 			Usage:     "Check protobuf files that define an API",
 			ArgsUsage: "files...",
 			Flags: []cli.Flag{
@@ -76,33 +76,82 @@ func runCLI(rules []lint.Rule, configs lint.RuntimeConfigs, args []string) error
 					return err
 				}
 
-				w := os.Stdout
-				if c.String("out") != "" {
-					var err error
-					w, err = os.Create(c.String("out"))
-					if err != nil {
-						return err
+				outFile := c.String("out")
+				outFmt := c.String("fmt")
+				return print(problems, outFile, outFmt)
+			},
+		},
+		{
+			Name:      "print",
+			Aliases:   []string{"p"},
+			Usage:     "Print rule information",
+			ArgsUsage: "rules...",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "out",
+					Value: "",
+					Usage: "output file path (default: stdout)",
+				},
+				cli.StringFlag{
+					Name:  "fmt",
+					Value: "yaml",
+					Usage: "output format",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				var infors []lint.RuleInfo
+				for _, rl := range rules {
+					infors = append(infors, rl.Info())
+				}
+
+				if len(c.Args()) > 0 {
+					prefixes := c.Args()
+					var filtered []lint.RuleInfo
+					for _, ri := range infors {
+						for _, pre := range prefixes {
+							if ri.Name.HasPrefix(pre) {
+								filtered = append(filtered, ri)
+								break
+							}
+						}
 					}
-					defer w.Close()
+					infors = filtered
 				}
 
-				marshal := yaml.Marshal
-				switch c.String("fmt") {
-				case "json":
-					marshal = json.Marshal
-				}
-				b, err := marshal(problems)
-				if err != nil {
-					return err
-				}
-
-				if _, err = w.Write(b); err != nil {
-					return err
-				}
-				return nil
+				outFile := c.String("out")
+				outFmt := c.String("fmt")
+				return print(infors, outFile, outFmt)
 			},
 		},
 	}
 
 	return app.Run(args)
+}
+
+// print data to the file in the given format. By default, it prints
+// to stdout if file is empty, and in YAML format if fmt is empty.
+func print(data interface{}, file, fmt string) error {
+	w := os.Stdout
+	if file != "" {
+		var err error
+		w, err = os.Create(file)
+		if err != nil {
+			return err
+		}
+		defer w.Close()
+	}
+	marshal := yaml.Marshal
+	switch fmt {
+	case "json":
+		marshal = json.Marshal
+	}
+	b, err := marshal(data)
+	if err != nil {
+		return err
+	}
+
+	if _, err = w.Write(b); err != nil {
+		return err
+	}
+	return nil
 }

--- a/lint/rule_info.go
+++ b/lint/rule_info.go
@@ -7,10 +7,10 @@ import (
 
 // RuleInfo stores information of a rule.
 type RuleInfo struct {
-	Name         RuleName      // rule name in the set.
-	Description  string        // a short description of this rule.
-	URI          string        // a link to a document for more details.
-	RequestTypes []RequestType // types of requests that this rule should receive.
+	Name         RuleName      `json:"name" yaml:"name"`                                   // rule name in the set.
+	Description  string        `json:"description,omitempty" yaml:"description,omitempty"` // a short description of this rule.
+	URI          string        `json:"uri,omitempty" yaml:"uri,omitempty"`                 // a link to a document for more details.
+	RequestTypes []RequestType `json:"-" yaml:"-"`                                         // types of requests that this rule should receive.
 
 	noPositional struct{} // Prevent positional composite literal instantiation
 }

--- a/rules/check_field_names_use_lower_snake_case.go
+++ b/rules/check_field_names_use_lower_snake_case.go
@@ -17,7 +17,6 @@ func checkFieldNamesUseLowerSnakeCase() lint.Rule {
 		RuleInfo: lint.RuleInfo{
 			Name:         lint.NewRuleName("core", "naming_formats", "field_names"),
 			Description:  "check that field names use lower snake case",
-			URI:          "https://g3doc.corp.google.com/google/api/tools/linter/g3doc/rules/naming-format.md?cl=head",
 			RequestTypes: []lint.RequestType{lint.ProtoRequest},
 		},
 		Callback: descriptor.Callbacks{

--- a/rules/check_proto_syntax_version.go
+++ b/rules/check_proto_syntax_version.go
@@ -17,7 +17,6 @@ func checkProtoVersion() lint.Rule {
 		RuleInfo: lint.RuleInfo{
 			Name:         lint.NewRuleName("core", "proto_version"),
 			Description:  "APIs should use proto3",
-			URI:          `https://g3doc.corp.google.com/google/api/tools/linter/g3doc/rules/proto-version.md?cl=head`,
 			RequestTypes: []lint.RequestType{lint.ProtoRequest},
 		},
 		Callback: descriptor.Callbacks{


### PR DESCRIPTION
1. Added print command:
```sh
NAME:
   api-linter print - Print rule information

USAGE:
   api-linter print [command options] rules...

OPTIONS:
   --out value  output file path (default: stdout)
   --fmt value  output format (default: "yaml")
```
2. Remove internal links;

3. Update README.