### PR TITLE
[refactor] Use text/template, not html/template.

### DIFF
--- a/rules/internal/testutils/parse.go
+++ b/rules/internal/testutils/parse.go
@@ -17,9 +17,9 @@ package testutils
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"


### PR DESCRIPTION
This will make templates able to parse things like quotes and such.
I somehow did not find this when writing the original parse
implementation.