### PR TITLE
Allowed injecting configs.

### DIFF
--- a/cmd/api-linter/main.go
+++ b/cmd/api-linter/main.go
@@ -25,6 +25,7 @@ import (
 )
 
 var globalRules = core.Rules()
+var globalConfigs = defaultConfigs()
 
 func main() {
 	if err := runCLI(os.Args[1:]); err != nil {
@@ -34,7 +35,7 @@ func main() {
 
 func runCLI(args []string) error {
 	c := newCli(args)
-	return c.lint(globalRules, defaultConfigs())
+	return c.lint(globalRules, globalConfigs)
 }
 
 func defaultConfigs() lint.Configs {


### PR DESCRIPTION
This allows injecting Google internal configs, for example, we can create a `google_configs.go` file with:

```golang
package main
func init() {
  globalConfigs = append(globalConfigs, myConfigs...)
}
```