### PR TITLE
Removed usage of function that's not available in google3

### DIFF
--- a/lint/linter_test.go
+++ b/lint/linter_test.go
@@ -20,7 +20,6 @@ import (
 	"strings"
 	"testing"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/descriptorpb"
 )
 
@@ -136,7 +135,8 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 
 		fd := new(descriptorpb.FileDescriptorProto)
 		fd.SourceCodeInfo = new(descriptorpb.SourceCodeInfo)
-		fd.Name = proto.String("test.proto")
+		filename := "test.proto"
+		fd.Name = &filename
 
 		l := New(r, []Config{{
 			IncludedPaths: []string{"**"},


### PR DESCRIPTION
`proto.String` is not yet synced to google3's version of protobuf/proto, so we're instead manually creating the `*string` for the filename.