### PR TITLE
Added rule doc uri to the output.

### DIFF
--- a/lint/problem.go
+++ b/lint/problem.go
@@ -16,6 +16,7 @@ package lint
 
 import (
 	"encoding/json"
+	"strings"
 
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
@@ -87,12 +88,14 @@ func (p Problem) marshal() interface{} {
 		Suggestion string       `json:"suggestion,omitempty" yaml:"suggestion,omitempty"`
 		Location   fileLocation `json:"location" yaml:"location"`
 		RuleID     RuleName     `json:"rule_id" yaml:"rule_id"`
+		RuleDocURI string       `json:"rule_doc_uri" yaml:"rule_doc_uri"`
 		Category   string       `json:"category,omitempty" yaml:"category,omitempty"`
 	}{
 		p.Message,
 		p.Suggestion,
 		fileLocationFromPBLocation(loc),
 		p.RuleID,
+		ruleDocURI(p.RuleID),
 		p.category,
 	}
 }
@@ -150,4 +153,13 @@ func fileLocationFromPBLocation(l *dpb.SourceCodeInfo_Location) fileLocation {
 			Column: int(span[2]) + 1,
 		},
 	}
+}
+
+// ruleDocURI returns the link to the rule doc in https://googleapis.github.io/api-linter.
+func ruleDocURI(name RuleName) string {
+	base := "https://googleapis.github.io/api-linter/rules"
+	nameParts := strings.Split(string(name), "::") // e.g., core::0122::camel-case-uri -> ["core", "0122", "camel-case-uri"]
+	ruleSet := nameParts[0]
+	path := strings.Join(nameParts[1:], "-")
+	return base + "/" + ruleSet + "/" + path + ".html"
 }

--- a/lint/problem_test.go
+++ b/lint/problem_test.go
@@ -117,3 +117,23 @@ func TestProblemDescriptor(t *testing.T) {
 	}
 
 }
+
+func TestRuleDocURI(t *testing.T) {
+	cases := []struct {
+		name     string
+		ruleName RuleName
+		wantURI  string
+	}{{
+		name:     "CoreRule",
+		ruleName: NewRuleName("core", "0122", "camel-case-uris"),
+		wantURI:  "https://googleapis.github.io/api-linter/rules/core/0122-camel-case-uris.html",
+	}}
+
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			if got, want := ruleDocURI(test.ruleName), test.wantURI; got != want {
+				t.Errorf("ruleDocURI(%q): got %q, but want %q", string(test.ruleName), got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Example output:

```yaml
- file_path: dummy.proto
  problems:
  - message: Method "GetDummyRequest" has no `name` field
    location:
      start_position:
        line_number: 5
        column_number: 1
      end_position:
        line_number: 7
        column_number: 2
    rule_id: core::0131::request-name-field
    rule_doc_uri: https://googleapis.github.io/api-linter/rules/core/0131-request-name-field.html
```