### PR TITLE
[AIP-140] Prohibit reserved words.

### DIFF
--- a/docs/rules/0140/prepositions.md
+++ b/docs/rules/0140/prepositions.md
@@ -46,7 +46,7 @@ message Book {
 
 ## Disabling
 
-If you need to violate this rule, use a leading comment above the method.
+If you need to violate this rule, use a leading comment above the field.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto

--- a/docs/rules/0140/reserved-words.md
+++ b/docs/rules/0140/reserved-words.md
@@ -8,7 +8,7 @@ redirect_from:
   - /0140/reserved-words
 ---
 
-# Field names: Prepositions
+# Field names: Reserved words
 
 This rule enforces that field names are not reserved words, as mandated in
 [AIP-140][].

--- a/docs/rules/0140/reserved-words.md
+++ b/docs/rules/0140/reserved-words.md
@@ -1,0 +1,70 @@
+---
+rule:
+  aip: 140
+  name: [core, '0140', reserved-words]
+  summary: Field names must not be reserved words.
+permalink: /140/reserved-words
+redirect_from:
+  - /0140/reserved-words
+---
+
+# Field names: Prepositions
+
+This rule enforces that field names are not reserved words, as mandated in
+[AIP-140][].
+
+## Details
+
+This rule looks at each field and complains if it the name is a reserved word
+in a common programming lanaguge.
+
+Currently, the linter checks all the reserved words in Java, JavaScript, and
+Python 3. The exhaustive list of reserved words is found in [the code][].
+
+**Note:** Reserved words in Golang are permitted because Golang's variable
+casing rules avoids a conflict.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  string name = 1;
+  bool public = 2;  // Reserved word in Java, JavaScript
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  string name = 1;
+  bool is_public = 2;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message Book {
+  string name = 1;
+  // (-- api-linter: core::0140::reserved-words=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  bool public = 2;  // Reserved word in Java, JavaScript
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+<!-- prettier-ignore-start -->
+[aip-136]: https://aip.dev/136
+[aip.dev/not-precedent]: https://aip.dev/not-precedent
+[the code]: https://github.com/googleapis/api-linter/blob/master/rules/aip0140/reserved_words.go
+<!-- prettier-ignore-end -->

--- a/rules/aip0140/aip0140.go
+++ b/rules/aip0140/aip0140.go
@@ -32,6 +32,7 @@ func AddRules(r lint.RuleRegistry) error {
 		base64,
 		lowerSnake,
 		noPrepositions,
+		reservedWords,
 	)
 }
 

--- a/rules/aip0140/reserved_words.go
+++ b/rules/aip0140/reserved_words.go
@@ -1,0 +1,121 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0140
+
+import (
+	"fmt"
+
+	"bitbucket.org/creachadair/stringset"
+	"github.com/googleapis/api-linter/lint"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var reservedWords = &lint.FieldRule{
+	Name: lint.NewRuleName(140, "reserved-words"),
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if name := f.GetName(); reservedWordsSet.Contains(name) {
+			return []lint.Problem{{
+				Message:    fmt.Sprintf("%q is a reserved word in a common language and should not be used.", name),
+				Descriptor: f,
+			}}
+		}
+		return nil
+	},
+}
+
+var reservedWordsSet = stringset.New(
+	"abstract",     // Java, JavaScript
+	"and",          // Python
+	"arguments",    // JavaScript
+	"as",           // Python
+	"assert",       // Java, Python
+	"async",        // Python
+	"await",        // JavaScript, Python
+	"boolean",      // Java, JavaScript
+	"break",        // Java, JavaScript, Python
+	"byte",         // Java, JavaScript
+	"case",         // Java, JavaScript
+	"catch",        // Java, JavaScript
+	"char",         // Java, JavaScript
+	"class",        // Java, JavaScript, Python
+	"const",        // Java, JavaScript
+	"continue",     // Java, JavaScript, Python
+	"debugger",     // JavaScript
+	"def",          // Python
+	"default",      // Java, JavaScript
+	"del",          // Python
+	"delete",       // JavaScript
+	"do",           // Java, JavaScript
+	"double",       // Java, JavaScript
+	"elif",         // Python
+	"else",         // Java, JavaScript, Python
+	"enum",         // Java, JavaScript
+	"eval",         // JavaScript
+	"except",       // Python
+	"export",       // JavaScript
+	"extends",      // Java, JavaScript
+	"false",        // JavaScript
+	"final",        // Java, JavaScript
+	"finally",      // Java, JavaScript, Python
+	"float",        // Java, JavaScript
+	"for",          // Java, JavaScript, Python
+	"from",         // Python
+	"function",     // JavaScript
+	"global",       // Python
+	"goto",         // Java, JavaScript
+	"if",           // Java, JavaScript, Python
+	"implements",   // Java, JavaScript
+	"import",       // Java, JavaScript, Python
+	"in",           // JavaScript, JavaScript, Python
+	"instanceof",   // Java, JavaScript
+	"int",          // Java, JavaScript
+	"interface",    // Java, JavaScript
+	"is",           // Python
+	"lambda",       // Python
+	"let",          // JavaScript
+	"long",         // Java, JavaScript
+	"native",       // Java, JavaScript
+	"new",          // Java, JavaScript
+	"nonlocal",     // Python
+	"not",          // Python
+	"null",         // JavaScript
+	"or",           // Python
+	"package",      // Java, JavaScript
+	"pass",         // Python
+	"private",      // Java, JavaScript
+	"protected",    // Java, JavaScript
+	"public",       // Java, JavaScript
+	"raise",        // Python
+	"return",       // Java, JavaScript, Python
+	"short",        // Java, JavaScript
+	"static",       // Java, JavaScript
+	"strictfp",     // Java
+	"super",        // Java, JavaScript
+	"switch",       // Java, JavaScript
+	"synchronized", // Java, JavaScript
+	"this",         // Java, JavaScript
+	"throw",        // Java, JavaScript
+	"throws",       // Java, JavaScript
+	"transient",    // Java, JavaScript
+	"true",         // JavaScript
+	"try",          // Java, JavaScript, Python
+	"typeof",       // JavaScript
+	"var",          // JavaScript
+	"void",         // Java, JavaScript
+	"volatile",     // Java, JavaScript
+	"while",        // Java, JavaScript, Python
+	"with",         // JavaScript, Python
+	"yield",        // JavaScript, Python
+)

--- a/rules/aip0140/reserved_words_test.go
+++ b/rules/aip0140/reserved_words_test.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0140
+
+import "testing"
+
+import "github.com/googleapis/api-linter/rules/internal/testutils"
+
+func TestReservedWords(t *testing.T) {
+	reservedWordsSet.Each(func(s string) {
+		t.Run(s, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				message Book {
+					string name = 1;
+					string {{.N}} = 2;
+				}
+			`, struct{ N string }{N: s})
+			field := f.GetMessageTypes()[0].GetFields()[1]
+			want := testutils.Problems{{Message: field.GetName(), Descriptor: field}}
+			if diff := want.Diff(reservedWords.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	})
+}


### PR DESCRIPTION
This rule currently checks Java, JavaScript, and Python 3.
I will add a couple additional languages in a follow-up PR.