### PR TITLE
Fixed bug in DescriptorLocation if d is nil

### DIFF
--- a/lint/source.go
+++ b/lint/source.go
@@ -173,9 +173,20 @@ func (s DescriptorSource) DescriptorLocation(d protoreflect.Descriptor) (Locatio
 	return s.findLocationByPath(getPath(d))
 }
 
+func (s DescriptorSource) DescriptorLocationOrFileStart(d protoreflect.Descriptor) Location {
+	loc, err := s.DescriptorLocation(d)
+	if err != nil {
+		return Location{
+			Start: Position{Line: 1, Column: 1},
+			End:   Position{Line: 1, Column: 1},
+		}
+	}
+	return loc
+}
+
 func getPath(d protoreflect.Descriptor) []int {
 	path := []int{}
-	for p := d; !isFileDescriptor(p); p = p.Parent() {
+	for p := d; p != nil && !isFileDescriptor(p); p = p.Parent() {
 		path = append(path, p.Index(), getDescriptorTag(p))
 	}
 	reverseInts(path)

--- a/rules/descriptor/callback_rule.go
+++ b/rules/descriptor/callback_rule.go
@@ -68,8 +68,7 @@ func (r *CallbackRule) Consume(d protoreflect.Descriptor) error {
 func (r *CallbackRule) addProblems(problems ...lint.Problem) {
 	for _, p := range problems {
 		if !p.Location.IsValid() {
-			loc, _ := r.source.DescriptorLocation(p.Descriptor)
-			p.Location = loc
+			p.Location = r.source.DescriptorLocationOrFileStart(p.Descriptor)
 		}
 		r.problems = append(r.problems, p)
 	}


### PR DESCRIPTION
Also added a helper function to return the start location if a descriptor is not found, as this is the behavior that most rules want to use.