### PR TITLE
[fix] Address broken links.

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -8,4 +8,4 @@ defaults:
       path: ''
     values:
       js:
-        - /assets/js/proto-syntax.js
+        - assets/js/proto-syntax.js

--- a/docs/_includes/linter-breadcrumb.html
+++ b/docs/_includes/linter-breadcrumb.html
@@ -5,27 +5,25 @@
   <!-- prettier-ignore -->
   <ol class="glue-breadcrumbs__list api-linter-breadcrumbs">
     <li class="glue-breadcrumbs__item" aria-level="1">
-      <a class="glue-breadcrumbs__link" href="/">
+      <a class="glue-breadcrumbs__link" href="{{ site.url }}">
         API Linter
       </a>
     </li>
     {%- if (page.url | slice: 0, 7) == '/rules/' %}
     {%- assign url_segments = page.url | split: '/' %}
     {%- assign url_limit = url_segments | size | minus: 2 %}
-    {%- assign cursor = '/' %}
+    {%- assign cursor = '' %}
     {%- for segment in url_segments offset: 1 limit: url_limit %}
       {%- assign cursor = cursor | append: segment | append: '/' %}
       <li class="glue-breadcrumbs__item" aria-level="2">
         <a class="glue-breadcrumbs__link" href="{{ cursor }}">
-          {%- unless segment contains "e" %}
-          AIP-{{ segment }}
-          {%- elsif segment == "rules" %}
+          {%- if segment == "rules" %}
           Rule Documentation
           {%- elsif segment == "core" %}
           Core rules
           {%- else %}
           {{ segment | replace: ('-', ' ') | capitalize }}
-          {% endunless %}
+          {% endif %}
         </a>
       </li>
     {%- endfor %}

--- a/docs/_includes/linter-nav-mobile.html
+++ b/docs/_includes/linter-nav-mobile.html
@@ -1,30 +1,30 @@
-<nav class="h-c-header__drawer-nav" id="aip-nav-mobile">
-  <ul class="h-c-header__drawer-nav-list">
-    <li class="h-c-header__drawer-nav-li drawer-heading">
+<nav class="glue-header__drawer-nav" id="api-linter-nav-mobile">
+  <ul class="glue-header__drawer-nav-list">
+    <li class="glue-header__drawer-nav-li drawer-heading">
       <div class="drawer-heading-text">API Linter</div>
     </li>
-    <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="/rules/" class="h-c-header__drawer-nav-li-link">
+    <li class="glue-header__drawer-nav-li" aria-level="1">
+      <a href="rules/" class="glue-header__drawer-nav-li-link">
         Rule Documentation
       </a>
     </li>
-    <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="#" class="h-c-header__drawer-nav-li-link">
+    <li class="glue-header__drawer-nav-li" aria-level="1">
+      <a href="configuration" class="glue-header__drawer-nav-li-link">
         Configuration
       </a>
     </li>
-    <li class="h-c-header__drawer-nav-li" aria-level="1">
-      <a href="#" class="h-c-header__drawer-nav-li-link">
+    <li class="glue-header__drawer-nav-li" aria-level="1">
+      <a href="#" class="glue-header__drawer-nav-li-link">
         Contributing
       </a>
     </li>
 
-    <li class="h-c-header__drawer-nav-li" aria-level="1">
+    <li class="glue-header__drawer-nav-li" aria-level="1">
       <button
         type="button"
-        class="h-c-header__drawer-nav-close-btn"
-        id="h-js-header__drawer-close-btn"
-        aria-controls="h-js-header__drawer"
+        class="glue-header__drawer-nav-close-btn"
+        id="glue-js-header__drawer-close-btn"
+        aria-controls="glue-js-header__drawer"
         aria-expanded="true"
         aria-label="Close the navigation drawer"
       >

--- a/docs/_includes/linter-rule-listing.html
+++ b/docs/_includes/linter-rule-listing.html
@@ -40,7 +40,7 @@ values are inclusive. {% endcomment -%}
           {% for p in pbr.items -%}
           <tr>
             <td style="vertical-align: top;">
-              <a href="{{ p.url }}">
+              <a href="{{ p.url | remove_first: '/' }}">
               <tt>{{ p.rule.name | join: '::' }}</tt>
               </a>
             </td>

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -2,16 +2,17 @@
 <html lang="{{ site.lang | default: 'en-US' }}" class="glue-flexbox">
   <head>
     <title>{% if page.aip %}AIP-{{ page.aip.id }}: {% endif %}{{ page.title }}</title>
+    <base href="{{ site.url }}">
     <meta charset='utf-8'>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,maximum-scale=2">
     <link href="//fonts.googleapis.com/css?family=Roboto:100,300,400,500,700|Google+Sans:400,500|Product+Sans:400&amp;lang=en" rel="stylesheet"></link>
     <link rel="stylesheet" type="text/css" media="screen" href="//www.gstatic.com/glue/v21_0/glue.min.css">
-    <link rel="stylesheet" type="text/css" media="screen" href="{{ '/assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" type="text/css" media="screen" href="{{ 'assets/css/style.css?v=' | append: site.github.build_revision | relative_url }}">
     {% for stylesheet in page.css -%}
     <link rel="stylesheet" type="text/css" media="screen" href="{{ stylesheet }}?v={{ site.github.build_revision }}">
     {% endfor -%}
-    <link rel="stylesheet" type="text/css" media="print" href="{{ '/assets/css/print.css?v=' | append: site.github.build_revision | relative_url }}">
+    <link rel="stylesheet" type="text/css" media="print" href="{{ 'assets/css/print.css?v=' | append: site.github.build_revision | relative_url }}">
     <script type="text/javascript" src="//code.jquery.com/jquery-3.4.0.min.js"></script>
     <script type="text/javascript" src="//www.gstatic.com/glue/latest/glue-detect.min.js"></script>
     <script type="text/javascript">
@@ -20,7 +21,7 @@
         $('html').css('visibility', 'visible');
       });
     </script>
-    <script type="text/javascript" src="{{ '/assets/js/global.js?v=' | append: site.github.build_revision | relative_url }}"></script>
+    <script type="text/javascript" src="{{ 'assets/js/global.js?v=' | append: site.github.build_revision | relative_url }}"></script>
     {% for js_script in page.js -%}
     <script type="text/javascript" src="{{ js_script }}?v={{ site.github.build_revision }}"></script>
     {% endfor -%}
@@ -99,12 +100,12 @@
         <nav class="glue-header__nav">
           <ul class="glue-header__nav-list">
             <li class="glue-header__nav-li" aria-level="1">
-              <a href="/rules/" class="glue-header__nav-li-link{% if page.url contains '/rules/' %} glue-is-active{% endif %}">
+              <a href="rules/" class="glue-header__nav-li-link{% if page.url contains '/rules/' %} glue-is-active{% endif %}">
                 Rule Documentation
               </a>
             </li>
             <li class="glue-header__nav-li" aria-level="1">
-              <a href="/configuration" class="glue-header__nav-li-link{% if page.url contains '/configuration' %} glue-is-active{% endif %}">
+              <a href="configuration" class="glue-header__nav-li-link{% if page.url contains '/configuration' %} glue-is-active{% endif %}">
                 Configuration
               </a>
             </li>
@@ -126,7 +127,7 @@
             <li class="glue-header__cta-li glue-header__cta-li--primary">
               <a href="https://github.com/googleapis/api-linter" class="glue-header__cta-li-link
                   glue-header__cta-li-link--primary">
-                <img src="/assets/images/github.png" class="github-logo">
+                <img src="assets/images/github.png" class="github-logo">
                 View on GitHub
               </a>
             </li>


### PR DESCRIPTION
Because we host from a subdirectory, all of the links that worked
on the development site do not work on live.

This adds a `<base href=...>` and moves to relative individual
links, which should work.