### PR TITLE
[Refactor] Unspecified: should check the enum value.

### DIFF
--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -24,20 +24,25 @@ import (
 	"github.com/stoewer/go-strcase"
 )
 
-var unspecified = &lint.EnumRule{
-	Name: lint.NewRuleName(126, "unspecified"),
-	LintEnum: func(e *desc.EnumDescriptor) []lint.Problem {
-		firstValue := e.GetValues()[0]
-		want := strings.ToUpper(strcase.SnakeCase(e.GetName()) + "_UNSPECIFIED")
-		if firstValue.GetName() != want {
+var unspecified = &lint.EnumValueRule{
+	Name:   lint.NewRuleName(126, "unspecified"),
+	OnlyIf: isFirstEnumValue,
+	LintEnumValue: func(v *desc.EnumValueDescriptor) []lint.Problem {
+		want := strings.ToUpper(strcase.SnakeCase(v.GetEnum().GetName()) + "_UNSPECIFIED")
+		if v.GetName() != want {
 			return []lint.Problem{{
 				Message:    fmt.Sprintf("The first enum value should be %q", want),
 				Suggestion: want,
-				Descriptor: firstValue,
-				Location:   locations.DescriptorName(firstValue),
+				Descriptor: v,
+				Location:   locations.DescriptorName(v),
 			}}
 		}
 
 		return nil
 	},
+}
+
+// Note: proto3 requires that first value in enum have numeric value of 0.
+func isFirstEnumValue(v *desc.EnumValueDescriptor) bool {
+	return v.GetNumber() == 0
 }


### PR DESCRIPTION
We would like to ensure that a rule checks only the descriptor as provided; in other words, a rule should not return a problem about other descriptors. It makes a rule much easy to understand and for future refactoring. 

For example, we would like to remove `Descriptor` in the `Problem`, as we already know which `Descriptor` a rule is checking and therefore it is redundant to ask the rule developer to return it again in a problem.