### PR TITLE
Using testing.T.Fatalf instead of log.Fatalf

### DIFF
--- a/lint/registry_test.go
+++ b/lint/registry_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestMakeRegistryFromAllFiles(t *testing.T) {
-	barProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	barProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "bar.proto",
 		Template: `syntax = "proto3";
 
@@ -17,7 +17,7 @@ message Bar {
 }`,
 	})
 
-	fooProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	fooProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "foo.proto",
 		Template: `syntax = "proto3";
 
@@ -57,7 +57,7 @@ message Foo {
 }
 
 func TestMakeRegistryFromAllFiles_DirectAndIndirectDependencies(t *testing.T) {
-	barProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	barProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "bar.proto",
 		Template: `syntax = "proto3";
 
@@ -66,7 +66,7 @@ message Bar {
 }`,
 	})
 
-	fooProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	fooProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "foo.proto",
 		Template: `syntax = "proto3";
 
@@ -78,7 +78,7 @@ message Foo {
 		Deps: []*descriptorpb.FileDescriptorProto{barProto},
 	})
 
-	bazProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	bazProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "baz.proto",
 		Template: `syntax = "proto3";
 
@@ -148,7 +148,7 @@ message Baz {
 }
 
 func TestMakeRegistryFromAllFiles_MissingImports(t *testing.T) {
-	barProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	barProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "bar.proto",
 		Template: `syntax = "proto3";
 
@@ -157,7 +157,7 @@ message Bar {
 }`,
 	})
 
-	fooProto := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	fooProto := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Filename: "foo.proto",
 		Template: `syntax = "proto3";
 

--- a/rules/0131_test.go
+++ b/rules/0131_test.go
@@ -48,6 +48,7 @@ func TestGetRequestMessageName(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-131 Request Name"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -103,6 +104,7 @@ func TestGetRequestMessageNameField(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-131 Request Name Field"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -170,6 +172,7 @@ func TestGetRequestMessageUnknownFields(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-131 Request Unknown Fields"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -226,6 +229,7 @@ func TestGetResponseMessageName(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-131 Response Message Name"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {

--- a/rules/0132_test.go
+++ b/rules/0132_test.go
@@ -51,6 +51,7 @@ func TestListRequestMessageName(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-132 Request Name"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -110,6 +111,7 @@ func TestListRequestMessageParentField(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-132 Request Parent Field"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -181,6 +183,7 @@ func TestListRequestMessageUnknownFields(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-132 Request Unknown Fields"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {
@@ -236,6 +239,7 @@ func TestListResponseMessageName(t *testing.T) {
 	for _, test := range tests {
 		errPrefix := "AIP-132 Response Message Name"
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {

--- a/rules/check_field_names_use_lower_snake_case_test.go
+++ b/rules/check_field_names_use_lower_snake_case_test.go
@@ -49,6 +49,7 @@ func TestFieldNamesUseLowerSnakeCaseRule(t *testing.T) {
 		errPrefix := fmt.Sprintf("Check field name `%s`", test.FieldName)
 
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {

--- a/rules/check_proto_syntax_version_test.go
+++ b/rules/check_proto_syntax_version_test.go
@@ -40,6 +40,7 @@ func TestProtoVersionRule(t *testing.T) {
 		errPrefix := fmt.Sprintf("Check syntax `%s`", test.Syntax)
 
 		req, err := lint.NewProtoRequest(testutil.MustCreateFileDescriptorProto(
+			t,
 			testutil.FileDescriptorSpec{Template: tmpl, Data: test},
 		), nil)
 		if err != nil {

--- a/rules/rules_test.go
+++ b/rules/rules_test.go
@@ -21,7 +21,7 @@ var testdatadir = func(lib string) string {
 }
 
 func TestTestData_ApiCommonProtos(t *testing.T) {
-	fd := testutil.MustCreateFileDescriptorProto(testutil.FileDescriptorSpec{
+	fd := testutil.MustCreateFileDescriptorProto(t, testutil.FileDescriptorSpec{
 		Template: `syntax = "proto3";
 
 import "google/api/auth.proto";

--- a/testutil/testutil.go
+++ b/testutil/testutil.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"log"
 	"os"
 	"os/exec"
+	"testing"
 	"text/template"
 
 	"google.golang.org/protobuf/proto"
@@ -34,29 +34,29 @@ type FileDescriptorSpec struct {
 }
 
 // MustCreateFileDescriptorProto creates a *descriptorpb.FileDescriptorProto from a string template and data.
-func MustCreateFileDescriptorProto(spec FileDescriptorSpec) *descriptorpb.FileDescriptorProto {
+func MustCreateFileDescriptorProto(t *testing.T, spec FileDescriptorSpec) *descriptorpb.FileDescriptorProto {
 	source := new(bytes.Buffer)
 	if err := template.Must(template.New("").Parse(spec.Template)).Execute(source, spec.Data); err != nil {
-		log.Fatalf("Error executing template %v", err)
+		t.Fatalf("Error executing template %v", err)
 	}
 
 	tmpDir := os.TempDir()
 
 	f, err := ioutil.TempFile(tmpDir, "proto*")
 	if err != nil {
-		log.Fatalf("Failed creating temp proto source file: %s", err)
+		t.Fatalf("Failed creating temp proto source file: %s", err)
 	}
-	defer mustCloseAndRemoveFile(f)
+	defer mustCloseAndRemoveFile(t, f)
 
 	if _, err = io.Copy(f, source); err != nil {
-		log.Fatalf("Failed to copy source to templ file: %s", err)
+		t.Fatalf("Failed to copy source to templ file: %s", err)
 	}
 
 	descSetF, err := ioutil.TempFile(tmpDir, "descset*")
 	if err != nil {
-		log.Fatalf("Failed to create temp descriptor set file: %s", err)
+		t.Fatalf("Failed to create temp descriptor set file: %s", err)
 	}
-	defer mustCloseAndRemoveFile(descSetF)
+	defer mustCloseAndRemoveFile(t, descSetF)
 
 	args := []string{
 		"--include_source_info",
@@ -69,8 +69,8 @@ func MustCreateFileDescriptorProto(spec FileDescriptorSpec) *descriptorpb.FileDe
 	}
 
 	if len(spec.Deps) > 0 {
-		descSetIn := mustCreateDescSetFile(spec.Deps)
-		defer mustCloseAndRemoveFile(descSetIn)
+		descSetIn := mustCreateDescSetFile(t, spec.Deps)
+		defer mustCloseAndRemoveFile(t, descSetIn)
 
 		args = append(args, fmt.Sprintf("--descriptor_set_in=%s", descSetIn.Name()))
 	}
@@ -83,21 +83,21 @@ func MustCreateFileDescriptorProto(spec FileDescriptorSpec) *descriptorpb.FileDe
 	cmd.Stderr = stderr
 
 	if err = cmd.Run(); err != nil {
-		log.Fatalf("protoc failed with %v and Stderr %q", err, stderr.String())
+		t.Fatalf("protoc failed with %v and Stderr %q", err, stderr.String())
 	}
 
 	descSet, err := ioutil.ReadFile(descSetF.Name())
 	if err != nil {
-		log.Fatalf("Failed to read descriptor set file: %s", err)
+		t.Fatalf("Failed to read descriptor set file: %s", err)
 	}
 
 	protoset := &descriptorpb.FileDescriptorSet{}
 	if err := proto.Unmarshal(descSet, protoset); err != nil {
-		log.Fatalf("Failed to unmarshal descriptor set file: %s", err)
+		t.Fatalf("Failed to unmarshal descriptor set file: %s", err)
 	}
 
 	if len(protoset.GetFile()) == 0 {
-		log.Fatalf("protoset.GetFile() returns empty list")
+		t.Fatalf("protoset.GetFile() returns empty list")
 	}
 
 	protoset.GetFile()[0].Name = &spec.Filename
@@ -105,7 +105,7 @@ func MustCreateFileDescriptorProto(spec FileDescriptorSpec) *descriptorpb.FileDe
 	return protoset.GetFile()[0]
 }
 
-func mustCreateDescSetFile(descs []*descriptorpb.FileDescriptorProto) *os.File {
+func mustCreateDescSetFile(t *testing.T, descs []*descriptorpb.FileDescriptorProto) *os.File {
 	if len(descs) == 0 {
 		return nil
 	}
@@ -116,29 +116,29 @@ func mustCreateDescSetFile(descs []*descriptorpb.FileDescriptorProto) *os.File {
 	rawDescSet, err := proto.Marshal(descSet)
 
 	if err != nil {
-		log.Fatalf("Failed to marshal descriptor set: %s", err)
+		t.Fatalf("Failed to marshal descriptor set: %s", err)
 	}
 
 	descSetF, err := ioutil.TempFile(os.TempDir(), "descset*")
 
 	if err != nil {
-		log.Fatalf("Failed to make descriptor set file: %s", err)
+		t.Fatalf("Failed to make descriptor set file: %s", err)
 	}
 
 	if _, err := io.Copy(descSetF, bytes.NewReader(rawDescSet)); err != nil {
-		mustCloseAndRemoveFile(descSetF)
-		log.Fatalf("Failed to ")
+		mustCloseAndRemoveFile(t, descSetF)
+		t.Fatalf("Failed to ")
 	}
 
 	return descSetF
 }
 
-func mustCloseAndRemoveFile(f *os.File) {
+func mustCloseAndRemoveFile(t *testing.T, f *os.File) {
 	if err := f.Close(); err != nil {
-		log.Fatalf("Error closing proto file: %v", err)
+		t.Fatalf("Error closing proto file: %v", err)
 	}
 
 	if err := os.Remove(f.Name()); err != nil {
-		log.Fatalf("Error removing proto file: %v", err)
+		t.Fatalf("Error removing proto file: %v", err)
 	}
 }

--- a/testutil/testutil_test.go
+++ b/testutil/testutil_test.go
@@ -32,7 +32,7 @@ func TestDescriptorFromProtoSource_CustomProtoPaths(t *testing.T) {
 		t.Fatalf("Failed to write proto source to sample.proto: %s", err)
 	}
 
-	desc := MustCreateFileDescriptorProto(FileDescriptorSpec{
+	desc := MustCreateFileDescriptorProto(t, FileDescriptorSpec{
 		AdditionalProtoPaths: []string{dirName},
 		Template: `
 		syntax = "proto3";
@@ -54,7 +54,7 @@ func TestDescriptorFromProtoSource_CustomProtoPaths(t *testing.T) {
 }
 
 func TestDescriptorFromProtoSource_CustomDeps(t *testing.T) {
-	foo := MustCreateFileDescriptorProto(FileDescriptorSpec{
+	foo := MustCreateFileDescriptorProto(t, FileDescriptorSpec{
 		Filename: "foo.proto",
 		Template: `
 		syntax = "proto3";
@@ -64,7 +64,7 @@ func TestDescriptorFromProtoSource_CustomDeps(t *testing.T) {
 		}`,
 	})
 
-	bar := MustCreateFileDescriptorProto(FileDescriptorSpec{
+	bar := MustCreateFileDescriptorProto(t, FileDescriptorSpec{
 		Filename: "bar.proto",
 		Template: `
 		syntax = "proto3";


### PR DESCRIPTION
As described in #99, currently, if anything in `testutil.MustXxx` fails, the entire test suite will stop executing because it uses `log.Fatalf`. By passing in `t` and using `t.Fatalf`, we will only fail the current test if a `MustXxx` function fails. We should follow this pattern with all `testutil.MustXxx` functions moving forward, as they are only supposed to be used in tests, so `t` should always be available.