### PR TITLE
Fix copy-pasted heading in name-suffix.

### DIFF
--- a/docs/rules/0122/name-suffix.md
+++ b/docs/rules/0122/name-suffix.md
@@ -8,7 +8,7 @@ redirect_from:
   - /0122/name-suffix
 ---
 
-# HTTP URI case
+# Name field suffix
 
 This rule enforces that fields do not use the suffix `_name`, as mandated in
 [AIP-122][].


### PR DESCRIPTION
This changes the heading from "HTTP URI Case" to "Name field suffix".