### PR TITLE
[feat] Add helper method for proto3 templates.

### DIFF
--- a/rules/internal/testutils/parse_test.go
+++ b/rules/internal/testutils/parse_test.go
@@ -78,3 +78,94 @@ func TestParseProtoStringError(t *testing.T) {
 		t.Errorf("Expected syntax error to cause a fatal error.")
 	}
 }
+
+func TestParseProto3String(t *testing.T) {
+	fd := ParseProto3String(t, `
+		message Foo {
+			int32 bar = 1;
+			int64 baz = 2;
+		}
+
+		message Spam {
+			string eggs = 2;
+		}
+	`)
+	if !fd.IsProto3() {
+		t.Errorf("Expected a proto3 file descriptor.")
+	}
+}
+
+func TestParseProto3Tmpl(t *testing.T) {
+	tests := []struct {
+		MessageName string
+		Field1Name  string
+		Field2Name  string
+	}{
+		{"Book", "title", "author"},
+		{"Foo", "bar", "baz"},
+	}
+	for _, test := range tests {
+		t.Run(test.MessageName, func(t *testing.T) {
+			fd := ParseProto3Tmpl(t, `
+				message {{.MessageName}} {
+					string {{.Field1Name}} = 1;
+					string {{.Field2Name}} = 2;
+				}
+			`, test)
+			if !fd.IsProto3() {
+				t.Errorf("Expected a proto3 file descriptor.")
+			}
+			msg := fd.GetMessageTypes()[0]
+			if got, want := msg.GetName(), test.MessageName; got != want {
+				t.Errorf("Got %q for message name, expected %q.", got, want)
+			}
+			for i, fn := range []string{test.Field1Name, test.Field2Name} {
+				if got, want := msg.GetFields()[i].GetName(), fn; got != want {
+					t.Errorf("Got %q for field name %d; expected %q.", got, i+1, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseProto3TmplSyntaxError(t *testing.T) {
+	canary := &testing.T{}
+
+	// t.Fatalf will exit the goroutine, so to test this,
+	// we run the test in a different goroutine.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ParseProto3Tmpl(canary, `
+			message {{.InvalidTmplVariable[0]}} {}
+		`, struct{}{})
+	}()
+	wg.Wait()
+
+	// Verify that the testing.T object was given a failure.
+	if !canary.Failed() {
+		t.Errorf("Expected syntax error to cause a fatal error.")
+	}
+}
+
+func TestParseProto3TmplDataError(t *testing.T) {
+	canary := &testing.T{}
+
+	// t.Fatalf will exit the goroutine, so to test this,
+	// we run the test in a different goroutine.
+	wg := &sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		ParseProto3Tmpl(canary, `
+			message {{.MissingVariable}} {}
+		`, struct{}{})
+	}()
+	wg.Wait()
+
+	// Verify that the testing.T object was given a failure.
+	if !canary.Failed() {
+		t.Errorf("Expected missing data to cause a fatal error.")
+	}
+}


### PR DESCRIPTION
This adds a `testutils.ParseProto3String` and `testutils.ParseProto3Tmpl` method, to make it easier to parse protobuf string templates in tests, and keep the focus on what is being tested.

Each method adds `syntax = "proto3";` to the top (we basically only work in proto3 so it is silly to boilerplate it over and over) and the template method also parses out a template.