### PR TITLE
[chore] Renovate should stick to a single PR for updates.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "extends": ["config:base"],
+  "groupName": "all"
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,0 @@
-{
-  "extends": [
-    "config:base"
-  ]
-}


### PR DESCRIPTION
Renovate is _really_ spammy for constantly-updated Go modules,
which is annoying.

Reconfigure it to keep one PR with dependency updates which we
can merge occasionally.