### PR TITLE
[docs] Permit, rather than recommend, disabling the AIP-191 rules.

### DIFF
--- a/docs/rules/0191/csharp-namespace.md
+++ b/docs/rules/0191/csharp-namespace.md
@@ -86,7 +86,7 @@ option csharp_namespace = "Google.Example.V1Beta1";
 
 This rule will improperly complain if it encounters an acronym. For example, it
 will complain about `Google.Cloud.AutoML.V1`, preferring `AutoMl`. This lint
-rule **should** be disabled in this case.
+rule **may** be disabled in this case.
 
 ## Disabling
 

--- a/docs/rules/0191/php-namespace.md
+++ b/docs/rules/0191/php-namespace.md
@@ -86,7 +86,7 @@ option php_namespace = "Google\\Example\\V1beta1";
 
 This rule will improperly complain if it encounters an acronym. For example, it
 will complain about `Google\Cloud\AutoML\V1`, preferring `AutoMl`. This lint
-rule **should** be disabled in this case.
+rule **may** be disabled in this case.
 
 ## Disabling
 

--- a/docs/rules/0191/ruby-package.md
+++ b/docs/rules/0191/ruby-package.md
@@ -86,7 +86,7 @@ option ruby_package = "Google::Example::V1beta1";
 
 This rule will improperly complain if it encounters an acronym. For example, it
 will complain about `Google::Cloud::AutoML::V1`, preferring `AutoMl`. This lint
-rule **should** be disabled in this case.
+rule **may** be disabled in this case.
 
 ## Disabling
 


### PR DESCRIPTION
This downgrades from **should** to **may** as @bufdev suggested (and I am convinced he is right).