### PR TITLE
[AIP-142] Add field type checks for timestamps.

### DIFF
--- a/rules/aip0142/aip0142.go
+++ b/rules/aip0142/aip0142.go
@@ -23,5 +23,6 @@ import (
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
 		fieldNames,
+		fieldType,
 	)
 }

--- a/rules/internal/utils/type_name.go
+++ b/rules/internal/utils/type_name.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/jhump/protoreflect/desc"
 )
 
 type hasGetType interface {
@@ -27,4 +28,12 @@ type hasGetType interface {
 // GetScalarTypeName returns the name of the type of the field, as a string.
 func GetScalarTypeName(t hasGetType) string {
 	return strings.ToLower(t.GetType().String()[len("TYPE_"):])
+}
+
+// GetMessageTypeName returns the name of the type of the field, as a string.
+func GetMessageTypeName(f *desc.FieldDescriptor) string {
+	if messageType := f.GetMessageType(); messageType != nil {
+		return messageType.GetFullyQualifiedName()
+	}
+	return ""
 }

--- a/rules/internal/utils/type_name_test.go
+++ b/rules/internal/utils/type_name_test.go
@@ -35,3 +35,28 @@ func TestGetScalarTypeName(t *testing.T) {
 		})
 	}
 }
+
+func TestGetMessageTypeName(t *testing.T) {
+	tests := []struct {
+		testName string
+		Type     string
+		want     string
+	}{
+		{"Message", "google.protobuf.Timestamp", "google.protobuf.Timestamp"},
+		{"Scalar", "int32", ""},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/protobuf/timestamp.proto";
+				message Book {
+					{{.Type}} field = 1;
+				}
+			`, test)
+			field := file.GetMessageTypes()[0].GetFields()[0]
+			if got := GetMessageTypeName(field); got != test.want {
+				t.Errorf("Got %q, expected %q.", got, test.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I believe this is the last rule needed for standard fields.
Fixes #183.