### PR TITLE
[chore] Install stdlib protos in test environment.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
 
             curl -OL https://github.com/google/protobuf/releases/download/v3.7.1/$PROTOC_ZIP
 
-            sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc
+            sudo unzip -o $PROTOC_ZIP -d /usr/local bin/protoc include/*
 
             rm -f $PROTOC_ZIP
       - run: go test -mod=readonly ./...


### PR DESCRIPTION
This adds the `google/protobuf/` protos in the place where
protoc looks for them, allowing them to be imported in tests.