### PR TITLE
Print multiple build errors

### DIFF
--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -159,6 +159,19 @@ func TestRules_DisabledByConfig(t *testing.T) {
 	}
 }
 
+func TestBuildErrors(t *testing.T) {
+	expected := `internal/testdata/build_errors.proto:8:1: syntax error: unexpected '}', expecting ';' or '['
+internal/testdata/build_errors.proto:13:1: syntax error: unexpected '}', expecting ';' or '['`
+	err := runCLI([]string{"internal/testdata/build_errors.proto"})
+	if err == nil {
+		t.Fatal("expected build error for build_errors.proto")
+	}
+	actual := err.Error()
+	if expected != actual {
+		t.Fatalf("expected %q, got %q", expected, actual)
+	}
+}
+
 func runLinter(t *testing.T, protoContent, configContent string) string {
 	tempDir, err := ioutil.TempDir("", "test")
 	if err != nil {

--- a/cmd/api-linter/internal/testdata/build_errors.proto
+++ b/cmd/api-linter/internal/testdata/build_errors.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package foo;
+
+message Bar1 {
+  // first build error
+  string baz1 = 1
+}
+
+message Bar2 {
+  // second build error
+  string baz2 = 1
+}


### PR DESCRIPTION
Fixes #314.

Feel free to commandeer this, first time contributing to this repository so not sure if this is how you want tests written etc. This also just combines the errors into a string and prints them out, nothing too fancy here. However it works:

```
$ api-linter cmd/api-linter/internal/testdata/build_errors.proto
2019/11/08 13:17:24 cmd/api-linter/internal/testdata/build_errors.proto:8:1: syntax error: unexpected '}', expecting ';' or '['
cmd/api-linter/internal/testdata/build_errors.proto:13:1: syntax error: unexpected '}', expecting ';' or '['
```