### PR TITLE
Add a installation note to Googlers.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,8 @@ It will install `api-linter` into your local Go binary directory
 `$HOME/go/bin`. Ensure that your operating system's `PATH` contains the Go
 binary directory.
 
+**Note:** In Google, you should use the released binary `/google/bin/releases/api-linter/api-linter`.
+
 ## Usage
 
 ```sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,7 +39,8 @@ It will install `api-linter` into your local Go binary directory
 `$HOME/go/bin`. Ensure that your operating system's `PATH` contains the Go
 binary directory.
 
-**Note:** In Google, you should use the released binary `/google/bin/releases/api-linter/api-linter`.
+**Note:** For working in Google-internal source control, you should
+use the released binary `/google/bin/releases/api-linter/api-linter`.
 
 ## Usage
 


### PR DESCRIPTION
Due to some differences about protobuf dependencies, we have an internal, compiled version in Google. In other words, the Github version installed using `go get` does not work in Google3. In this PR, we advice googlers to use the internal, released binary instead. 