### PR TITLE
[refactor] Move location functions into their own package.

### DIFF
--- a/lint/problem.go
+++ b/lint/problem.go
@@ -120,7 +120,10 @@ type fileLocation struct {
 // protocol buffer SourceCodeInfo_Location
 func fileLocationFromPBLocation(l *dpb.SourceCodeInfo_Location) fileLocation {
 	// Spans are guaranteed by protobuf to have either three or four ints.
-	span := l.Span
+	span := []int32{0, 0, 1}
+	if l != nil {
+		span = l.Span
+	}
 
 	// If `span` has four ints; they correspond to
 	// [start line, start column, end line, end column].

--- a/locations/descriptor_locations.go
+++ b/locations/descriptor_locations.go
@@ -23,7 +23,10 @@ import (
 //
 // This works for any descriptor, regardless of type (message, field, etc.).
 func DescriptorName(d desc.Descriptor) *dpb.SourceCodeInfo_Location {
-	// All descriptors seem to have `string name = 1`, so this conveniently works.
-	path := append(d.GetSourceInfo().Path, 1)
-	return pathLocation(d.GetFile(), path)
+	if sourceInfo := d.GetSourceInfo(); sourceInfo != nil {
+		// All descriptors seem to have `string name = 1`, so this conveniently works.
+		path := append(sourceInfo.Path, 1)
+		return pathLocation(d.GetFile(), path)
+	}
+	return nil
 }

--- a/locations/descriptor_locations.go
+++ b/locations/descriptor_locations.go
@@ -12,28 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0191
+package locations
 
 import (
-	"path/filepath"
-	"strings"
-
-	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/locations"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var filename = &lint.FileRule{
-	Name: lint.NewRuleName("core", "0191", "filenames"),
-	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		fn := strings.ReplaceAll(filepath.Base(f.GetName()), ".proto", "")
-		if versionRegexp.MatchString(fn) {
-			return []lint.Problem{{
-				Message:    "The proto version must not be used as the filename.",
-				Descriptor: f,
-				Location:   locations.FilePackage(f),
-			}}
-		}
-		return nil
-	},
+// DescriptorName returns the precise location for a descriptor's name.
+//
+// This works for any descriptor, regardless of type (message, field, etc.).
+func DescriptorName(d desc.Descriptor) *dpb.SourceCodeInfo_Location {
+	// All descriptors seem to have `string name = 1`, so this conveniently works.
+	path := append(d.GetSourceInfo().Path, 1)
+	return pathLocation(d.GetFile(), path)
 }

--- a/locations/descriptor_locations_test.go
+++ b/locations/descriptor_locations_test.go
@@ -25,6 +25,7 @@ func TestDescriptorName(t *testing.T) {
 	f := parse(t, `
 		message Foo {
 		  string bar = 1;
+		  map<string, string> baz = 2;
 		}
 	`)
 
@@ -35,6 +36,7 @@ func TestDescriptorName(t *testing.T) {
 	}{
 		{"Message", f.GetMessageTypes()[0], []int32{2, 8, 11}},
 		{"Field", f.GetMessageTypes()[0].GetFields()[0], []int32{3, 9, 12}},
+		{"MapField", f.GetMessageTypes()[0].GetFields()[1], []int32{4, 22, 25}},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
@@ -42,5 +44,14 @@ func TestDescriptorName(t *testing.T) {
 				t.Errorf(diff)
 			}
 		})
+	}
+}
+
+func TestFileDescriptorName(t *testing.T) {
+	f := parse(t, `
+		message Foo {}
+	`)
+	if got := DescriptorName(f); got != nil {
+		t.Errorf("%v", got)
 	}
 }

--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -12,28 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0191
+package locations
 
 import (
-	"path/filepath"
-	"strings"
-
-	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/locations"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var filename = &lint.FileRule{
-	Name: lint.NewRuleName("core", "0191", "filenames"),
-	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		fn := strings.ReplaceAll(filepath.Base(f.GetName()), ".proto", "")
-		if versionRegexp.MatchString(fn) {
-			return []lint.Problem{{
-				Message:    "The proto version must not be used as the filename.",
-				Descriptor: f,
-				Location:   locations.FilePackage(f),
-			}}
-		}
-		return nil
-	},
+// FieldType returns the precise location for a field's type.
+func FieldType(f *desc.FieldDescriptor) *dpb.SourceCodeInfo_Location {
+	var path []int32
+	if f.GetMessageType() != nil || f.GetEnumType() != nil {
+		path = append(f.GetSourceInfo().Path, 6) // type_name
+	} else {
+		path = append(f.GetSourceInfo().Path, 5) // type
+	}
+	return pathLocation(f.GetFile(), path)
 }

--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -21,11 +21,14 @@ import (
 
 // FieldType returns the precise location for a field's type.
 func FieldType(f *desc.FieldDescriptor) *dpb.SourceCodeInfo_Location {
-	var path []int32
-	if f.GetMessageType() != nil || f.GetEnumType() != nil {
-		path = append(f.GetSourceInfo().Path, 6) // type_name
-	} else {
-		path = append(f.GetSourceInfo().Path, 5) // type
+	if sourceInfo := f.GetSourceInfo(); sourceInfo != nil {
+		var path []int32
+		if f.GetMessageType() != nil || f.GetEnumType() != nil {
+			path = append(sourceInfo.Path, 6) // type_name
+		} else {
+			path = append(sourceInfo.Path, 5) // type
+		}
+		return pathLocation(f.GetFile(), path)
 	}
-	return pathLocation(f.GetFile(), path)
+	return nil
 }

--- a/locations/field_locations_test.go
+++ b/locations/field_locations_test.go
@@ -12,28 +12,37 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0191
+package locations
 
 import (
-	"path/filepath"
-	"strings"
+	"testing"
 
-	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/locations"
+	"github.com/google/go-cmp/cmp"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var filename = &lint.FileRule{
-	Name: lint.NewRuleName("core", "0191", "filenames"),
-	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		fn := strings.ReplaceAll(filepath.Base(f.GetName()), ".proto", "")
-		if versionRegexp.MatchString(fn) {
-			return []lint.Problem{{
-				Message:    "The proto version must not be used as the filename.",
-				Descriptor: f,
-				Location:   locations.FilePackage(f),
-			}}
+func TestFieldLocations(t *testing.T) {
+	f := parse(t, `
+		message Book {
+		  string name = 1;
+		  Author author = 2;
 		}
-		return nil
-	},
+		message Author {}
+	`)
+	tests := []struct {
+		name  string
+		field *desc.FieldDescriptor
+		span  []int32
+	}{
+		{"Primitive", f.GetMessageTypes()[0].GetFields()[0], []int32{3, 2, 8}},
+		{"Composite", f.GetMessageTypes()[0].GetFields()[1], []int32{4, 2, 8}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			l := FieldType(test.field)
+			if diff := cmp.Diff(l.GetSpan(), test.span); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
 }

--- a/locations/file_locations.go
+++ b/locations/file_locations.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locations
+
+import (
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// FileSyntax returns the location of the syntax definition in a file descriptor.
+//
+// If the location can not be found (for example, because there is no syntax
+// statement), it returns nil.
+func FileSyntax(f *desc.FileDescriptor) *dpb.SourceCodeInfo_Location {
+	return pathLocation(f, []int32{12}) // syntax == 12
+}
+
+// FilePackage returns the location of the package definition in a file descriptor.
+//
+// If the location can not be found (for example, because there is no package
+// statement), it returns nil.
+func FilePackage(f *desc.FileDescriptor) *dpb.SourceCodeInfo_Location {
+	return pathLocation(f, []int32{2}) // package == 2
+}

--- a/locations/locations.go
+++ b/locations/locations.go
@@ -12,41 +12,24 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package lint
+// Package locations provides functions to get the location of a particular part
+// of a descriptor, allowing Problems to be attached to just a descriptor's
+// name, type, etc.. This allows for better auto-replacement functionality in
+// code review tools.
+//
+// All functions in this package accept a descriptor and return a
+// protobuf SourceCodeInfo_Location object, which can be passed directly
+// to the Location property on Problem.
+package locations
 
 import (
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 )
 
-// PathLocation returns the precise location within a file for a given path.
-func PathLocation(f *desc.FileDescriptor, path []int32) *dpb.SourceCodeInfo_Location {
+// pathLocation returns the precise location within a file for a given path.
+func pathLocation(f *desc.FileDescriptor, path []int32) *dpb.SourceCodeInfo_Location {
 	return sourceInfoRegistry.sourceInfo(f).findLocation(path)
-}
-
-// SyntaxLocation returns the location of the syntax definition in a file
-// descriptor.
-//
-// If the location can not be found (for example, because there is no syntax
-// statement), it returns nil.
-func SyntaxLocation(f *desc.FileDescriptor) *dpb.SourceCodeInfo_Location {
-	return PathLocation(f, []int32{12}) // syntax == 12
-}
-
-// PackageLocation returns the location of the package definition in a file
-// descriptor.
-//
-// If the location can not be found (for example, because there is no package
-// statement), it returns nil.
-func PackageLocation(f *desc.FileDescriptor) *dpb.SourceCodeInfo_Location {
-	return PathLocation(f, []int32{2}) // package == 2
-}
-
-// DescriptorNameLocation returns the precise location for a descriptor's name.
-func DescriptorNameLocation(d desc.Descriptor) *dpb.SourceCodeInfo_Location {
-	// All descriptors seem to have `string name = 1`, so this conveniently works.
-	path := append(d.GetSourceInfo().Path, 1)
-	return PathLocation(d.GetFile(), path)
 }
 
 type sourceInfo map[string]*dpb.SourceCodeInfo_Location

--- a/locations/method_locations.go
+++ b/locations/method_locations.go
@@ -12,28 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0191
+package locations
 
 import (
-	"path/filepath"
-	"strings"
-
-	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/locations"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var filename = &lint.FileRule{
-	Name: lint.NewRuleName("core", "0191", "filenames"),
-	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		fn := strings.ReplaceAll(filepath.Base(f.GetName()), ".proto", "")
-		if versionRegexp.MatchString(fn) {
-			return []lint.Problem{{
-				Message:    "The proto version must not be used as the filename.",
-				Descriptor: f,
-				Location:   locations.FilePackage(f),
-			}}
-		}
-		return nil
-	},
+// MethodRequestType returns the precise location of the method's input type.
+func MethodRequestType(m *desc.MethodDescriptor) *dpb.SourceCodeInfo_Location {
+	path := append(m.GetSourceInfo().Path, 2) // input_type == 2
+	return pathLocation(m.GetFile(), path)
+}
+
+// MethodResponseType returns the precise location of the method's output type.
+func MethodResponseType(m *desc.MethodDescriptor) *dpb.SourceCodeInfo_Location {
+	path := append(m.GetSourceInfo().Path, 3) // output_type == 3
+	return pathLocation(m.GetFile(), path)
 }

--- a/locations/method_locations.go
+++ b/locations/method_locations.go
@@ -21,12 +21,18 @@ import (
 
 // MethodRequestType returns the precise location of the method's input type.
 func MethodRequestType(m *desc.MethodDescriptor) *dpb.SourceCodeInfo_Location {
-	path := append(m.GetSourceInfo().Path, 2) // input_type == 2
-	return pathLocation(m.GetFile(), path)
+	if sourceInfo := m.GetSourceInfo(); sourceInfo != nil {
+		path := append(sourceInfo.Path, 2) // input_type == 2
+		return pathLocation(m.GetFile(), path)
+	}
+	return nil
 }
 
 // MethodResponseType returns the precise location of the method's output type.
 func MethodResponseType(m *desc.MethodDescriptor) *dpb.SourceCodeInfo_Location {
-	path := append(m.GetSourceInfo().Path, 3) // output_type == 3
-	return pathLocation(m.GetFile(), path)
+	if sourceInfo := m.GetSourceInfo(); sourceInfo != nil {
+		path := append(m.GetSourceInfo().Path, 3) // output_type == 3
+		return pathLocation(m.GetFile(), path)
+	}
+	return nil
 }

--- a/locations/method_locations_test.go
+++ b/locations/method_locations_test.go
@@ -1,0 +1,49 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package locations
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestMethodRequestType(t *testing.T) {
+	f := parse(t, `
+		service Library {
+		  rpc GetBook(GetBookRequest) returns (Book);
+		}
+		message GetBookRequest {}
+		message Book {}
+	`)
+	loc := MethodRequestType(f.GetServices()[0].GetMethods()[0])
+	if diff := cmp.Diff(loc.GetSpan(), []int32{3, 14, 28}); diff != "" {
+		t.Errorf(diff)
+	}
+}
+
+func TestMethodResponseType(t *testing.T) {
+	f := parse(t, `
+		service Library {
+		  rpc GetBook(GetBookRequest) returns (Book);
+		}
+		message GetBookRequest {}
+		message Book {}
+	`)
+	loc := MethodResponseType(f.GetServices()[0].GetMethods()[0])
+	if diff := cmp.Diff(loc.GetSpan(), []int32{3, 39, 43}); diff != "" {
+		t.Errorf(diff)
+	}
+}

--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
 )
@@ -33,7 +34,7 @@ var unspecified = &lint.EnumRule{
 				Message:    fmt.Sprintf("The first enum value should be %q", want),
 				Suggestion: want,
 				Descriptor: firstValue,
-				Location:   lint.DescriptorNameLocation(firstValue),
+				Location:   locations.DescriptorName(firstValue),
 			}}
 		}
 

--- a/rules/aip0126/upper_snake_values.go
+++ b/rules/aip0126/upper_snake_values.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
 )
@@ -20,7 +21,7 @@ var enumValueUpperSnakeCase = &lint.EnumRule{
 					Message:    fmt.Sprintf("Enum value %q must use UPPER_SNAKE_CASE.", got),
 					Suggestion: want,
 					Descriptor: v,
-					Location:   lint.DescriptorNameLocation(v),
+					Location:   locations.DescriptorName(v),
 				})
 			}
 		}

--- a/rules/aip0131/synonyms.go
+++ b/rules/aip0131/synonyms.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -36,7 +37,7 @@ var synonyms = &lint.MethodRule{
 					),
 					Suggestion: strings.Replace(name, syn, "Get", 1),
 					Descriptor: m,
-					Location:   lint.DescriptorNameLocation(m),
+					Location:   locations.DescriptorName(m),
 				}}
 			}
 		}

--- a/rules/aip0133/request_resource_field.go
+++ b/rules/aip0133/request_resource_field.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
 )
@@ -39,7 +40,7 @@ var resourceField = &lint.MessageRule{
 						Message:    fmt.Sprintf("Resource field should be named %q.", want),
 						Descriptor: fieldDesc,
 						Suggestion: want,
-						Location:   lint.DescriptorNameLocation(fieldDesc),
+						Location:   locations.DescriptorName(fieldDesc),
 					}}
 				}
 				return nil

--- a/rules/aip0133/synonyms.go
+++ b/rules/aip0133/synonyms.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -35,7 +36,7 @@ var synonyms = &lint.MethodRule{
 						syn,
 					),
 					Descriptor: m,
-					Location:   lint.DescriptorNameLocation(m),
+					Location:   locations.DescriptorName(m),
 					Suggestion: strings.Replace(name, syn, "Create", 1),
 				}}
 			}

--- a/rules/aip0134/request_resource_field.go
+++ b/rules/aip0134/request_resource_field.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
 )
@@ -39,7 +40,7 @@ var resourceField = &lint.MessageRule{
 						Message:    fmt.Sprintf("Resource field should be named %q.", want),
 						Descriptor: fieldDesc,
 						Suggestion: want,
-						Location:   lint.DescriptorNameLocation(fieldDesc),
+						Location:   locations.DescriptorName(fieldDesc),
 					}}
 				}
 				return nil

--- a/rules/aip0134/synonyms.go
+++ b/rules/aip0134/synonyms.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -35,7 +36,7 @@ var synonyms = &lint.MethodRule{
 						syn,
 					),
 					Descriptor: m,
-					Location:   lint.DescriptorNameLocation(m),
+					Location:   locations.DescriptorName(m),
 					Suggestion: strings.Replace(name, syn, "Update", 1),
 				}}
 			}

--- a/rules/aip0136/prepositions.go
+++ b/rules/aip0136/prepositions.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/data"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
@@ -32,7 +33,7 @@ var noPrepositions = &lint.MethodRule{
 				problems = append(problems, lint.Problem{
 					Message:    fmt.Sprintf("Method names should not include prepositions (%q).", word),
 					Descriptor: m,
-					Location:   lint.DescriptorNameLocation(m),
+					Location:   locations.DescriptorName(m),
 				})
 			}
 		}

--- a/rules/aip0136/verb_noun.go
+++ b/rules/aip0136/verb_noun.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/stoewer/go-strcase"
 )
@@ -33,7 +34,7 @@ var verbNoun = &lint.MethodRule{
 			return []lint.Problem{{
 				Message:    "Custom methods should be named using a verb followed by a noun.",
 				Descriptor: m,
-				Location:   lint.DescriptorNameLocation(m),
+				Location:   locations.DescriptorName(m),
 			}}
 		}
 

--- a/rules/aip0140/abbreviations.go
+++ b/rules/aip0140/abbreviations.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -59,7 +60,7 @@ var abbreviations = &lint.DescriptorRule{
 					),
 					Suggestion: strings.ReplaceAll(d.GetName(), caseFunc(long), caseFunc(short)),
 					Descriptor: d,
-					Location:   lint.DescriptorNameLocation(d),
+					Location:   locations.DescriptorName(d),
 				})
 			}
 		}

--- a/rules/aip0140/prepositions.go
+++ b/rules/aip0140/prepositions.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/data"
 	"github.com/jhump/protoreflect/desc"
 )
@@ -31,7 +32,7 @@ var noPrepositions = &lint.FieldRule{
 				problems = append(problems, lint.Problem{
 					Message:    fmt.Sprintf("Avoid using %q in field names.", word),
 					Descriptor: f,
-					Location:   lint.DescriptorNameLocation(f),
+					Location:   locations.DescriptorName(f),
 				})
 			}
 		}

--- a/rules/aip0141/count_suffix.go
+++ b/rules/aip0141/count_suffix.go
@@ -19,6 +19,7 @@ import (
 
 	pluralize "github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -30,7 +31,7 @@ var count = &lint.FieldRule{
 			return []lint.Problem{{
 				Message:    "Quantities: Use a _count suffix, not a num_ prefix.",
 				Descriptor: f,
-				Location:   lint.DescriptorNameLocation(f),
+				Location:   locations.DescriptorName(f),
 				Suggestion: want,
 			}}
 		}

--- a/rules/aip0142/time_field_names.go
+++ b/rules/aip0142/time_field_names.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
@@ -37,7 +38,7 @@ var fieldNames = &lint.FieldRule{
 				return []lint.Problem{{
 					Message:    "Use the imperative mood and a `_time` suffix for timestamps.",
 					Descriptor: f,
-					Location:   lint.DescriptorNameLocation(f),
+					Location:   locations.DescriptorName(f),
 					Suggestion: want,
 				}}
 			}
@@ -48,7 +49,7 @@ var fieldNames = &lint.FieldRule{
 			return []lint.Problem{{
 				Message:    "Timestamp fields should end in `_time`.",
 				Descriptor: f,
-				Location:   lint.DescriptorNameLocation(f),
+				Location:   locations.DescriptorName(f),
 			}}
 		}
 

--- a/rules/aip0143/standardized_codes.go
+++ b/rules/aip0143/standardized_codes.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -39,7 +40,7 @@ var fieldNames = &lint.FieldRule{
 			return []lint.Problem{{
 				Message:    fmt.Sprintf("Use %q in place of %q.", want, f.GetName()),
 				Descriptor: f,
-				Location:   lint.DescriptorNameLocation(f),
+				Location:   locations.DescriptorName(f),
 				Suggestion: want,
 			}}
 		}

--- a/rules/aip0191/syntax.go
+++ b/rules/aip0191/syntax.go
@@ -16,6 +16,7 @@ package aip0191
 
 import (
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -28,7 +29,7 @@ var syntax = &lint.FileRule{
 				Message:    "All API proto files must use proto3 syntax.",
 				Suggestion: "syntax = \"proto3\";",
 				Descriptor: f,
-				Location:   lint.SyntaxLocation(f),
+				Location:   locations.FileSyntax(f),
 			}}
 		}
 		return nil

--- a/rules/aip0192/has_comments.go
+++ b/rules/aip0192/has_comments.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -30,7 +31,7 @@ var hasComments = &lint.DescriptorRule{
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf("Missing comment over %q.", d.GetName()),
 				Descriptor: d,
-				Location:   lint.DescriptorNameLocation(d),
+				Location:   locations.DescriptorName(d),
 			})
 		}
 		return


### PR DESCRIPTION
This creates a Go package for `locations` to group these helper
functions together. It also adds several more:

  - FieldType
  - MethodRequestType
  - MethodResponseType

This will better group these functions together in godoc, which
will be useful to rule authors.

Conveniently, also fixes #306.