### PR TITLE
[AIP-192] Add rule for leading comments.

### DIFF
--- a/lint/rule.go
+++ b/lint/rule.go
@@ -287,6 +287,9 @@ func (r *DescriptorRule) GetURI() string {
 
 // Lint accepts a FileDescriptor and iterates over the descriptors within
 // it, and runs the LintDescriptor function on each.
+//
+// It visits every service, method, message, field, enum, and enum value.
+// This order is not guaranteed.
 func (r *DescriptorRule) Lint(fd *desc.FileDescriptor) []Problem {
 	problems := []Problem{}
 

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -251,21 +251,70 @@ func (r *EnumRule) GetURI() string {
 func (r *EnumRule) Lint(fd *desc.FileDescriptor) []Problem {
 	problems := []Problem{}
 
-	// Lint enums that are at the top level of the file.
-	for _, enum := range fd.GetEnumTypes() {
+	// Lint all enums, either at the top of the file, or nested within messages.
+	for _, enum := range getAllEnums(fd) {
 		if r.OnlyIf == nil || r.OnlyIf(enum) {
 			problems = append(problems, r.LintEnum(enum)...)
 		}
 	}
+	return problems
+}
 
-	// Lint enums that are nested within messages.
-	for _, message := range getAllMessages(fd) {
-		for _, enum := range message.GetNestedEnumTypes() {
-			if r.OnlyIf == nil || r.OnlyIf(enum) {
-				problems = append(problems, r.LintEnum(enum)...)
-			}
+// DescriptorRule defines a lint rule that is run on every descriptor
+// in the file (but not the file itself).
+type DescriptorRule struct {
+	Name RuleName
+	URI  string
+
+	// LintDescriptor accepts a generic descriptor and lints it.
+	//
+	// Note: Unless the descriptor is typecast to a more specific type,
+	// only a subset of methods are available to it.
+	LintDescriptor func(desc.Descriptor) []Problem
+
+	noPositional struct{}
+}
+
+// GetName returns the name of the rule.
+func (r *DescriptorRule) GetName() RuleName {
+	return r.Name
+}
+
+// GetURI returns the URI where the applicable guideline is documented.
+func (r *DescriptorRule) GetURI() string {
+	return r.URI
+}
+
+// Lint accepts a FileDescriptor and iterates over the descriptors within
+// it, and runs the LintDescriptor function on each.
+func (r *DescriptorRule) Lint(fd *desc.FileDescriptor) []Problem {
+	problems := []Problem{}
+
+	// Iterate over all services and methods.
+	for _, service := range fd.GetServices() {
+		problems = append(problems, r.LintDescriptor(service)...)
+		for _, method := range service.GetMethods() {
+			problems = append(problems, r.LintDescriptor(method)...)
 		}
 	}
+
+	// Iterate over all messages, and all fields within each message.
+	for _, message := range getAllMessages(fd) {
+		problems = append(problems, r.LintDescriptor(message)...)
+		for _, field := range message.GetFields() {
+			problems = append(problems, r.LintDescriptor(field)...)
+		}
+	}
+
+	// Iterate over all enums and enum values.
+	for _, enum := range getAllEnums(fd) {
+		problems = append(problems, r.LintDescriptor(enum)...)
+		for _, value := range enum.GetValues() {
+			problems = append(problems, r.LintDescriptor(value)...)
+		}
+	}
+
+	// Done; return the full set of problems.
 	return problems
 }
 
@@ -320,6 +369,20 @@ func getAllNestedMessages(m *desc.MessageDescriptor) (messages []*desc.MessageDe
 		messages = append(messages, getAllNestedMessages(nested)...)
 	}
 	return messages
+}
+
+// getAllEnums returns a slice with every enum (not just top-level enums)
+// in the file.
+func getAllEnums(f *desc.FileDescriptor) (enums []*desc.EnumDescriptor) {
+	// Append all enums at the top level.
+	enums = append(enums, f.GetEnumTypes()...)
+
+	// Append all enums nested within messages.
+	for _, m := range getAllMessages(f) {
+		enums = append(enums, m.GetNestedEnumTypes()...)
+	}
+
+	return
 }
 
 // fileHeader attempts to get the comment at the top of the file, but it

--- a/lint/rule_test.go
+++ b/lint/rule_test.go
@@ -305,7 +305,8 @@ func TestDescriptorRule(t *testing.T) {
 	// Create a rule that lets us verify that each descriptor was visited.
 	visited := make(map[string]desc.Descriptor)
 	rule := &DescriptorRule{
-		Name: NewRuleName("test"),
+		Name: NewRuleName("test", "test"),
+		URI:  "https://aip.dev/1",
 		LintDescriptor: func(d desc.Descriptor) []Problem {
 			visited[d.GetName()] = d
 			return nil
@@ -320,6 +321,12 @@ func TestDescriptorRule(t *testing.T) {
 	wantDescriptors := []string{
 		"Author", "Book", "ConjureBook", "Format", "FORMAT_UNSPECIFIED",
 		"name", "Library", "State",
+	}
+	if got, want := rule.GetName(), "test::test"; string(got) != want {
+		t.Errorf("Got name %q, wanted %q", got, want)
+	}
+	if got, want := rule.GetURI(), "https://aip.dev/1"; got != want {
+		t.Errorf("Got URI %q, wanted %q.", got, want)
 	}
 	if got, want := len(visited), len(wantDescriptors); got != want {
 		t.Errorf("Got %d descriptors, wanted %d.", got, want)

--- a/rules/aip0192/aip0192.go
+++ b/rules/aip0192/aip0192.go
@@ -46,7 +46,7 @@ func separateInternalComments(comments ...string) struct {
 			if len(open) > 1 {
 				c = strings.TrimSpace(open[1])
 			} else {
-				c = ""
+				break
 			}
 
 			// Now that the opening component is tokenized, anything before
@@ -58,7 +58,7 @@ func separateInternalComments(comments ...string) struct {
 			if len(close) > 1 {
 				c = strings.TrimSpace(close[1])
 			} else {
-				c = ""
+				break
 			}
 		}
 	}

--- a/rules/aip0192/aip0192.go
+++ b/rules/aip0192/aip0192.go
@@ -1,0 +1,66 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aip0192 contains rules defined in https://aip.dev/192.
+package aip0192
+
+import (
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+// AddRules adds all of the AIP-192 rules to the provided registry.
+func AddRules(r lint.RuleRegistry) {
+	r.Register(
+		onlyLeadingComments,
+	)
+}
+
+func separateInternalComments(comments ...string) struct {
+	Internal []string
+	External []string
+} {
+	answer := struct {
+		Internal []string
+		External []string
+	}{}
+	for _, c := range comments {
+		for len(c) > 0 {
+			// Anything before the `(--` is external string.
+			open := strings.SplitN(c, "(--", 2)
+			if ex := strings.TrimSpace(open[0]); ex != "" {
+				answer.External = append(answer.External, ex)
+			}
+			if len(open) > 1 {
+				c = strings.TrimSpace(open[1])
+			} else {
+				c = ""
+			}
+
+			// Now that the opening component is tokenized, anything before
+			// the `--)` is internal string.
+			close := strings.SplitN(c, "--)", 2)
+			if in := strings.TrimSpace(close[0]); in != "" {
+				answer.Internal = append(answer.Internal, in)
+			}
+			if len(close) > 1 {
+				c = strings.TrimSpace(close[1])
+			} else {
+				c = ""
+			}
+		}
+	}
+	return answer
+}

--- a/rules/aip0192/aip0192_test.go
+++ b/rules/aip0192/aip0192_test.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0192
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+func TestAddRules(t *testing.T) {
+	rules := make(lint.RuleRegistry)
+	AddRules(rules)
+	for ruleName := range rules {
+		if !strings.HasPrefix(string(ruleName), "core::0192") {
+			t.Errorf("Rule %s is not namespaced to core::0192.", ruleName)
+		}
+	}
+}

--- a/rules/aip0192/leading_comments.go
+++ b/rules/aip0192/leading_comments.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0192
+
+import (
+	"fmt"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// onlyLeadingComments ensures that a descriptor has only leading external
+// comments. (Internal trailing or detached comments are permitted.)
+var onlyLeadingComments = &lint.DescriptorRule{
+	Name: lint.NewRuleName("core", "0192", "comments", "only-leading"),
+	URI:  "https://aip.dev/192",
+	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
+		problems := []lint.Problem{}
+		c := d.GetSourceInfo()
+		if len(separateInternalComments(c.GetTrailingComments()).External) > 0 {
+			problems = append(problems, lint.Problem{
+				Message: fmt.Sprintf(
+					"%q should have only leading (not trailing) public comments.",
+					d.GetName(),
+				),
+				Descriptor: d,
+			})
+		}
+		if len(separateInternalComments(c.GetLeadingDetachedComments()...).External) > 0 {
+			problems = append(problems, lint.Problem{
+				Message: fmt.Sprintf(
+					"%q has comments with empty lines between the comment and %q.",
+					d.GetName(), d.GetName(),
+				),
+				Descriptor: d,
+			})
+		}
+		return problems
+	},
+}

--- a/rules/aip0192/leading_comments_test.go
+++ b/rules/aip0192/leading_comments_test.go
@@ -1,0 +1,88 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0192
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestOnlyLeadingComments(t *testing.T) {
+	tests := []struct {
+		testName string
+		Detached string
+		Trailing string
+		problems testutils.Problems
+	}{
+		{"ValidNone", "", "", testutils.Problems{}},
+		{"ValidInternalDetached", "// (-- detached --)", "", testutils.Problems{}},
+		{"ValidInternalTrailing", "// (-- trailing --)", "", testutils.Problems{}},
+		{"ValidInternalTrailingNoClose", "// (-- trailing", "", testutils.Problems{}},
+		{
+			"ValidInternalBoth",
+			"// (-- detached --)",
+			"// (-- trailing --)",
+			testutils.Problems{},
+		},
+		{
+			"ValidInternalBothDouble",
+			"// (-- detached --)\n// (-- detached --)",
+			"// (-- trailing --)\n// (-- trailing --)",
+			testutils.Problems{},
+		},
+		{"InvalidDetached", "// detached", "", testutils.Problems{{Message: "empty lines"}}},
+		{"InvalidTrailing", "", "// trailing", testutils.Problems{{Message: "trailing"}}},
+		{
+			"InvalidBoth",
+			"// detached",
+			"// trailing",
+			testutils.Problems{{Message: "trailing"}, {Message: "empty lines"}},
+		},
+		{
+			"InvalidPartialDetachedInternalFirst",
+			"// (-- detached --) detached",
+			"",
+			testutils.Problems{{Message: "empty lines"}},
+		},
+		{
+			"InvalidPartialDetachedExternalFirst",
+			"// detached (-- detached --)",
+			"",
+			testutils.Problems{{Message: "empty lines"}},
+		},
+		{
+			"InvalidPartialDetachedSandwich",
+			"// (-- detached --) detached (-- detached --)",
+			"",
+			testutils.Problems{{Message: "empty lines"}},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				{{.Detached}}
+
+				// The book.
+				message Book {}
+				{{.Trailing}}
+			`, test)
+			problems := onlyLeadingComments.Lint(file)
+			if diff := test.problems.SetDescriptor(file.GetMessageTypes()[0]).Diff(problems); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0192/leading_comments_test.go
+++ b/rules/aip0192/leading_comments_test.go
@@ -29,8 +29,8 @@ func TestOnlyLeadingComments(t *testing.T) {
 	}{
 		{"ValidNone", "", "", testutils.Problems{}},
 		{"ValidInternalDetached", "// (-- detached --)", "", testutils.Problems{}},
-		{"ValidInternalTrailing", "// (-- trailing --)", "", testutils.Problems{}},
-		{"ValidInternalTrailingNoClose", "// (-- trailing", "", testutils.Problems{}},
+		{"ValidInternalTrailing", "", "// (-- trailing --)", testutils.Problems{}},
+		{"ValidInternalTrailingNoClose", "", "// (-- trailing", testutils.Problems{}},
 		{
 			"ValidInternalBoth",
 			"// (-- detached --)",

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0140"
 	"github.com/googleapis/api-linter/rules/aip0158"
 	"github.com/googleapis/api-linter/rules/aip0191"
+	"github.com/googleapis/api-linter/rules/aip0192"
 )
 
 func init() {
@@ -30,6 +31,7 @@ func init() {
 	aip0140.AddRules(coreRules)
 	aip0158.AddRules(coreRules)
 	aip0191.AddRules(coreRules)
+	aip0192.AddRules(coreRules)
 }
 
 var coreRules, _ = lint.NewRuleRegistry()


### PR DESCRIPTION
Also adds a `DescriptorRule` that pokes everything.
I will migrate the AIP-140 abbreviations component to that
after this is merged.

Fixes #174.