### PR TITLE
Exposing Configs.GetRuleConfig

### DIFF
--- a/lint/config.go
+++ b/lint/config.go
@@ -109,9 +109,9 @@ func ReadConfigsYAML(f io.Reader) (Configs, error) {
 	return c, nil
 }
 
-// getRuleConfig returns a RuleConfig that matches the given path and rule.
+// GetRuleConfig returns a RuleConfig that matches the given path and rule.
 // Returns an error if a config is not found for the path.
-func (c Configs) getRuleConfig(path string, rule RuleName) (result RuleConfig, err error) {
+func (c Configs) GetRuleConfig(path string, rule RuleName) (result RuleConfig, err error) {
 	err = fmt.Errorf("failed to find a config for path %q", path)
 	for _, cfg := range c {
 		if cfg.match(path) {

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -101,9 +101,9 @@ func TestRuleConfigs_getRuleConfig(t *testing.T) {
 		},
 	}
 	for ind, test := range tests {
-		cfg, _ := test.configs.getRuleConfig(test.path, test.rule)
+		cfg, _ := test.configs.GetRuleConfig(test.path, test.rule)
 		if cfg != test.result {
-			t.Errorf("Test #%d: %+v.getRuleConfig(%q, %q)=%+v; want %+v", ind+1, test.configs, test.path, test.rule, cfg, test.result)
+			t.Errorf("Test #%d: %+v.GetRuleConfig(%q, %q)=%+v; want %+v", ind+1, test.configs, test.path, test.rule, cfg, test.result)
 		}
 	}
 }

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -73,7 +73,7 @@ func (l *Linter) run(req Request) (Response, error) {
 	for name, rl := range l.rules {
 		var config RuleConfig
 
-		if c, err := l.configs.getRuleConfig(req.ProtoFile().Path(), name); err == nil {
+		if c, err := l.configs.GetRuleConfig(req.ProtoFile().Path(), name); err == nil {
 			config = config.withOverride(c)
 		} else {
 			errMessages = append(errMessages, err.Error())


### PR DESCRIPTION
GetRuleConfig tells us which rules we actually want to run. By exposing this API, clients may be able to completely eliminate the need to compile protos by checking file paths against their set of rules.