### PR TITLE
[AIP-214] Enforce `ttl` field presence.

### DIFF
--- a/docs/rules/0214/index.md
+++ b/docs/rules/0214/index.md
@@ -1,0 +1,10 @@
+---
+aip_listing: 214
+permalink: /214/
+redirect_from:
+  - /0214/
+---
+
+# States
+
+{% include linter-aip-listing.md aip=214 %}

--- a/docs/rules/0214/resource-expiry.md
+++ b/docs/rules/0214/resource-expiry.md
@@ -1,0 +1,77 @@
+---
+rule:
+  aip: 214
+  name: [core, '0214', resource-expiry]
+  summary: Resources with user-set expiry times should offer a ttl field.
+permalink: /214/resource-expiry
+redirect_from:
+  - /0214/resource-expiry
+---
+
+# Resource expiry
+
+This rule enforces that resources that have an expire time that can be set by
+users also have an input-only `ttl` field, as recommended in [AIP-214][].
+
+## Details
+
+This rule looks at fields named `expire_time`, and complains if **none** of the
+following conditions are met:
+
+- A field named `ttl` also exists in the message.
+- The `expire_time` field is annotated as `OUTPUT_ONLY`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  string name = 1;
+  google.protobuf.Timestamp expire_time = 2;  // Should have `ttl` also.
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  string name = 1;
+  google.protobuf.Timestamp expire_time = 2
+    [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+```
+
+```proto
+// Correct.
+message Book {
+  string name = 1;
+  oneof expiration {
+    google.protobuf.Timestamp expire_time = 2;
+    google.protobuf.Duration ttl = 3;
+  }
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the enum.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message Book {
+  string name = 1;
+  // (-- api-linter: core::0214::resource-expiry=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  google.protobuf.Timestamp expire_time = 2
+    [(google.api.field_behavior) = OUTPUT_ONLY];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-214]: https://aip.dev/214
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0214/aip0214.go
+++ b/rules/aip0214/aip0214.go
@@ -1,0 +1,28 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aip0214 contains rules defined in https://aip.dev/214.
+package aip0214
+
+import (
+	"github.com/googleapis/api-linter/lint"
+)
+
+// AddRules adds all of the AIP-214 rules to the provided registry.
+func AddRules(r lint.RuleRegistry) error {
+	return r.Register(
+		214,
+		resourceExpiry,
+	)
+}

--- a/rules/aip0214/aip0214_test.go
+++ b/rules/aip0214/aip0214_test.go
@@ -1,0 +1,27 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0214
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+func TestAddRules(t *testing.T) {
+	if err := AddRules(lint.NewRuleRegistry()); err != nil {
+		t.Errorf("AddRules got an error: %v", err)
+	}
+}

--- a/rules/aip0214/resource_expiry.go
+++ b/rules/aip0214/resource_expiry.go
@@ -1,0 +1,45 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0214
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var resourceExpiry = &lint.FieldRule{
+	Name: lint.NewRuleName(214, "resource-expiry"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return f.GetName() == "expire_time"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		// If this field is output only, then there is no user input permitted
+		// and therefore having a `ttl` field does not matter.
+		if utils.GetFieldBehavior(f).Contains("OUTPUT_ONLY") {
+			return nil
+		}
+
+		// If this message does not have a `ttl` field, suggest one.
+		if f.GetOwner().FindFieldByName("ttl") == nil {
+			return []lint.Problem{{
+				Message:    "Resources that let users set expire_time should include an input only `ttl` field.",
+				Descriptor: f,
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0214/resource_expiry_test.go
+++ b/rules/aip0214/resource_expiry_test.go
@@ -1,0 +1,52 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0214
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceExpiry(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		FieldBehavior string
+		AddtlField    string
+		problems      testutils.Problems
+	}{
+		{"ValidTtl", "", "google.protobuf.Duration ttl = 3;", testutils.Problems{}},
+		{"ValidOutputOnly", "[(google.api.field_behavior) = OUTPUT_ONLY]", "", testutils.Problems{}},
+		{"Invalid", "", "", testutils.Problems{{Message: "ttl"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/field_behavior.proto";
+				import "google/protobuf/timestamp.proto";
+				import "google/protobuf/duration.proto";
+
+				message Book {
+					string name = 1;
+					google.protobuf.Timestamp expire_time = 2 {{.FieldBehavior}};
+					{{.AddtlField}}
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[1]
+			if diff := test.problems.SetDescriptor(field).Diff(resourceExpiry.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/internal/testutils/parse.go
+++ b/rules/internal/testutils/parse.go
@@ -17,9 +17,9 @@ package testutils
 import (
 	"bytes"
 	"fmt"
-	"html/template"
 	"strings"
 	"testing"
+	"text/template"
 
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"

--- a/rules/internal/testutils/parse.go
+++ b/rules/internal/testutils/parse.go
@@ -75,7 +75,7 @@ func ParseProto3String(t *testing.T, src string) *desc.FileDescriptor {
 // ParseProto3Tmpl parses a template string representing a proto file, and
 // returns a FileDescriptor.
 //
-// It parses the template using Go's template Parse function, and then
+// It parses the template using Go's text/template Parse function, and then
 // calls ParseProto3String.
 func ParseProto3Tmpl(t *testing.T, src string, data interface{}) *desc.FileDescriptor {
 	// Create a new template object.

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -71,6 +71,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0191"
 	"github.com/googleapis/api-linter/rules/aip0192"
 	"github.com/googleapis/api-linter/rules/aip0203"
+	"github.com/googleapis/api-linter/rules/aip0214"
 	"github.com/googleapis/api-linter/rules/aip0216"
 	"github.com/googleapis/api-linter/rules/aip0217"
 	"github.com/googleapis/api-linter/rules/aip0231"
@@ -101,6 +102,7 @@ var aipAddRulesFuncs = []addRulesFuncType{
 	aip0191.AddRules,
 	aip0192.AddRules,
 	aip0203.AddRules,
+	aip0214.AddRules,
 	aip0216.AddRules,
 	aip0217.AddRules,
 	aip0231.AddRules,


### PR DESCRIPTION
Uses #390 as a base.