### PR TITLE
[chore] Export lint.ProtoRule

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -99,7 +99,7 @@ func (l *Linter) lintFileDescriptor(fd *desc.FileDescriptor) (Response, error) {
 	return resp, err
 }
 
-func (l *Linter) runAndRecoverFromPanics(rule protoRule, fd *desc.FileDescriptor) (probs []Problem, err error) {
+func (l *Linter) runAndRecoverFromPanics(rule ProtoRule, fd *desc.FileDescriptor) (probs []Problem, err error) {
 	defer func() {
 		if r := recover(); r != nil {
 			if rerr, ok := r.(error); ok {

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -133,7 +133,7 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 
 	tests := []struct {
 		testName string
-		rule     protoRule
+		rule     ProtoRule
 	}{
 		{
 			testName: "Panic",

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -22,8 +22,8 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
-// protoRule defines a lint rule that checks Google Protobuf APIs.
-type protoRule interface {
+// ProtoRule defines a lint rule that checks Google Protobuf APIs.
+type ProtoRule interface {
 	// GetName returns the name of the rule.
 	GetName() RuleName
 
@@ -271,7 +271,7 @@ func (r *EnumRule) Lint(fd *desc.FileDescriptor) []Problem {
 
 // ruleIsEnabled returns true if the rule is enabled (not disabled by the comments
 // for the given descriptor or its file), false otherwise.
-func ruleIsEnabled(rule protoRule, d desc.Descriptor, aliasMap map[string]string) bool {
+func ruleIsEnabled(rule ProtoRule, d desc.Descriptor, aliasMap map[string]string) bool {
 	// Some rules have a legacy name. We add it to the check list.
 	ruleName := string(rule.GetName())
 	names := []string{ruleName}

--- a/lint/rule_registry.go
+++ b/lint/rule_registry.go
@@ -19,7 +19,7 @@ import (
 )
 
 // RuleRegistry is a registry for registering and looking up rules.
-type RuleRegistry map[RuleName]protoRule
+type RuleRegistry map[RuleName]ProtoRule
 
 // Copy returns a new copy of the rules.
 func (r RuleRegistry) Copy() RuleRegistry {
@@ -32,7 +32,7 @@ func (r RuleRegistry) Copy() RuleRegistry {
 
 // Register registers the list of rules.
 // Return an error if any of the rules is found duplicate in the registry.
-func (r RuleRegistry) Register(rules ...protoRule) error {
+func (r RuleRegistry) Register(rules ...ProtoRule) error {
 	for _, rl := range rules {
 		if !rl.GetName().IsValid() {
 			return fmt.Errorf("%q is not a valid RuleName", rl.GetName())
@@ -48,8 +48,8 @@ func (r RuleRegistry) Register(rules ...protoRule) error {
 }
 
 // All returns all rules.
-func (r RuleRegistry) All() []protoRule {
-	rules := make([]protoRule, 0, len(r))
+func (r RuleRegistry) All() []ProtoRule {
+	rules := make([]ProtoRule, 0, len(r))
 	for _, r1 := range r {
 		rules = append(rules, r1)
 	}
@@ -57,7 +57,7 @@ func (r RuleRegistry) All() []protoRule {
 }
 
 // NewRuleRegistry returns a rule registry initialized with the given set of rules.
-func NewRuleRegistry(rules ...protoRule) (RuleRegistry, error) {
+func NewRuleRegistry(rules ...ProtoRule) (RuleRegistry, error) {
 	r := make(RuleRegistry, len(rules))
 	err := r.Register(rules...)
 	return r, err

--- a/lint/rule_test.go
+++ b/lint/rule_test.go
@@ -363,7 +363,7 @@ type lintRuleTest struct {
 }
 
 // runRule runs a rule within a test environment.
-func (test *lintRuleTest) runRule(rule protoRule, fd *desc.FileDescriptor, t *testing.T) {
+func (test *lintRuleTest) runRule(rule ProtoRule, fd *desc.FileDescriptor, t *testing.T) {
 	// Establish that the metadata methods work.
 	if got, want := string(rule.GetName()), string(NewRuleName("test", test.testName)); got != want {
 		t.Errorf("Got %q for GetName(), expected %q", got, want)


### PR DESCRIPTION
This undoes #162, for the following reasons:

1. It is an anti-pattern for a public function to return a private interface.
2. In my upcoming PR (edit: #209) for the rules for #167, I have a need to declare a struct in a rule test with a `lint.ProtoRule` as one of the values, which I can not do if it is private.
3. The entire point of going to an interface is to be able to use that interface. :)