### PR TITLE
[AIP-191] File option consistency.

### DIFF
--- a/docs/rules/0191/file-option-consistency.md
+++ b/docs/rules/0191/file-option-consistency.md
@@ -23,6 +23,7 @@ The following annotations are included:
 
 - `csharp_namespace`
 - `go_package`
+- `java_multiple_files`
 - `java_package`
 - `php_class_prefix`
 - `php_metadata_namespace`

--- a/docs/rules/0191/file-option-consistency.md
+++ b/docs/rules/0191/file-option-consistency.md
@@ -8,7 +8,7 @@ redirect_from:
   - /0191/file-option-consistency
 ---
 
-# Java package annotation
+# File option consistency
 
 This rule enforces that every proto file for a public API surface sets file
 packaging options consistently, as mandated in [AIP-191][].

--- a/docs/rules/0191/file-option-consistency.md
+++ b/docs/rules/0191/file-option-consistency.md
@@ -1,0 +1,110 @@
+---
+rule:
+  aip: 191
+  name: [core, '0191', file-option-consistency]
+  summary: All proto files must set file packaging options consistently.
+permalink: /191/file-option-consistency
+redirect_from:
+  - /0191/file-option-consistency
+---
+
+# Java package annotation
+
+This rule enforces that every proto file for a public API surface sets file
+packaging options consistently, as mandated in [AIP-191][].
+
+## Details
+
+This rule looks at each proto file, and reads any files that it imports that
+are in the same proto package. It iterates over the file packaging options in
+each one and complains if they are inconsistent.
+
+The following annotations are included:
+
+- `csharp_namespace`
+- `go_package`
+- `java_package`
+- `php_class_prefix`
+- `php_metadata_namespace`
+- `php_namespace`
+- `objc_class_prefix`
+- `ruby_package`
+- `swift_prefix`
+
+## Examples
+
+**Incorrect** code for this rule:
+
+In `foo.proto`:
+
+```proto
+// Incorrect.
+syntax = "proto3";
+
+package google.example.v1;
+
+option csharp_namespace = "Google\\Example\\V1";
+option ruby_namespace = "Google::Example::V1";
+```
+
+In `bar.proto`:
+
+```proto
+// Incorrect.
+syntax = "proto3";
+
+package google.example.v1;
+
+import "foo.proto";
+
+option csharp_namespace = "Example\\V1";  // Inconsistent.
+// option ruby_namespace is missing, which is also inconsistent.
+```
+
+**Correct** code for this rule:
+
+In `foo.proto`:
+
+```proto
+// Correct.
+syntax = "proto3";
+
+package google.example.v1;
+
+option csharp_namespace = "Google\\Example\\V1";
+option ruby_namespace = "Google::Example::V1";
+```
+
+In `bar.proto`:
+
+```proto
+// Correct.
+syntax = "proto3";
+
+package google.example.v1;
+
+import "foo.proto";
+
+option csharp_namespace = "Google\\Example\\V1";
+option ruby_namespace = "Google::Example::V1";
+```
+
+## Disabling
+
+If you need to violate this rule, use a comment at the top of the file.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0191::file-option-consistency=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+syntax = "proto3";
+
+package google.example.v1;
+
+import "foo.proto";
+
+option csharp_namespace = "Example\\V1";
+```
+
+[aip-191]: https://aip.dev/191
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0191/aip0191.go
+++ b/rules/aip0191/aip0191.go
@@ -28,6 +28,7 @@ func AddRules(r lint.RuleRegistry) error {
 		191,
 		csharpNamespace,
 		filename,
+		fileOptionConsistency,
 		javaMultipleFiles,
 		javaOuterClassname,
 		javaPackage,

--- a/rules/aip0191/file_option_consistency.go
+++ b/rules/aip0191/file_option_consistency.go
@@ -1,0 +1,73 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0191
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/stoewer/go-strcase"
+)
+
+var consistentOptions = []string{
+	"csharp_namespace",
+	"go_package",
+	"java_package",
+	"php_class_prefix",
+	"php_metadata_namespace",
+	"php_namespace",
+	"objc_class_prefix",
+	"ruby_package",
+	"swift_prefix",
+}
+
+var fileOptionConsistency = &lint.FileRule{
+	Name:   lint.NewRuleName(191, "file-option-consistency"),
+	OnlyIf: hasPackage,
+	LintFile: func(f *desc.FileDescriptor) (problems []lint.Problem) {
+		opts := f.GetFileOptions()
+		for _, dep := range f.GetDependencies() {
+			// We only need to look at files that are in the same package
+			// as the proto we are linting.
+			if dep.GetPackage() != f.GetPackage() {
+				continue
+			}
+
+			// The file package options should all match between this file
+			// and the file being imported.
+			//
+			// We will naively complain on *this* file, even though either one
+			// might be the one that is wrong, and trust the API producer to do
+			// the right thing.
+			depOpts := dep.GetFileOptions()
+			for _, opt := range consistentOptions {
+				funcName := "Get" + strcase.UpperCamelCase(opt)
+				a := reflect.ValueOf(opts).MethodByName(funcName).Call([]reflect.Value{})[0].String()
+				b := reflect.ValueOf(depOpts).MethodByName(funcName).Call([]reflect.Value{})[0].String()
+				if a != b {
+					problems = append(problems, lint.Problem{
+						Message:    fmt.Sprintf("Option %q should be consistent throughout the package.", opt),
+						Descriptor: f,
+						Location:   locations.FilePackage(f),
+					})
+				}
+			}
+		}
+		return
+	},
+}

--- a/rules/aip0191/file_option_consistency_test.go
+++ b/rules/aip0191/file_option_consistency_test.go
@@ -1,0 +1,124 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0191
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/golang/protobuf/proto"
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/jhump/protoreflect/desc/builder"
+	"github.com/stoewer/go-strcase"
+)
+
+func TestFileOptionConsistency(t *testing.T) {
+	// Make a "control file".
+	// This is a situation where using a builder is much easier
+	// than parsing a proto template.
+	controlFile := builder.NewFile("control.proto").SetPackageName(
+		"google.example.v1",
+	).SetOptions(getOptions(nil))
+
+	// Run our tests. Each test will make a "test file" that imports the
+	// control file.
+	for _, test := range []consistencyTest{
+		{"ValidSame", map[string]string{}},
+		{"InvalidCsharpNamespaceMissing", map[string]string{"csharp_namespace": ""}},
+		{"InvalidCsharpNamespaceMismatch", map[string]string{"csharp_namespace": "Example.V1"}},
+		{"InvalidJavaPackageMissing", map[string]string{"java_package": ""}},
+		{"InvalidJavaPackageMismatch", map[string]string{"java_package": "com.example.v1"}},
+		{"InvalidPhpNamespaceMissing", map[string]string{"php_namespace": ""}},
+		{"InvalidPhpNamespaceMismatch", map[string]string{"php_namespace": "Example\\V1"}},
+		{"InvalidPhpMetadataNamespace", map[string]string{"php_metadata_namespace": "Example\\V1"}},
+		{"InvalidPhpClassPrefix", map[string]string{"php_class_prefix": "ExampleProto"}},
+		{"InvalidObjcClassPrefixMissing", map[string]string{"objc_class_prefix": ""}},
+		{"InvalidObjcClassPrefixMismatch", map[string]string{"objc_class_prefix": "GEXV1"}},
+		{"InvalidRubyPackageMissing", map[string]string{"ruby_package": ""}},
+		{"InvalidRubyPackageMismatch", map[string]string{"ruby_package": "Example::V1"}},
+		{"InvalidSwiftPrefixMissing", map[string]string{"swift_prefix": ""}},
+		{"InvalidSwiftPrefixMismatch", map[string]string{"swift_prefix": "ExampleProto"}},
+		{"InvalidLotsOfReasons", map[string]string{
+			"csharp_namespace": "Example.V1",
+			"go_package":       "google.golang.org/googleapis/genproto/googleapis/example/v1;example",
+			"java_package":     "com.example.v1",
+			"ruby_package":     "Example::V1",
+			"swift_prefix":     "",
+		}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			// Build our test file, which imports the control file.
+			testFile, err := builder.NewFile("test.proto").AddDependency(
+				controlFile,
+			).SetPackageName("google.example.v1").SetOptions(getOptions(test.options)).Build()
+			if err != nil {
+				t.Fatalf("Could not build test file.")
+			}
+			if diff := test.getProblems(testFile).Diff(fileOptionConsistency.Lint(testFile)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+
+	// Also ensure separate packages are ignored.
+	t.Run("ValidDifferentPackages", func(t *testing.T) {
+		testFile, err := builder.NewFile("test.proto").AddDependency(controlFile).SetOptions(
+			getOptions(map[string]string{"java_package": "com.wrong"}),
+		).SetPackageName("google.different.v1").Build()
+		if err != nil {
+			t.Fatalf("Could not build test file.")
+		}
+		if diff := (testutils.Problems{}).Diff(fileOptionConsistency.Lint(testFile)); diff != "" {
+			t.Errorf(diff)
+		}
+	})
+}
+
+func getOptions(fileopts map[string]string) *dpb.FileOptions {
+	opts := &dpb.FileOptions{
+		CsharpNamespace: proto.String("Google.Example.V1"),
+		GoPackage:       proto.String("github.com/googleapis/genproto/googleapis/example/v1;example"),
+		JavaPackage:     proto.String("com.google.example.v1"),
+		PhpNamespace:    proto.String("Google\\Example\\V1"),
+		ObjcClassPrefix: proto.String("GEX"),
+		RubyPackage:     proto.String("Google::Example::V1"),
+		SwiftPrefix:     proto.String("Google_Example_V1"),
+	}
+	for k, v := range fileopts {
+		field := strcase.UpperCamelCase(k)
+		reflect.ValueOf(opts).Elem().FieldByName(field).Set(reflect.ValueOf(proto.String(v)))
+	}
+	return opts
+}
+
+type consistencyTest struct {
+	name    string
+	options map[string]string
+}
+
+func (ct *consistencyTest) getProblems(f *desc.FileDescriptor) testutils.Problems {
+	p := testutils.Problems{}
+	for k := range ct.options {
+		p = append(p, lint.Problem{Message: k, Descriptor: f})
+	}
+	sort.Slice(p, func(i, j int) bool {
+		return p[i].Message < p[j].Message
+	})
+	return p
+}


### PR DESCRIPTION
This rule checks that options like `csharp_namespace`, `ruby_package`,
and so on are applied consistently throughout an API.

~Uses #365 as a base (for `hasPackage`).~