### PR TITLE
Add EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,8 +10,7 @@ insert_final_newline = true
 
 # Matches multiple files with brace expansion notation
 # Set default charset
-[*.{go}]
-charset = utf-8
+[*.go]
 indent_style = tab
 indent_size = 2
 trim_trailing_whitespace = true


### PR DESCRIPTION
This (primarily) just makes the tab characters show up as 2-space indentations, meaning code is easier to review.

![image](https://user-images.githubusercontent.com/112928/62555451-ede2eb00-b840-11e9-90d6-ad2e078becb9.png)
