### PR TITLE
Refactor GetHTTPRules.

### DIFF
--- a/rules/aip0131/method_rules.go
+++ b/rules/aip0131/method_rules.go
@@ -77,7 +77,7 @@ var httpVerb = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that the RPC uses HTTP GET.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetGet() == "" {
+			if httpRule.Method != "GET" {
 				return []lint.Problem{{
 					Message:    "Get methods must use the HTTP GET verb.",
 					Descriptor: m,
@@ -97,7 +97,7 @@ var httpNameField = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if uri := httpRule.GetGet(); uri != "" {
+			if httpRule.Method != "GET" {
 				if !getURINameRegexp.MatchString(uri) {
 					return []lint.Problem{{
 						Message:    "Get methods should include the `name` field in the URI.",
@@ -119,7 +119,7 @@ var httpBody = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetBody() != "" {
+			if httpRule.Body != "" {
 				return []lint.Problem{{
 					Message:    "Get methods should not have an HTTP body.",
 					Descriptor: m,

--- a/rules/aip0131/method_rules.go
+++ b/rules/aip0131/method_rules.go
@@ -98,7 +98,7 @@ var httpNameField = &lint.MethodRule{
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			if httpRule.Method != "GET" {
-				if !getURINameRegexp.MatchString(uri) {
+				if !getURINameRegexp.MatchString(httpRule.URI) {
 					return []lint.Problem{{
 						Message:    "Get methods should include the `name` field in the URI.",
 						Descriptor: m,

--- a/rules/aip0131/method_rules.go
+++ b/rules/aip0131/method_rules.go
@@ -97,13 +97,11 @@ var httpNameField = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.Method != "GET" {
-				if !getURINameRegexp.MatchString(httpRule.URI) {
-					return []lint.Problem{{
-						Message:    "Get methods should include the `name` field in the URI.",
-						Descriptor: m,
-					}}
-				}
+			if !getURINameRegexp.MatchString(httpRule.URI) {
+				return []lint.Problem{{
+					Message:    "Get methods should include the `name` field in the URI.",
+					Descriptor: m,
+				}}
 			}
 		}
 

--- a/rules/aip0133/method_rules.go
+++ b/rules/aip0133/method_rules.go
@@ -100,7 +100,11 @@ var httpBody = &lint.MethodRule{
 				// "core::0133::request-message::resource-field"
 			} else if resourceFieldName != "" && httpRule.Body != resourceFieldName {
 				return []lint.Problem{{
-					Message:    fmt.Sprintf("The content of body %q must map to the resource field %q in the request message", body, resourceFieldName),
+					Message: fmt.Sprintf(
+						"The content of body %q must map to the resource field %q in the request message",
+						httpRule.Body,
+						resourceFieldName,
+					),
 					Descriptor: m,
 				}}
 			}

--- a/rules/aip0133/method_rules.go
+++ b/rules/aip0133/method_rules.go
@@ -31,7 +31,7 @@ var httpVerb = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that the RPC uses HTTP POST.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetPost() == "" {
+			if httpRule.Method != "POST" {
 				return []lint.Problem{{
 					Message:    "Create methods must use the HTTP POST verb.",
 					Descriptor: m,
@@ -51,13 +51,11 @@ var httpURIField = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC uri should include the `parent` field.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if uri := httpRule.GetPost(); uri != "" {
-				if !createURINameRegexp.MatchString(uri) {
-					return []lint.Problem{{
-						Message:    "Post methods should include the `parent` field in the URI.",
-						Descriptor: m,
-					}}
-				}
+			if !createURINameRegexp.MatchString(httpRule.URI) {
+				return []lint.Problem{{
+					Message:    "Create methods should include the `parent` field in the URI.",
+					Descriptor: m,
+				}}
 			}
 		}
 
@@ -90,7 +88,7 @@ var httpBody = &lint.MethodRule{
 
 		// Establish that HTTP body the RPC should map the resource field name in the request message.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if body := httpRule.GetBody(); body == "" {
+			if httpRule.Body == "" {
 				// Establish that the RPC should have HTTP body
 				return []lint.Problem{{
 					Message:    "Post methods should have an HTTP body.",
@@ -100,7 +98,7 @@ var httpBody = &lint.MethodRule{
 				// will not be triggered by the rule"core::0133::http-body". It will be
 				// triggered by another rule
 				// "core::0133::request-message::resource-field"
-			} else if resourceFieldName != "" && body != resourceFieldName {
+			} else if resourceFieldName != "" && httpRule.Body != resourceFieldName {
 				return []lint.Problem{{
 					Message:    fmt.Sprintf("The content of body %q must map to the resource field %q in the request message", body, resourceFieldName),
 					Descriptor: m,

--- a/rules/aip0134/method_rules.go
+++ b/rules/aip0134/method_rules.go
@@ -85,7 +85,7 @@ var httpVerb = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that the RPC uses HTTP PATCH.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetPatch() == "" {
+			if httpRule.Method != "PATCH" {
 				return []lint.Problem{{
 					Message:    "Update methods must use the HTTP PATCH verb.",
 					Descriptor: m,
@@ -106,14 +106,12 @@ var httpNameField = &lint.MethodRule{
 		fieldName := strcase.SnakeCase(m.GetName()[6:])
 		// Establish that the RPC has expected HTTP pattern.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if uri := httpRule.GetPatch(); uri != "" {
-				matches := updateURINameRegexp.FindStringSubmatch(uri)
-				if matches == nil || matches[1] != fieldName {
-					return []lint.Problem{{
-						Message:    fmt.Sprintf("Update methods should include the `%s.name` field in the URI.", fieldName),
-						Descriptor: m,
-					}}
-				}
+			matches := updateURINameRegexp.FindStringSubmatch(httpRule.URI)
+			if matches == nil || matches[1] != fieldName {
+				return []lint.Problem{{
+					Message:    fmt.Sprintf("Update methods should include the `%s.name` field in the URI.", fieldName),
+					Descriptor: m,
+				}}
 			}
 		}
 
@@ -130,7 +128,7 @@ var httpBody = &lint.MethodRule{
 		fieldName := strcase.SnakeCase(m.GetName()[6:])
 		// Establish that the RPC has HTTP body equal to fieldName.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetBody() != fieldName {
+			if httpRule.Body != fieldName {
 				return []lint.Problem{{
 					Message:    fmt.Sprintf("Update methods should have an HTTP body equal to `%q`.", fieldName),
 					Descriptor: m,

--- a/rules/aip0135/method_rules.go
+++ b/rules/aip0135/method_rules.go
@@ -17,8 +17,8 @@ package aip0135
 import (
 	"fmt"
 
-	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -84,7 +84,7 @@ var httpVerb = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that the RPC uses HTTP DELETE.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetDelete() == "" {
+			if httpRule.Method != "DELETE" {
 				return []lint.Problem{{
 					Message:    "Delete methods must use the HTTP DELETE verb.",
 					Descriptor: m,
@@ -104,13 +104,11 @@ var httpNameField = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if uri := httpRule.GetDelete(); uri != "" {
-				if !deleteURINameRegexp.MatchString(uri) {
-					return []lint.Problem{{
-						Message:    "Delete methods should include the `name` field in the URI.",
-						Descriptor: m,
-					}}
-				}
+			if !deleteURINameRegexp.MatchString(httpRule.URI) {
+				return []lint.Problem{{
+					Message:    "Delete methods should include the `name` field in the URI.",
+					Descriptor: m,
+				}}
 			}
 		}
 
@@ -126,7 +124,7 @@ var httpBody = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Establish that the RPC has no HTTP body.
 		for _, httpRule := range utils.GetHTTPRules(m) {
-			if httpRule.GetBody() != "" {
+			if httpRule.Body != "" {
 				return []lint.Problem{{
 					Message:    "Delete methods should not have an HTTP body.",
 					Descriptor: m,

--- a/rules/internal/utils/http.go
+++ b/rules/internal/utils/http.go
@@ -26,8 +26,8 @@ import (
 // and then flattens the values in `additional_bindings`.
 // This allows rule authors to simply range over all of the HTTP rules,
 // since the common case is to want to apply the checks to all of them.
-func GetHTTPRules(m *desc.MethodDescriptor) []*apb.HttpRule {
-	rules := []*apb.HttpRule{}
+func GetHTTPRules(m *desc.MethodDescriptor) []*HTTPRule {
+	rules := []*HTTPRule{}
 
 	// Get the method options.
 	opts := m.GetMethodOptions()
@@ -35,12 +35,60 @@ func GetHTTPRules(m *desc.MethodDescriptor) []*apb.HttpRule {
 	// Get the "primary" rule (the direct google.api.http annotation).
 	if x, err := proto.GetExtension(opts, apb.E_Http); err == nil {
 		httpRule := x.(*apb.HttpRule)
-		rules = append(rules, httpRule)
+		if parsedRule := parseRule(httpRule); parsedRule != nil {
+			rules = append(rules, parsedRule)
 
-		// Add any additional bindings and flatten them into `rules`.
-		rules = append(rules, httpRule.GetAdditionalBindings()...)
+			// Add any additional bindings and flatten them into `rules`.
+			for _, binding := range httpRule.GetAdditionalBindings() {
+				rules = append(rules, parseRule(binding))
+			}
+		}
 	}
 
 	// Done; return the rules.
 	return rules
+}
+
+func parseRule(rule *apb.HttpRule) *HTTPRule {
+	answer := &HTTPRule{}
+	if uri := rule.GetGet(); uri != "" {
+		answer.Method = "GET"
+		answer.URI = uri
+	} else if uri := rule.GetPost(); uri != "" {
+		answer.Method = "POST"
+		answer.URI = uri
+	} else if uri := rule.GetPut(); uri != "" {
+		answer.Method = "PUT"
+		answer.URI = uri
+	} else if uri := rule.GetPatch(); uri != "" {
+		answer.Method = "PATCH"
+		answer.URI = uri
+	} else if uri := rule.GetDelete(); uri != "" {
+		answer.Method = "DELETE"
+		answer.URI = uri
+	} else if custom := rule.GetCustom(); custom != nil {
+		answer.Method = custom.GetKind()
+		answer.URI = custom.GetPath()
+	}
+
+	// Set the body and response body, and return the answer.
+	answer.Body = rule.GetBody()
+	answer.ResponseBody = rule.GetResponseBody()
+	return answer
+}
+
+// HTTPRule defines a parsed, easier-to-query equivalent to `apb.HttpRule`.
+type HTTPRule struct {
+	// The HTTP method. Guaranteed to be in all caps.
+	// This is set to "CUSTOM" if the Custom property is set.
+	Method string
+
+	// The HTTP URI (the value corresponding to the selected HTTP method).
+	URI string
+
+	// The `body` value forwarded from the generated proto's HttpRule.
+	Body string
+
+	// The `response_body` value forwarded from the generated proto's HttpRule.
+	ResponseBody string
 }

--- a/rules/internal/utils/http_test.go
+++ b/rules/internal/utils/http_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/googleapis/api-linter/rules/internal/testutils"
+	apb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 func TestGetHTTPRules(t *testing.T) {
@@ -70,6 +71,13 @@ func TestGetHTTPRulesEmpty(t *testing.T) {
 	`)
 	if resp := GetHTTPRules(file.GetServices()[0].GetMethods()[0]); len(resp) > 0 {
 		t.Errorf("Got %v; expected no rules.", resp)
+	}
+}
+
+func TestParseRuleEmpty(t *testing.T) {
+	http := &apb.HttpRule{}
+	if got := parseRule(http); got != nil {
+		t.Errorf("Got %v, expected nil.", got)
 	}
 }
 


### PR DESCRIPTION
In writing an upcoming rule for AIP-156, I realized I have cases
where I *only* care about the URI, and not the method. Getting
this is a huge pain.

I have therefore refactored `GetHTTPRules` to return a custom
struct instead of the underlying proto annotation. The custom
struct has `Method` and `URI` fields that correspond to the
values on the annotation.

In the refactor to the standard method rules, the change clearly
does a better job of expressing intent: `if r.Method == "POST"`
is much clearer than `if r.GetPost() != ""`.