### PR TITLE
Add DoNotImplement to the ProtoRule interface.

### DIFF
--- a/internal/pragma/pragma.go
+++ b/internal/pragma/pragma.go
@@ -1,3 +1,18 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package pragma provides types that can be embedded into a struct to statically enforce or prevent certain language properties.
 package pragma
 
 // DoNotImplement can be embedded in an interface to prevent trivial

--- a/internal/pragma/pragma.go
+++ b/internal/pragma/pragma.go
@@ -1,0 +1,8 @@
+package pragma
+
+// DoNotImplement can be embedded in an interface to prevent trivial
+// implementations of the interface.
+//
+// This is useful to prevent unauthorized implementations of an interface
+// so that it can be extended in the future for any API changes.
+type DoNotImplement interface{ LinterInternal(DoNotImplement) }

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -19,8 +19,11 @@ import (
 	"strings"
 
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/googleapis/api-linter/internal/pragma"
 	"github.com/jhump/protoreflect/desc"
 )
+
+type doNotImplement pragma.DoNotImplement
 
 // ProtoRule defines a lint rule that checks Google Protobuf APIs.
 //
@@ -33,6 +36,8 @@ type ProtoRule interface {
 	// Lint accepts a FileDescriptor and lints it,
 	// returning a slice of Problem objects it finds.
 	Lint(*desc.FileDescriptor) []Problem
+
+	doNotImplement
 }
 
 // FileRule defines a lint rule that checks a file as a whole.
@@ -49,6 +54,9 @@ type FileRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *FileRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *FileRule) GetName() RuleName {
@@ -80,6 +88,9 @@ type MessageRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *MessageRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *MessageRule) GetName() RuleName {
@@ -116,6 +127,9 @@ type FieldRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *FieldRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *FieldRule) GetName() RuleName {
@@ -155,6 +169,9 @@ type ServiceRule struct {
 	noPositional struct{}
 }
 
+// LinterInternal implements DoNotImplement.
+func (r *ServiceRule) LinterInternal(pragma.DoNotImplement) {}
+
 // GetName returns the name of the rule.
 func (r *ServiceRule) GetName() RuleName {
 	return r.Name
@@ -187,6 +204,9 @@ type MethodRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *MethodRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *MethodRule) GetName() RuleName {
@@ -222,6 +242,9 @@ type EnumRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *EnumRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *EnumRule) GetName() RuleName {
@@ -261,6 +284,9 @@ type DescriptorRule struct {
 
 	noPositional struct{}
 }
+
+// LinterInternal implements DoNotImplement.
+func (r *DescriptorRule) LinterInternal(pragma.DoNotImplement) {}
 
 // GetName returns the name of the rule.
 func (r *DescriptorRule) GetName() RuleName {


### PR DESCRIPTION
Restrict implementation of `ProtoRule` to this repo until we are ready to release linter version 1.