### PR TITLE
[feat] Add GetScalarTypeName function.

### DIFF
--- a/rules/aip0141/types.go
+++ b/rules/aip0141/types.go
@@ -16,10 +16,10 @@ package aip0141
 
 import (
 	"fmt"
-	"strings"
 
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
 )
@@ -37,7 +37,7 @@ var forbiddenTypes = &lint.FieldRule{
 			builder.FieldTypeUInt64(),
 		} {
 			// Change "TYPE_TYPENAME" to "typename".
-			nope[t.GetType()] = strings.ToLower(t.GetType().String()[len("TYPE_"):])
+			nope[t.GetType()] = utils.GetScalarTypeName(t)
 		}
 		if typeName, ok := nope[f.GetType()]; ok {
 			// Preserve original intent w/r/t 32-bit vs. 64-bit.

--- a/rules/internal/utils/type_name.go
+++ b/rules/internal/utils/type_name.go
@@ -1,0 +1,30 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"strings"
+
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+)
+
+type hasGetType interface {
+	GetType() dpb.FieldDescriptorProto_Type
+}
+
+// GetScalarTypeName returns the name of the type of the field, as a string.
+func GetScalarTypeName(t hasGetType) string {
+	return strings.ToLower(t.GetType().String()[len("TYPE_"):])
+}

--- a/rules/internal/utils/type_name_test.go
+++ b/rules/internal/utils/type_name_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestGetScalarTypeName(t *testing.T) {
+	for _, ty := range []string{"int32", "int64", "string", "bytes", "float", "double"} {
+		t.Run(ty, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message Book {
+					{{.Type}} field = 1;
+				}
+			`, struct{ Type string }{ty})
+			field := file.GetMessageTypes()[0].GetFields()[0]
+			if got, want := GetScalarTypeName(field), ty; got != want {
+				t.Errorf("Got %q, expected %q.", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I have now needed several times a way to get the string type
for a scalar (e.g. "string", "int32", etc.). Time to make it a
utility function.