### PR TITLE
[fix] Be stricter about rule names.

### DIFF
--- a/lint/rule_name.go
+++ b/lint/rule_name.go
@@ -19,13 +19,15 @@ import (
 	"strings"
 )
 
-// RuleName is an identifier for a rule. Allowed characters include a-z, A-Z, 0-9, -, _. The
-// namespace separator :: is allowed between RuleName segments (for example, my_namespace::my_rule).
+// RuleName is an identifier for a rule. Allowed characters include a-z, 0-9, -.
+//
+// The namespace separator :: is allowed between RuleName segments
+// (for example, my-namespace::my-rule).
 type RuleName string
 
 const nameSeparator string = "::"
 
-var ruleNameValidator = regexp.MustCompile("^([a-zA-Z0-9-_]+(::[a-zA-Z0-9-_]+)?)+$")
+var ruleNameValidator = regexp.MustCompile("^([a-z0-9][a-z0-9-]*(::[a-z0-9][a-z0-9-]*)?)+$")
 
 // NewRuleName creates a RuleName from segments.
 // It will join the segments with the "::" separator.

--- a/lint/rule_name_test.go
+++ b/lint/rule_name_test.go
@@ -16,25 +16,49 @@ package lint
 
 import "testing"
 
-func TestRuleName_IsValid(t *testing.T) {
+func TestRuleNameValid(t *testing.T) {
 	tests := []struct {
-		name  RuleName
-		valid bool
+		testName string
+		ruleName RuleName
 	}{
-		{"", false},
-		{"a:::b", false},
-		{"a::::b", false},
-		{"a", true},
-		{"::my_rule", false},
-		{"my_namespace::", false},
-		{"my_namespace:my_rule", false},
-		{"my_namespace::my_rule", true},
-		{"my_rule", true},
+		{"Lower", "aip"},
+		{"LowerNumber", "aip0121"},
+		{"LowerNumberKebab", "aip-0121"},
+		{"Namespaced", "aip::0121"},
 	}
 
 	for _, test := range tests {
-		if test.name.IsValid() != test.valid {
-			t.Errorf("%q.IsValid()=%t; want %t", test.name, test.name.IsValid(), test.valid)
+		t.Run(test.testName, func(t *testing.T) {
+			if !test.ruleName.IsValid() {
+				t.Errorf("Rule name %q is invalid; want valid.", test.ruleName)
+			}
+		})
+	}
+}
+
+func TestRuleNameInvalid(t *testing.T) {
+	tests := []struct {
+		testName string
+		ruleName RuleName
+	}{
+		{"EmptyString", ""},
+		{"TripleColon", "a:::b"},
+		{"QuadrupleColon", "a::::b"},
+		{"CapitalLetter", "A"},
+		{"LeadingDoubleColon", "::my-rule"},
+		{"TrailingDoubleColon", "my-namespace::"},
+		{"LeadingHyphen", "-core::aip-0131"},
+		{"LeadingSegmentHyphen", "core::-aip-0131"},
+		{"OnlyHyphen", "-"},
+		{"SingleColon", "core:aip-0131"},
+		{"Underscore", "core::aip_0131"},
+		{"CamelCase", "myRule"},
+		{"PascalCase", "MyRule"},
+	}
+
+	for _, test := range tests {
+		if test.ruleName.IsValid() {
+			t.Errorf("Rule name %q is valid; want invalid.", test.ruleName)
 		}
 	}
 }
@@ -46,7 +70,7 @@ func TestNewRuleName(t *testing.T) {
 	}{
 		{[]string{}, ""},
 		{[]string{""}, ""},
-		{[]string{"my_namespace", "my_rule"}, "my_namespace::my_rule"},
+		{[]string{"my-namespace", "my-rule"}, "my-namespace::my-rule"},
 		{[]string{"my", "name", "space", "foo"}, "my::name::space::foo"},
 	}
 

--- a/lint/rule_name_test.go
+++ b/lint/rule_name_test.go
@@ -25,6 +25,7 @@ func TestRuleNameValid(t *testing.T) {
 		{"LowerNumber", "aip0121"},
 		{"LowerNumberKebab", "aip-0121"},
 		{"Namespaced", "aip::0121"},
+		{"NamespacedHyphen", "core::aip-0121"},
 	}
 
 	for _, test := range tests {

--- a/lint/rule_name_test.go
+++ b/lint/rule_name_test.go
@@ -57,9 +57,11 @@ func TestRuleNameInvalid(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		if test.ruleName.IsValid() {
-			t.Errorf("Rule name %q is valid; want invalid.", test.ruleName)
-		}
+		t.Run(test.testName, func(t *testing.T) {
+			if test.ruleName.IsValid() {
+				t.Errorf("Rule name %q is valid; want invalid.", test.ruleName)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
We should enforce a stricter standard on rule names.

- They should always be lower-case (no upper-case).
- They should always start with a letter or number.
- They should always use `-` as a word separator, not `_` (kebab-case).
- They should not begin or end with a word separator.

This PR does all of that with the exception of enforcing no
trailing hyphens (I am willing to assume that given the enforcement
of the remaining rules, nobody will try that).