### PR TITLE
[AIP-136] Add initial rules for AIP-136.

### DIFF
--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -23,6 +23,52 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
+// This rule enforces that all enums have a default unspecified value,
+// as described in [AIP-126](http://aip.dev/126).
+//
+// Because our APIs create automatically-generated client libraries, we need
+// to consider languages that have varying behavior around default values.
+// To avoid any ambiguity or confusion across languages, all enumerations
+// should use an "unspecified" value beginning with the name of the enum
+// itself as the first (0) value.
+//
+// ## Details
+//
+// This rule finds all enumerations and ensures that the first one is
+// named after the enum itself with an `_UNSPECIFIED` suffix attached.
+//
+// ## Examples
+//
+// **Incorrect** code for this rule:
+//
+//   enum Format {
+//     HARDCOVER = 0;  // Should have "FORMAT_UNSPECIFIED" first.
+//   }
+//
+//   enum Format {
+//     UNSPECIFIED = 0;  // Should be "FORMAT_UNSPECIFIED".
+//     HARDCOVER = 1;
+//   }
+//
+// **Correct** code for this rule:
+//
+//   enum Format {
+//     FORMAT_UNSPECIFIED = 0;
+//     HARDCOVER = 1;
+//   }
+//
+// ## Disabling
+//
+// If you need to violate this rule, use a leading comment above the enum
+// value.
+//
+//   enum Format {
+//     // (-- api-linter: core::0126::unspecified=disabled --)
+//     HARDCOVER = 0;
+//   }
+//
+// If you need to violate this rule for an entire file, place the comment at
+// the top of the file.
 var unspecified = &lint.EnumRule{
 	Name: lint.NewRuleName("core", "0126", "unspecified"),
 	URI:  "https://aip.dev/126#guidance",

--- a/rules/aip0131/aip0131.go
+++ b/rules/aip0131/aip0131.go
@@ -27,8 +27,8 @@ import (
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
 		httpBody,
+		httpMethod,
 		httpNameField,
-		httpVerb,
 		responseMessageName,
 		requestMessageName,
 		standardFields,

--- a/rules/aip0131/method_rules.go
+++ b/rules/aip0131/method_rules.go
@@ -70,8 +70,8 @@ var responseMessageName = &lint.MethodRule{
 }
 
 // Get methods should use the HTTP GET verb.
-var httpVerb = &lint.MethodRule{
-	Name:   lint.NewRuleName("core", "0131", "http-verb"),
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName("core", "0131", "http-method"),
 	URI:    "https://aip.dev/131#guidance",
 	OnlyIf: isGetMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0131/method_rules_test.go
+++ b/rules/aip0131/method_rules_test.go
@@ -97,7 +97,7 @@ func TestResponseMessageName(t *testing.T) {
 	}
 }
 
-func TestHttpVerb(t *testing.T) {
+func TestHttpMethod(t *testing.T) {
 	// Set up GET and POST HTTP annotations.
 	httpGet := &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Get{
@@ -142,7 +142,7 @@ func TestHttpVerb(t *testing.T) {
 			}
 
 			// Run the method, ensure we get what we expect.
-			problems := httpVerb.Lint(service.GetFile())
+			problems := httpMethod.Lint(service.GetFile())
 			if test.msg == "" && len(problems) > 0 {
 				t.Errorf("Got %v, expected no problems.", problems)
 			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {

--- a/rules/aip0133/aip0133.go
+++ b/rules/aip0133/aip0133.go
@@ -27,9 +27,9 @@ import (
 // this AIP's rules to it.
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
-		httpURIField,
-		httpVerb,
 		httpBody,
+		httpURIField,
+		httpMethod,
 		inputName,
 		outputName,
 		resourceField,

--- a/rules/aip0133/method_rules.go
+++ b/rules/aip0133/method_rules.go
@@ -24,8 +24,8 @@ import (
 )
 
 // Create methods should use the HTTP POST verb.
-var httpVerb = &lint.MethodRule{
-	Name:   lint.NewRuleName("core", "0133", "http-verb"),
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName("core", "0133", "http-method"),
 	URI:    "https://aip.dev/133#guidance",
 	OnlyIf: isCreateMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0133/method_rules_test.go
+++ b/rules/aip0133/method_rules_test.go
@@ -25,7 +25,7 @@ import (
 	"google.golang.org/genproto/googleapis/api/annotations"
 )
 
-func TestHttpVerb(t *testing.T) {
+func TestHttpMethod(t *testing.T) {
 	// Set up GET and POST HTTP annotations.
 	httpGet := &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Get{
@@ -70,7 +70,7 @@ func TestHttpVerb(t *testing.T) {
 			}
 
 			// Run the method, ensure we get what we expect.
-			problems := httpVerb.Lint(service.GetFile())
+			problems := httpMethod.Lint(service.GetFile())
 			if test.msg == "" && len(problems) > 0 {
 				t.Errorf("Got %v, expected no problems.", problems)
 			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {

--- a/rules/aip0134/aip0134.go
+++ b/rules/aip0134/aip0134.go
@@ -27,8 +27,8 @@ import (
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
 		httpBody,
+		httpMethod,
 		httpNameField,
-		httpVerb,
 		responseMessageName,
 		requestMessageName,
 		standardFields,

--- a/rules/aip0134/method_rules.go
+++ b/rules/aip0134/method_rules.go
@@ -78,8 +78,8 @@ var responseMessageName = &lint.MethodRule{
 }
 
 // Update methods should use the HTTP PATCH verb.
-var httpVerb = &lint.MethodRule{
-	Name:   lint.NewRuleName("core", "0134", "http-verb"),
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName("core", "0134", "http-method"),
 	URI:    "https://aip.dev/134#patch-and-put",
 	OnlyIf: isUpdateMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0134/method_rules_test.go
+++ b/rules/aip0134/method_rules_test.go
@@ -108,7 +108,7 @@ func TestResponseMessageName(t *testing.T) {
 	}
 }
 
-func TestHttpVerb(t *testing.T) {
+func TestHttpMethod(t *testing.T) {
 	// Set up POST and PATCH HTTP annotations.
 	httpPost := &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Post{
@@ -153,7 +153,7 @@ func TestHttpVerb(t *testing.T) {
 			}
 
 			// Run the method, ensure we get what we expect.
-			problems := httpVerb.Lint(service.GetFile())
+			problems := httpMethod.Lint(service.GetFile())
 			if test.msg == "" && len(problems) > 0 {
 				t.Errorf("Got %v, expected no problems.", problems)
 			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {

--- a/rules/aip0135/aip0135.go
+++ b/rules/aip0135/aip0135.go
@@ -27,8 +27,8 @@ import (
 func AddRules(r lint.RuleRegistry) {
 	r.Register(
 		httpBody,
+		httpMethod,
 		httpNameField,
-		httpVerb,
 		responseMessageName,
 		requestMessageName,
 		standardFields,

--- a/rules/aip0135/method_rules.go
+++ b/rules/aip0135/method_rules.go
@@ -17,8 +17,8 @@ package aip0135
 import (
 	"fmt"
 
-	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -76,9 +76,9 @@ var responseMessageName = &lint.MethodRule{
 	},
 }
 
-// Delete methods should use the HTTP DELETE verb.
-var httpVerb = &lint.MethodRule{
-	Name:   lint.NewRuleName("core", "0135", "http-verb"),
+// Delete methods should use the HTTP DELETE method.
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName("core", "0135", "http-method"),
 	URI:    "https://aip.dev/135#guidance",
 	OnlyIf: isDeleteMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0135/method_rules_test.go
+++ b/rules/aip0135/method_rules_test.go
@@ -20,9 +20,7 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	epb "github.com/golang/protobuf/ptypes/empty"
 	"github.com/googleapis/api-linter/rules/internal/testutils"
-	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
 	"google.golang.org/genproto/googleapis/api/annotations"
 )

--- a/rules/aip0135/method_rules_test.go
+++ b/rules/aip0135/method_rules_test.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/golang/protobuf/proto"
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
-	"github.com/googleapis/api-linter/rules/internal/testutils"
 	epb "github.com/golang/protobuf/ptypes/empty"
+	"github.com/googleapis/api-linter/rules/internal/testutils"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
 	"google.golang.org/genproto/googleapis/api/annotations"
@@ -84,10 +84,10 @@ func TestResponseMessageName(t *testing.T) {
 
 	// Set up the testing permutations.
 	tests := []struct {
-		testName     string
-		methodName   string
-		respMessage  *builder.MessageBuilder
-		problems     testutils.Problems
+		testName    string
+		methodName  string
+		respMessage *builder.MessageBuilder
+		problems    testutils.Problems
 	}{
 		{"ValidEmpty", "DeleteBook", emptybldr, testutils.Problems{}},
 		{"ValidLRO", "DeleteBook", opbldr, testutils.Problems{}},
@@ -118,7 +118,7 @@ func TestResponseMessageName(t *testing.T) {
 	}
 }
 
-func TestHttpVerb(t *testing.T) {
+func TestHttpMethod(t *testing.T) {
 	// Set up GET and DELETE HTTP annotations.
 	httpGet := &annotations.HttpRule{
 		Pattern: &annotations.HttpRule_Get{
@@ -163,7 +163,7 @@ func TestHttpVerb(t *testing.T) {
 			}
 
 			// Run the method, ensure we get what we expect.
-			problems := httpVerb.Lint(service.GetFile())
+			problems := httpMethod.Lint(service.GetFile())
 			if test.msg == "" && len(problems) > 0 {
 				t.Errorf("Got %v, expected no problems.", problems)
 			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {

--- a/rules/aip0136/aip0136.go
+++ b/rules/aip0136/aip0136.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 		https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,30 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0140
+// Package aip0136 contains rules defined in https://aip.dev/136.
+package aip0136
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/rules/internal/data"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var noPrepositions = &lint.FieldRule{
-	Name: lint.NewRuleName("core", "0140", "prepositions"),
-	URI:  "https://aip.dev/140#prepositions",
-	LintField: func(f *desc.FieldDescriptor) (problems []lint.Problem) {
-		for _, word := range strings.Split(f.GetName(), "_") {
-			if data.Prepositions.Contains(word) {
-				problems = append(problems, lint.Problem{
-					Message:    fmt.Sprintf("Avoid using %q in field names.", word),
-					Descriptor: f,
-					Location:   lint.DescriptorNameLocation(f),
-				})
-			}
+// AddRules accepts a register function and registers each of
+// this AIP's rules to it.
+func AddRules(r lint.RuleRegistry) {
+	r.Register(
+		httpMethod,
+		noPrepositions,
+		verbNoun,
+	)
+}
+
+func isCustomMethod(m *desc.MethodDescriptor) bool {
+	for _, prefix := range []string{"Get", "List", "Create", "Update", "Delete", "Replace"} {
+		if strings.HasPrefix(m.GetName(), prefix) {
+			return false
 		}
-		return
-	},
+	}
+	return true
 }

--- a/rules/aip0136/aip0136_test.go
+++ b/rules/aip0136/aip0136_test.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+func TestAddRules(t *testing.T) {
+	rules := make(lint.RuleRegistry)
+	AddRules(rules)
+	for ruleName := range rules {
+		if !strings.HasPrefix(string(ruleName), "core::0136") {
+			t.Errorf("Rule %s is not namespaced to core::0136.", ruleName)
+		}
+	}
+}

--- a/rules/aip0136/http_method.go
+++ b/rules/aip0136/http_method.go
@@ -26,7 +26,7 @@ var httpMethod = &lint.MethodRule{
 	OnlyIf: isCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetPost() == "" && httpRule.GetGet() == "" {
+			if httpRule.Method != "POST" && httpRule.Method != "GET" {
 				return []lint.Problem{{
 					Message:    "Custom methods should use the HTTP POST or GET method.",
 					Descriptor: m,

--- a/rules/aip0136/http_method.go
+++ b/rules/aip0136/http_method.go
@@ -1,0 +1,38 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName("core", "0136", "http-method"),
+	URI:    "https://aip.dev/136#guidance",
+	OnlyIf: isCustomMethod,
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		for _, httpRule := range utils.GetHTTPRules(m) {
+			if httpRule.GetPost() == "" && httpRule.GetGet() == "" {
+				return []lint.Problem{{
+					Message:    "Custom methods should use the HTTP POST or GET method.",
+					Descriptor: m,
+				}}
+			}
+		}
+		return nil
+	},
+}

--- a/rules/aip0136/http_method_test.go
+++ b/rules/aip0136/http_method_test.go
@@ -1,0 +1,60 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestHttpMethod(t *testing.T) {
+	tests := []struct {
+		testName   string
+		MethodName string
+		HTTPMethod string
+		problems   testutils.Problems
+	}{
+		{"ValidGet", "ArchiveBook", "get", testutils.Problems{}},
+		{"ValidPost", "ArchiveBook", "post", testutils.Problems{}},
+		{"InvalidPut", "ArchiveBook", "put", testutils.Problems{{Message: "POST or GET"}}},
+		{"InvalidPatch", "ArchiveBook", "patch", testutils.Problems{{Message: "POST or GET"}}},
+		{"InvalidDelete", "ArchiveBook", "delete", testutils.Problems{{Message: "POST or GET"}}},
+		{"IrrelevantPatch", "UpdateBook", "patch", testutils.Problems{}},
+		{"IrrelevantDelete", "DeleteBook", "delete", testutils.Problems{}},
+		{"IrrelevantPut", "ReplaceBook", "put", testutils.Problems{}},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/annotations.proto";
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
+						option (google.api.http) = {
+							{{.HTTPMethod}}: "/v1:{{.MethodName}}"
+						};
+					}
+				}
+				message {{.MethodName}}Request {}
+				message {{.MethodName}}Response {}
+			`, test)
+			method := file.GetServices()[0].GetMethods()[0]
+			got := httpMethod.Lint(file)
+			if diff := test.problems.SetDescriptor(method).Diff(got); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0136/prepositions.go
+++ b/rules/aip0136/prepositions.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-// 		https://www.apache.org/licenses/LICENSE-2.0
+//     https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0140
+package aip0136
 
 import (
 	"fmt"
@@ -21,18 +21,19 @@ import (
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/rules/internal/data"
 	"github.com/jhump/protoreflect/desc"
+	"github.com/stoewer/go-strcase"
 )
 
-var noPrepositions = &lint.FieldRule{
-	Name: lint.NewRuleName("core", "0140", "prepositions"),
-	URI:  "https://aip.dev/140#prepositions",
-	LintField: func(f *desc.FieldDescriptor) (problems []lint.Problem) {
-		for _, word := range strings.Split(f.GetName(), "_") {
+var noPrepositions = &lint.MethodRule{
+	Name: lint.NewRuleName("core", "0136", "prepositions"),
+	URI:  "https://aip.dev/136#guidance",
+	LintMethod: func(m *desc.MethodDescriptor) (problems []lint.Problem) {
+		for _, word := range strings.Split(strcase.SnakeCase(m.GetName()), "_") {
 			if data.Prepositions.Contains(word) {
 				problems = append(problems, lint.Problem{
-					Message:    fmt.Sprintf("Avoid using %q in field names.", word),
-					Descriptor: f,
-					Location:   lint.DescriptorNameLocation(f),
+					Message:    fmt.Sprintf("Method names should not include prepositions (%q).", word),
+					Descriptor: m,
+					Location:   lint.DescriptorNameLocation(m),
 				})
 			}
 		}

--- a/rules/aip0136/prepositions_test.go
+++ b/rules/aip0136/prepositions_test.go
@@ -1,0 +1,48 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestNoPrepositions(t *testing.T) {
+	tests := []struct {
+		MethodName string
+		problems   testutils.Problems
+	}{
+		{"ArchiveBook", testutils.Problems{}},
+		{"MoveToBook", testutils.Problems{{Message: "to"}}},
+		{"MoveFromShelfToShelf", testutils.Problems{{Message: "from"}, {Message: "to"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.MethodName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response);
+				}
+				message {{.MethodName}}Request {}
+				message {{.MethodName}}Response {}
+			`, test)
+			method := file.GetServices()[0].GetMethods()[0]
+			got := noPrepositions.Lint(file)
+			if diff := test.problems.SetDescriptor(method).Diff(got); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0136/verb_noun.go
+++ b/rules/aip0136/verb_noun.go
@@ -1,0 +1,43 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/stoewer/go-strcase"
+)
+
+var verbNoun = &lint.MethodRule{
+	Name: lint.NewRuleName("core", "0136", "verb-noun"),
+	URI:  "https://aip.dev/136#guidance",
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		// We can not detect this precisely without a full dictionary (probably
+		// not worth it), but we can catch some common mistakes.
+
+		// Are there at least two words?
+		if wordCount := len(strings.Split(strcase.SnakeCase(m.GetName()), "_")); wordCount == 1 {
+			return []lint.Problem{{
+				Message:    "Custom methods should be named using a verb followed by a noun.",
+				Descriptor: m,
+				Location:   lint.DescriptorNameLocation(m),
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0136/verb_noun_test.go
+++ b/rules/aip0136/verb_noun_test.go
@@ -1,0 +1,47 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestVerbNoun(t *testing.T) {
+	tests := []struct {
+		MethodName string
+		problems   testutils.Problems
+	}{
+		{"ArchiveBook", testutils.Problems{}},
+		{"Archive", testutils.Problems{{Message: "verb followed by a noun"}}},
+	}
+	for _, test := range tests {
+		t.Run(test.MethodName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response);
+				}
+				message {{.MethodName}}Request {}
+				message {{.MethodName}}Response {}
+			`, test)
+			method := file.GetServices()[0].GetMethods()[0]
+			got := verbNoun.Lint(file)
+			if diff := test.problems.SetDescriptor(method).Diff(got); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/internal/data/data.go
+++ b/rules/internal/data/data.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package data contains constants used in multiple AIP rules.
+package data
+
+import "bitbucket.org/creachadair/stringset"
+
+// Conjunctions is a set of conjunctions.
+var Conjunctions = stringset.New("and", "or")
+
+// Prepositions is a set of prepositions.
+var Prepositions = stringset.New(
+	"after", "at", "before", "between", "but", "by", "except",
+	"for", "from", "in", "including", "into", "of", "over", "since", "to",
+	"toward", "under", "upon", "with", "within", "without",
+)

--- a/rules/internal/data/data_test.go
+++ b/rules/internal/data/data_test.go
@@ -1,0 +1,25 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package data
+
+import "testing"
+
+// "per" is a special exception to the preposition rule, per AIP-140
+// (but it would be easy for a well-meaning person to add it to the set).
+func TestPrepositionsExcludesPer(t *testing.T) {
+	if Prepositions.Contains("per") {
+		t.Errorf("`per` should be an acceptable preposition.")
+	}
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -22,6 +22,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0133"
 	"github.com/googleapis/api-linter/rules/aip0134"
 	"github.com/googleapis/api-linter/rules/aip0135"
+	"github.com/googleapis/api-linter/rules/aip0136"
 	"github.com/googleapis/api-linter/rules/aip0140"
 	"github.com/googleapis/api-linter/rules/aip0141"
 	"github.com/googleapis/api-linter/rules/aip0142"
@@ -39,6 +40,7 @@ func init() {
 	aip0133.AddRules(coreRules)
 	aip0134.AddRules(coreRules)
 	aip0135.AddRules(coreRules)
+	aip0136.AddRules(coreRules)
 	aip0140.AddRules(coreRules)
 	aip0141.AddRules(coreRules)
 	aip0142.AddRules(coreRules)


### PR DESCRIPTION
This also renames `http-verb` in other AIPs to `http-method`, which is the term most folks use.

Uses #247 as a base, because I made a mistake.