### PR TITLE
Executing rules inside a function that recovers from panics.

### DIFF
--- a/lint/config.go
+++ b/lint/config.go
@@ -109,6 +109,16 @@ func ReadConfigsYAML(f io.Reader) (Configs, error) {
 	return c, nil
 }
 
+// MakeConfigsForAllPaths takes an input RuleConfig and applies it to all Rules and all file paths.
+func MakeConfigsForAllRulesAndPaths(rc RuleConfig) Configs {
+	return []Config{{
+		IncludedPaths: []string{"**"},
+		RuleConfigs: map[string]RuleConfig{
+			"": rc,
+		},
+	}}
+}
+
 // getRuleConfig returns a RuleConfig that matches the given path and rule.
 // Returns an error if a config is not found for the path.
 func (c Configs) getRuleConfig(path string, rule RuleName) (result RuleConfig, err error) {

--- a/lint/config.go
+++ b/lint/config.go
@@ -109,16 +109,6 @@ func ReadConfigsYAML(f io.Reader) (Configs, error) {
 	return c, nil
 }
 
-// MakeConfigsForAllPaths takes an input RuleConfig and applies it to all Rules and all file paths.
-func MakeConfigsForAllRulesAndPaths(rc RuleConfig) Configs {
-	return []Config{{
-		IncludedPaths: []string{"**"},
-		RuleConfigs: map[string]RuleConfig{
-			"": rc,
-		},
-	}}
-}
-
 // getRuleConfig returns a RuleConfig that matches the given path and rule.
 // Returns an error if a config is not found for the path.
 func (c Configs) getRuleConfig(path string, rule RuleName) (result RuleConfig, err error) {

--- a/lint/linter.go
+++ b/lint/linter.go
@@ -18,6 +18,7 @@ package lint
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"google.golang.org/protobuf/types/descriptorpb"
@@ -81,7 +82,7 @@ func (l *Linter) run(req Request) (Response, error) {
 		}
 
 		if !config.Disabled && !req.DescriptorSource().isRuleDisabledInFile(rl.Info().Name) {
-			if problems, err := rl.Lint(req); err == nil {
+			if problems, err := l.runAndRecoverFromPanics(rl, req); err == nil {
 				for _, p := range problems {
 					if !req.DescriptorSource().isRuleDisabled(rl.Info().Name, p.Descriptor) {
 						p.RuleID = rl.Info().Name
@@ -101,4 +102,18 @@ func (l *Linter) run(req Request) (Response, error) {
 	}
 
 	return resp, err
+}
+
+func (l *Linter) runAndRecoverFromPanics(rl Rule, req Request) (probs []Problem, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			if rerr, ok := r.(error); ok {
+				err = rerr
+			} else {
+				err = fmt.Errorf("panic occurred during rule execution: %v", r)
+			}
+		}
+	}()
+
+	return rl.Lint(req)
 }

--- a/lint/linter_test.go
+++ b/lint/linter_test.go
@@ -128,9 +128,7 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 	// linter with only one rule, and a default configuration which enables all rules for all files
 	l := New(r, []Config{{
 		IncludedPaths: []string{"**"},
-		RuleConfigs: map[string]RuleConfig{
-			"": {},
-		},
+		RuleConfigs:   map[string]RuleConfig{"": {}},
 	}})
 
 	_, err = l.LintProtos([]*descriptorpb.FileDescriptorProto{fd})

--- a/lint/linter_test.go
+++ b/lint/linter_test.go
@@ -125,7 +125,14 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 	fd := new(descriptorpb.FileDescriptorProto)
 	fd.SourceCodeInfo = new(descriptorpb.SourceCodeInfo)
 
-	l := New(r, MakeConfigsForAllRulesAndPaths(RuleConfig{}))
+	// linter with only one rule, and a default configuration which enables all rules for all files
+	l := New(r, []Config{{
+		IncludedPaths: []string{"**"},
+		RuleConfigs: map[string]RuleConfig{
+			"": {},
+		},
+	}})
+
 	_, err = l.LintProtos([]*descriptorpb.FileDescriptorProto{fd})
 	if err == nil || !strings.Contains(err.Error(), "panic") {
 		t.Fatalf("Expected error with panic, got %q", err)


### PR DESCRIPTION
This will prevent a panic inside a rule from impacting the rest of the linter rules.