### PR TITLE
Rewrite lint configuration.

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -92,23 +92,15 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 		configs = append(configs, config...)
 	}
 	// Add configs for the enabled rules.
-	for _, ruleName := range c.EnabledRules {
-		configs = append(configs, lint.Config{
-			IncludedPaths: []string{"**/*.proto"},
-			RuleConfigs: map[string]lint.RuleConfig{
-				ruleName: {}, // default is enabled.
-			},
-		})
-	}
+	configs = append(configs, lint.Config{
+		IncludedPaths: []string{"**"},
+		EnabledRules:  c.EnabledRules,
+	})
 	// Add configs for the disabled rules.
-	for _, ruleName := range c.DisabledRules {
-		configs = append(configs, lint.Config{
-			IncludedPaths: []string{"**/*.proto"},
-			RuleConfigs: map[string]lint.RuleConfig{
-				ruleName: {Disabled: true},
-			},
-		})
-	}
+	configs = append(configs, lint.Config{
+		IncludedPaths: []string{"**"},
+		DisabledRules: c.DisabledRules,
+	})
 	// Prepare proto import lookup.
 	var lookupImport func(string) (*desc.FileDescriptor, error)
 	if c.ProtoDescPath != "" {

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -93,12 +93,10 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 	}
 	// Add configs for the enabled rules.
 	configs = append(configs, lint.Config{
-		IncludedPaths: []string{"**"},
-		EnabledRules:  c.EnabledRules,
+		EnabledRules: c.EnabledRules,
 	})
 	// Add configs for the disabled rules.
 	configs = append(configs, lint.Config{
-		IncludedPaths: []string{"**"},
 		DisabledRules: c.DisabledRules,
 	})
 	// Prepare proto import lookup.

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -101,7 +101,6 @@ func TestRules_DisabledByConfig(t *testing.T) {
 	config := `
 	[
 		{
-			"included_paths": ["*.proto"],
 			"disabled_rules": ["replace-me-here"]
 		}
 	]

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -72,25 +72,11 @@ func TestRules_EnabledByDefault(t *testing.T) {
 }
 
 func TestRules_DisabledByFileComments(t *testing.T) {
-	config := `
-	[
-		{
-			"included_paths": ["*.proto"],
-			"rule_configs": {
-				"": {
-					"status": "enabled",
-					"category": "warning"
-				}
-			}
-		}
-	]
-	`
-
 	for _, test := range testCases {
 		t.Run(test.testName, func(t *testing.T) {
 			disableInFile := fmt.Sprintf("// (-- api-linter: %s=disabled --)", test.rule)
 			proto := disableInFile + "\n" + test.proto
-			result := runLinter(t, proto, config)
+			result := runLinter(t, proto, "")
 			if strings.Contains(result, test.rule) {
 				t.Errorf("Rule %q should be disabled by file comments", test.rule)
 			}
@@ -99,25 +85,11 @@ func TestRules_DisabledByFileComments(t *testing.T) {
 }
 
 func TestRules_DisabledByInlineComments(t *testing.T) {
-	config := `
-	[
-		{
-			"included_paths": ["*.proto"],
-			"rule_configs": {
-				"": {
-					"status": "enabled",
-					"category": "warning"
-				}
-			}
-		}
-	]
-	`
-
 	for _, test := range testCases {
 		t.Run(test.testName, func(t *testing.T) {
 			disableInline := fmt.Sprintf("(-- api-linter: %s=disabled --)", test.rule)
 			proto := strings.Replace(test.proto, "disable-me-here", disableInline, -1)
-			result := runLinter(t, proto, config)
+			result := runLinter(t, proto, "")
 			if strings.Contains(result, test.rule) {
 				t.Errorf("Rule %q should be disabled by in-line comments", test.rule)
 			}
@@ -130,20 +102,7 @@ func TestRules_DisabledByConfig(t *testing.T) {
 	[
 		{
 			"included_paths": ["*.proto"],
-			"rule_configs": {
-				"": {
-					"disabled": false,
-					"category": "warning"
-				}
-			}
-		},
-		{
-			"included_paths": ["*.proto"],
-			"rule_configs": {
-				"replace-me-here": {
-					"disabled": true
-				}
-			}
+			"disabled_rules": ["replace-me-here"]
 		}
 	]
 	`

--- a/cmd/api-linter/main.go
+++ b/cmd/api-linter/main.go
@@ -38,10 +38,10 @@ func runCLI(args []string) error {
 	return c.lint(globalRules, globalConfigs)
 }
 
+// Enable all rules by default.
+// Once we have rules other than core,
+// we will determine if we want to
+// change this policy.
 func defaultConfigs() lint.Configs {
-	return lint.Configs{
-		lint.Config{
-			IncludedPaths: []string{"**"},
-		},
-	}
+	return lint.Configs{}
 }

--- a/cmd/api-linter/main.go
+++ b/cmd/api-linter/main.go
@@ -41,10 +41,7 @@ func runCLI(args []string) error {
 func defaultConfigs() lint.Configs {
 	return lint.Configs{
 		lint.Config{
-			IncludedPaths: []string{"**/*.proto"},
-			RuleConfigs: map[string]lint.RuleConfig{
-				"core": {},
-			},
+			IncludedPaths: []string{"**"},
 		},
 	}
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -34,10 +34,8 @@ directory `tests` using a JSON config file:
 ```json
 [
   {
-    "included_paths": ["tests/*.proto"],
-    "rule_configs": {
-      "core::0140::lower-snake": { "disabled": true }
-    }
+    "included_paths": ["tests/**/*.proto"],
+    "disabled_rules": ["core::0140::lower-snake"]
   }
 ]
 ```
@@ -47,10 +45,9 @@ Disable the same rule using a YAML config file:
 ```yaml
 ---
 - included_paths:
-    - '**/*.proto'
-  rule_configs:
-    core::proto_version:
-      disabled: true
+    - 'tests/**/*.proto'
+  disabled_rules:
+    - 'core::0140::lower-snake'
 ```
 
 ## Proto comments

--- a/lint/config.go
+++ b/lint/config.go
@@ -124,7 +124,7 @@ func matchPath(path string, pathPatterns ...string) bool {
 
 func matchRule(rule string, rulePrefixes ...string) bool {
 	for _, prefix := range rulePrefixes {
-		if prefix == rule || strings.HasPrefix(rule, prefix+"::") {
+		if prefix == "all" || prefix == rule || strings.HasPrefix(rule, prefix+"::") {
 			return true
 		}
 	}

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -69,6 +69,18 @@ func TestRuleConfigs_IsRuleEnabled(t *testing.T) {
 			disabled,
 		},
 		{
+			"PathExactMatched_DisabledRulesMatchedAll_Disabled",
+			Configs{
+				{
+					IncludedPaths: []string{"a.proto"},
+					DisabledRules: []string{"all"},
+				},
+			},
+			"a.proto",
+			"testrule",
+			disabled,
+		},
+		{
 			"PathDoubleStartMatched_DisabledRulesMatched_Disabled",
 			Configs{
 				{

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -105,6 +105,30 @@ func TestRuleConfigs_IsRuleEnabled(t *testing.T) {
 			disabled,
 		},
 		{
+			"PathMatched_DisabledRulesSuffixMatched_Disabled",
+			Configs{
+				{
+					IncludedPaths: []string{"a/b/c.proto"},
+					DisabledRules: []string{"child"},
+				},
+			},
+			"a/b/c.proto",
+			"parent::child",
+			disabled,
+		},
+		{
+			"PathMatched_DisabledRulesMiddleMatched_Disabled",
+			Configs{
+				{
+					IncludedPaths: []string{"a/b/c.proto"},
+					DisabledRules: []string{"middle"},
+				},
+			},
+			"a/b/c.proto",
+			"parent::middle::child",
+			disabled,
+		},
+		{
 			"EmptyIncludePath_ConfigMatched_DisabledRulesMatched_Disabled",
 			Configs{
 				{

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -20,91 +20,167 @@ import (
 	"testing"
 )
 
-func TestRuleConfigs_getRuleConfig(t *testing.T) {
-	matchConfig := RuleConfig{Disabled: false, Category: "warning"}
+func TestRuleConfigs_IsRuleEnabled(t *testing.T) {
+	enabled := true
+	disabled := false
 
 	tests := []struct {
+		name    string
 		configs Configs
 		path    string
-		rule    RuleName
-		result  RuleConfig
+		rule    string
+		want    bool
 	}{
-		{nil, "a", "b", RuleConfig{}},
+		{"EmptyConfig", nil, "a", "b", enabled},
 		{
+			"NoConfigMatched_Enabled",
 			Configs{
 				{
 					IncludedPaths: []string{"a.proto"},
-					RuleConfigs: map[string]RuleConfig{
-						"foo":      {},
-						"testrule": matchConfig,
-					},
+					DisabledRules: []string{"testrule"},
 				},
 			},
 			"b.proto",
 			"testrule",
-			RuleConfig{},
+			enabled,
 		},
 		{
+			"PathMatched_DisabledRulesNotMatch_Enabled",
 			Configs{
 				{
 					IncludedPaths: []string{"a.proto"},
-					RuleConfigs: map[string]RuleConfig{
-						"foo": matchConfig,
-					},
+					DisabledRules: []string{"somerule"},
 				},
 			},
 			"a.proto",
 			"testrule",
-			RuleConfig{},
+			enabled,
 		},
 		{
+			"PathExactMatched_DisabledRulesMatched_Disabled",
 			Configs{
 				{
 					IncludedPaths: []string{"a.proto"},
-					RuleConfigs: map[string]RuleConfig{
-						"foo":      {},
-						"testrule": matchConfig,
-					},
+					DisabledRules: []string{"somerule", "testrule"},
 				},
 			},
 			"a.proto",
 			"testrule",
-			matchConfig,
+			disabled,
 		},
 		{
+			"PathDoubleStartMatched_DisabledRulesMatched_Disabled",
 			Configs{
 				{
 					IncludedPaths: []string{"a/**/*.proto"},
-					RuleConfigs: map[string]RuleConfig{
-						"foo":     {},
-						"a::b::c": matchConfig,
-					},
+					DisabledRules: []string{"somerule", "testrule"},
 				},
 			},
 			"a/with/long/sub/dir/ect/ory/e.proto",
-			"a::b::c",
-			matchConfig,
+			"testrule",
+			disabled,
 		},
 		{
+			"PathMatched_DisabledRulesPrefixMatched_Disabled",
 			Configs{
 				{
-					IncludedPaths: []string{"a/**/*.proto"},
-					RuleConfigs: map[string]RuleConfig{
-						"foo":       {},
-						"a::module": matchConfig,
-					},
+					IncludedPaths: []string{"a/b/c.proto"},
+					DisabledRules: []string{"parent"},
 				},
 			},
-			"a/with/long/sub/dir/ect/ory/e.proto",
-			"a::module::test_rule",
-			matchConfig,
+			"a/b/c.proto",
+			"parent::test_rule",
+			disabled,
+		},
+		{
+			"EmptyIncludePath_ConfigMatched_DisabledRulesMatched_Disabled",
+			Configs{
+				{
+					DisabledRules: []string{"testrule"},
+				},
+			},
+			"a.proto",
+			"testrule",
+			disabled,
+		},
+		{
+			"ExcludedPathMatch_ConfigNotMatched_DisabledRulesMatched_Enabled",
+			Configs{
+				{
+					ExcludedPaths: []string{"a.proto"},
+					DisabledRules: []string{"testrule"},
+				},
+			},
+			"a.proto",
+			"testrule",
+			enabled,
+		},
+		{
+			"TwoConfigs_Override_Enabled",
+			Configs{
+				{
+					DisabledRules: []string{"testrule"},
+				},
+				{
+					EnabledRules: []string{"testrule::a"},
+				},
+			},
+			"a.proto",
+			"testrule::a",
+			enabled,
+		},
+		{
+			"TwoConfigs_Override_Disabled",
+			Configs{
+				{
+					EnabledRules: []string{"testrule"},
+				},
+				{
+					DisabledRules: []string{"testrule::a"},
+				},
+			},
+			"a.proto",
+			"testrule::a",
+			disabled,
+		},
+		{
+			"TwoConfigs_DoubleEnable_Enabled",
+			Configs{
+				{
+					EnabledRules: []string{"testrule"},
+				},
+				{
+					EnabledRules: []string{"testrule::a"},
+				},
+			},
+			"a.proto",
+			"testrule::a",
+			enabled,
+		},
+		{
+			"TwoConfigs_DoubleDisabled_Disabled",
+			Configs{
+				{
+					DisabledRules: []string{"testrule"},
+				},
+				{
+					DisabledRules: []string{"testrule::a"},
+				},
+			},
+			"a.proto",
+			"testrule::a",
+			disabled,
 		},
 	}
-	for ind, test := range tests {
-		cfg, _ := test.configs.GetRuleConfig(test.path, test.rule)
-		if cfg != test.result {
-			t.Errorf("Test #%d: %+v.GetRuleConfig(%q, %q)=%+v; want %+v", ind+1, test.configs, test.path, test.rule, cfg, test.result)
-		}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := test.configs.IsRuleEnabled(test.rule, test.path)
+
+			if got != test.want {
+				t.Errorf("IsRuleEnabled: got %t, but want %t", got, test.want)
+			}
+		})
+
 	}
 }
 
@@ -112,14 +188,10 @@ func TestReadConfigsJSON(t *testing.T) {
 	content := `
 	[
 		{
-			"included_paths": ["a"],
-			"excluded_paths": ["b"],
-			"rule_configs": {
-				"rule_a": {
-					"status": "enabled",
-					"category": "warning"
-				}
-			}
+			"included_paths": ["path_a"],
+			"excluded_paths": ["path_b"],
+			"disabled_rules": ["rule_a", "rule_b"],
+			"enabled_rules": ["rule_c", "rule_d"]
 		}
 	]
 	`
@@ -131,68 +203,13 @@ func TestReadConfigsJSON(t *testing.T) {
 
 	expected := Configs{
 		{
-			IncludedPaths: []string{"a"},
-			ExcludedPaths: []string{"b"},
-			RuleConfigs: map[string]RuleConfig{
-				"rule_a": {
-					Disabled: false,
-					Category: "warning",
-				},
-			},
+			IncludedPaths: []string{"path_a"},
+			ExcludedPaths: []string{"path_b"},
+			DisabledRules: []string{"rule_a", "rule_b"},
+			EnabledRules:  []string{"rule_c", "rule_d"},
 		},
 	}
 	if !reflect.DeepEqual(configs, expected) {
 		t.Errorf("ReadConfigsJSON returns %v, but want %v", configs, expected)
-	}
-}
-
-func TestRuleConfig_WithOverride(t *testing.T) {
-	tests := []struct {
-		original RuleConfig
-		override RuleConfig
-		result   RuleConfig
-	}{
-		{
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Disabled: false, Category: "warning"},
-		},
-		{
-			RuleConfig{},
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Disabled: false, Category: "warning"},
-		},
-		{
-			RuleConfig{Category: ""},
-			RuleConfig{Disabled: true, Category: "warning"},
-			RuleConfig{Disabled: true, Category: "warning"},
-		},
-		{
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Disabled: true, Category: "error"},
-			RuleConfig{Disabled: true, Category: "error"},
-		},
-		{
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Category: ""},
-			RuleConfig{Disabled: false, Category: "warning"},
-		},
-		{
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Disabled: true, Category: ""},
-			RuleConfig{Disabled: true, Category: "warning"},
-		},
-		{
-			RuleConfig{Disabled: false, Category: "warning"},
-			RuleConfig{Category: "error"},
-			RuleConfig{Disabled: false, Category: "error"},
-		},
-	}
-
-	for _, test := range tests {
-		result := test.original.withOverride(test.override)
-		if result != test.result {
-			t.Errorf("%+v.WithOverride(%+v)=%+v; want %+v", test.original, test.override, result, test.result)
-		}
 	}
 }

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -65,23 +65,13 @@ func (l *Linter) lintFileDescriptor(fd *desc.FileDescriptor) (Response, error) {
 	var errMessages []string
 
 	for name, rule := range l.rules {
-		var config RuleConfig
-
-		if c, err := l.configs.GetRuleConfig(fd.GetName(), name); err == nil {
-			config = config.withOverride(c)
-		} else {
-			errMessages = append(errMessages, err.Error())
-			continue
-		}
-
 		// Run the linter rule against this file, and throw away any problems
 		// which should have been disabled.
-		if !config.Disabled {
+		if l.configs.IsRuleEnabled(string(name), fd.GetName()) {
 			if problems, err := l.runAndRecoverFromPanics(rule, fd); err == nil {
 				for _, p := range problems {
 					if ruleIsEnabled(rule, p.Descriptor, aliasMap) {
 						p.RuleID = rule.GetName()
-						p.category = config.Category
 						resp.Problems = append(resp.Problems, p)
 					}
 				}

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -30,14 +30,17 @@ func TestLinter_run(t *testing.T) {
 		t.Fatalf("Failed to build a file descriptor.")
 	}
 	defaultConfigs := Configs{
-		{[]string{"**"}, []string{}, map[string]RuleConfig{}},
+		{
+			IncludedPaths: []string{"**"},
+		},
 	}
 
+	testRuleID := "test::rule1"
 	ruleProblems := []Problem{{
 		Message:    "rule1_problem",
 		Descriptor: fd,
 		category:   "",
-		RuleID:     "test::rule1",
+		RuleID:     RuleName(testRuleID),
 	}}
 
 	tests := []struct {
@@ -52,7 +55,6 @@ func TestLinter_run(t *testing.T) {
 				defaultConfigs,
 				Config{
 					IncludedPaths: []string{"nofile"},
-					RuleConfigs:   map[string]RuleConfig{"": {Disabled: true}},
 				},
 			),
 			ruleProblems,
@@ -63,7 +65,7 @@ func TestLinter_run(t *testing.T) {
 				defaultConfigs,
 				Config{
 					IncludedPaths: []string{"*"},
-					RuleConfigs:   map[string]RuleConfig{"foo::bar": {Disabled: true}},
+					DisabledRules: []string{"foo::bar"},
 				},
 			),
 			ruleProblems,
@@ -74,30 +76,10 @@ func TestLinter_run(t *testing.T) {
 				defaultConfigs,
 				Config{
 					IncludedPaths: []string{"*"},
-					RuleConfigs: map[string]RuleConfig{
-						"test::rule1": {Disabled: true},
-					},
+					DisabledRules: []string{testRuleID},
 				},
 			),
 			[]Problem{},
-		},
-		{
-			"CategoryOverride",
-			append(
-				defaultConfigs,
-				Config{
-					IncludedPaths: []string{"*"},
-					RuleConfigs: map[string]RuleConfig{
-						"test::rule1": {Category: "error"},
-					},
-				},
-			),
-			[]Problem{{
-				Descriptor: fd,
-				Message:    "rule1_problem",
-				RuleID:     "test::rule1",
-				category:   "error",
-			}},
 		},
 	}
 
@@ -165,7 +147,6 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 			// Instantiate a linter with the given rule.
 			l := New(r, []Config{{
 				IncludedPaths: []string{"**"},
-				RuleConfigs:   map[string]RuleConfig{"": {}},
 			}})
 
 			_, err = l.LintProtos(fd)

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -29,11 +29,7 @@ func TestLinter_run(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to build a file descriptor.")
 	}
-	defaultConfigs := Configs{
-		{
-			IncludedPaths: []string{"**"},
-		},
-	}
+	defaultConfigs := Configs{}
 
 	testRuleID := "test::rule1"
 	ruleProblems := []Problem{{
@@ -64,7 +60,6 @@ func TestLinter_run(t *testing.T) {
 			append(
 				defaultConfigs,
 				Config{
-					IncludedPaths: []string{"*"},
 					DisabledRules: []string{"foo::bar"},
 				},
 			),
@@ -75,7 +70,6 @@ func TestLinter_run(t *testing.T) {
 			append(
 				defaultConfigs,
 				Config{
-					IncludedPaths: []string{"*"},
 					DisabledRules: []string{testRuleID},
 				},
 			),
@@ -145,9 +139,7 @@ func TestLinter_LintProtos_RulePanics(t *testing.T) {
 			}
 
 			// Instantiate a linter with the given rule.
-			l := New(r, []Config{{
-				IncludedPaths: []string{"**"},
-			}})
+			l := New(r, nil)
 
 			_, err = l.LintProtos(fd)
 			if err == nil || !strings.Contains(err.Error(), "panic") {


### PR DESCRIPTION
The configurations work in two steps:
First, we check if a configuration is matched against the given path.
1. If none is matched, the rule is enabled by default;
2. Otherwise, we apply the matched configuration against the rule:
(a) if the given rule is in the disabled list, the rule is disabled;
(b) if the given rule is in the enabled list, the rule is enabled;
(c) if the given rule is in neither list, the rule remains the state determined by the previous matched configuration.