### PR TITLE
Resolved proto file paths.

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -127,7 +127,12 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 		IncludeSourceCodeInfo: true,
 		LookupImport:          lookupImport,
 	}
-	fd, err := p.ParseFiles(c.ProtoFiles...)
+	// Resolve file absolute paths to relative ones.
+	protoFiles, err := protoparse.ResolveFilenames(c.ProtoImportPaths, c.ProtoFiles...)
+	if err != nil {
+		return err
+	}
+	fd, err := p.ParseFiles(protoFiles...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
It is using `protoparse.ResolveFilenaming` to resolve absolute file paths (e.g., "./test.proto") into relative ones (e.g., "test.proto") before feeding the proto files into `protoparse`.

I verified:
```
git clone git@github.com:googleapis/googleapis.git ~/Downloads/googleapis
api-linter -I ~/Downloads/googleapis --output-format summary $(find ~/Downloads/googleapis -name '*.proto')
```
and got:
```
+--------------------------------------------+------------------+----------------+
|                    RULE                    | TOTAL VIOLATIONS | VIOLATED FILES |
+--------------------------------------------+------------------+----------------+
| core::0131::http-body                      |                1 |              1 |
| core::0131::http-method                    |                1 |              1 |
| core::0151::lro-metadata-type              |                2 |              2 |
| core::0133::http-method                    |                3 |              1 |
| core::0151::lro-types-defined-in-file      |                3 |              1 |
| core::0136::http-method                    |                4 |              4 |
| core::0134::request-message-name           |                5 |              4 |
| core::0133::request-message-name           |                7 |              5 |
| core::0203::input-only                     |                9 |              5 |
| core::0135::response-message-name          |                9 |              6 |
| core::0131::synonyms                       |               11 |              9 |
| core::0136::prepositions                   |               15 |              6 |
| core::0136::http-body                      |               15 |             15 |
| core::0141::count-suffix                   |               17 |             12 |
| core::0151::lro-response-type              |               19 |             13 |
| core::0131::response-message-name          |               20 |             15 |
| core::0133::response-message-name          |               20 |             16 |
| core::0134::response-message-name          |               21 |             14 |
| core::0133::request-resource-field         |               25 |             22 |
| core::0134::request--resource-field        |               26 |             19 |
| core::0140::abbreviations                  |               27 |              9 |
| core::0140::base64                         |               28 |             17 |
| core::0141::forbidden-types                |               29 |             19 |
| core::0135::request-name-field             |               31 |             25 |
| core::0135::http-uri-name                  |               32 |             25 |
| core::0142::time-field-names               |               34 |             27 |
| core::0134::request-mask-field             |               34 |             25 |
| core::0134::http-method                    |               35 |             25 |
| core::0133::request-parent-field           |               39 |             29 |
| core::0158::response-next-page-token-field |               39 |             28 |
| core::0158::request-page-token-field       |               40 |             28 |
| core::0134::http-body                      |               42 |             30 |
| core::0143::standardized-codes             |               43 |             22 |
| core::0158::request-page-size-field        |               46 |             31 |
| core::0203::immutable                      |               49 |             26 |
| core::0136::verb-noun                      |               51 |             24 |
| core::0133::http-body                      |               54 |             38 |
| core::0143::string-type                    |               65 |             40 |
| core::0134::synonyms                       |               65 |             30 |
| core::0134::http-uri-name                  |               66 |             43 |
| core::0135::request-unknown-fields         |               75 |             36 |
| core::0122::camel-case-uris                |               85 |             11 |
| core::0132::request-parent-field           |               87 |             63 |
| core::0151::operation-info                 |              110 |             41 |
| core::0133::request-unknown-fields         |              110 |             45 |
| core::0134::request-unknown-fields         |              157 |             53 |
| core::0133::http-uri-parent                |              176 |            108 |
| core::0142::time-field-type                |              189 |             73 |
| core::0132::request-unknown-fields         |              212 |             79 |
| core::0131::request-name-field             |              241 |            227 |
| core::0131::http-uri-name                  |              257 |            235 |
| core::0140::prepositions                   |              281 |            111 |
| core::0131::request-unknown-fields         |              339 |            248 |
| core::0136::http-uri-suffix                |              391 |            205 |
| core::0203::output-only                    |              820 |            140 |
| core::0192::only-leading-comments          |             1036 |           1036 |
| core::0203::required                       |             1060 |            256 |
| core::0192::has-comments                   |             1182 |            164 |
+--------------------------------------------+------------------+----------------+
Linted 1604 proto files
```
