### PR TITLE
[AIP-126] Pilot great godoc documentation.

### DIFF
--- a/rules/aip0126/aip0126.go
+++ b/rules/aip0126/aip0126.go
@@ -21,6 +21,6 @@ import "github.com/googleapis/api-linter/lint"
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
 		enumValueUpperSnakeCase,
-		unspecified,
+		Unspecified(),
 	)
 }

--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -23,6 +23,52 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
+// This rule enforces that all enums have a default unspecified value,
+// as described in [AIP-126](http://aip.dev/126).
+//
+// Because our APIs create automatically-generated client libraries, we need
+// to consider languages that have varying behavior around default values.
+// To avoid any ambiguity or confusion across languages, all enumerations
+// should use an "unspecified" value beginning with the name of the enum
+// itself as the first (0) value.
+//
+// ## Details
+//
+// This rule finds all enumerations and ensures that the first one is
+// named after the enum itself with an `_UNSPECIFIED` suffix attached.
+//
+// ## Examples
+//
+// **Incorrect** code for this rule:
+//
+//   enum Format {
+//     HARDCOVER = 0;  // Should have "FORMAT_UNSPECIFIED" first.
+//   }
+//
+//   enum Format {
+//     UNSPECIFIED = 0;  // Should be "FORMAT_UNSPECIFIED".
+//     HARDCOVER = 1;
+//   }
+//
+// **Correct** code for this rule:
+//
+//   enum Format {
+//     FORMAT_UNSPECIFIED = 0;
+//     HARDCOVER = 1;
+//   }
+//
+// ## Disabling
+//
+// If you need to violate this rule, use a leading comment above the enum
+// value.
+//
+//   enum Format {
+//     // (-- api-linter: core::0126::unspecified=disabled --)
+//     HARDCOVER = 0;
+//   }
+//
+// If you need to violate this rule for an entire file, place the comment at
+// the top of the file.
 var unspecified = &lint.EnumRule{
 	Name: lint.NewRuleName("core", "0126", "unspecified"),
 	URI:  "https://aip.dev/126#guidance",

--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -23,8 +23,7 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
-// This rule enforces that all enums have a default unspecified value,
-// as described in [AIP-126](http://aip.dev/126).
+// Unspecified enforces that all enums have a default unspecified value.
 //
 // Because our APIs create automatically-generated client libraries, we need
 // to consider languages that have varying behavior around default values.
@@ -32,14 +31,14 @@ import (
 // should use an "unspecified" value beginning with the name of the enum
 // itself as the first (0) value.
 //
-// ## Details
+// Details
 //
 // This rule finds all enumerations and ensures that the first one is
 // named after the enum itself with an `_UNSPECIFIED` suffix attached.
 //
-// ## Examples
+// Examples
 //
-// **Incorrect** code for this rule:
+// Incorrect code for this rule:
 //
 //   enum Format {
 //     HARDCOVER = 0;  // Should have "FORMAT_UNSPECIFIED" first.
@@ -50,14 +49,14 @@ import (
 //     HARDCOVER = 1;
 //   }
 //
-// **Correct** code for this rule:
+// Correct code for this rule:
 //
 //   enum Format {
 //     FORMAT_UNSPECIFIED = 0;
 //     HARDCOVER = 1;
 //   }
 //
-// ## Disabling
+// Disabling
 //
 // If you need to violate this rule, use a leading comment above the enum
 // value.
@@ -69,21 +68,23 @@ import (
 //
 // If you need to violate this rule for an entire file, place the comment at
 // the top of the file.
-var unspecified = &lint.EnumRule{
-	Name: lint.NewRuleName("core", "0126", "unspecified"),
-	URI:  "https://aip.dev/126#guidance",
-	LintEnum: func(e *desc.EnumDescriptor) []lint.Problem {
-		firstValue := e.GetValues()[0]
-		want := strings.ToUpper(strcase.SnakeCase(e.GetName()) + "_UNSPECIFIED")
-		if firstValue.GetName() != want {
-			return []lint.Problem{{
-				Message:    fmt.Sprintf("The first enum value should be %q", want),
-				Suggestion: want,
-				Descriptor: firstValue,
-				Location:   lint.DescriptorNameLocation(firstValue),
-			}}
-		}
+func Unspecified() lint.ProtoRule {
+	return &lint.EnumRule{
+		Name: lint.NewRuleName("core", "0126", "unspecified"),
+		URI:  "https://aip.dev/126#guidance",
+		LintEnum: func(e *desc.EnumDescriptor) []lint.Problem {
+			firstValue := e.GetValues()[0]
+			want := strings.ToUpper(strcase.SnakeCase(e.GetName()) + "_UNSPECIFIED")
+			if firstValue.GetName() != want {
+				return []lint.Problem{{
+					Message:    fmt.Sprintf("The first enum value should be %q", want),
+					Suggestion: want,
+					Descriptor: firstValue,
+					Location:   lint.DescriptorNameLocation(firstValue),
+				}}
+			}
 
-		return nil
-	},
+			return nil
+		},
+	}
 }

--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -31,8 +31,6 @@ import (
 // should use an "unspecified" value beginning with the name of the enum
 // itself as the first (0) value.
 //
-// Details
-//
 // This rule finds all enumerations and ensures that the first one is
 // named after the enum itself with an `_UNSPECIFIED` suffix attached.
 //

--- a/rules/aip0126/unspecified_test.go
+++ b/rules/aip0126/unspecified_test.go
@@ -43,7 +43,7 @@ func TestUnspecified(t *testing.T) {
 			`, test)
 
 			// Run the lint rule and establish we get the correct problems.
-			problems := unspecified.Lint(f)
+			problems := Unspecified().Lint(f)
 			if diff := test.problems.SetDescriptor(f.GetEnumTypes()[0].GetValues()[0]).Diff(problems); diff != "" {
 				t.Errorf(diff)
 			}


### PR DESCRIPTION
This PR is an attempt to make documentation for a rule awesome.
It uses godoc to do the heavy lifting.

This requires making a function that returns the rule.
If we decide to go with this route, we will also probably need to tell rules what their godoc link is, because they will not be able to infer it as best as I can tell (rats).

![image](https://user-images.githubusercontent.com/4346/67237801-d4dde500-f400-11e9-9d20-b03ff930109a.png)

We should not merge this until we talk about whether this is the strategy we want.
If we do want this strategy, we should probably shore up our docs everywhere since people are likely view them frequently. I have sent #250 as a down payment on this.