### PR TITLE
Update Go to v1.13

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/api-linter
 
-go 1.12
+go 1.13
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.8


### PR DESCRIPTION
Go 1.13 supports [errors wrapping](https://golang.org/doc/go1.13#error_wrapping).