### PR TITLE
[fix] Make java_outer_classname ignore directories.

### DIFF
--- a/rules/aip0191/java_outer_classname.go
+++ b/rules/aip0191/java_outer_classname.go
@@ -29,7 +29,11 @@ var javaOuterClassname = &lint.FileRule{
 	OnlyIf: hasPackage,
 	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
 		if f.GetFileOptions().GetJavaOuterClassname() == "" {
-			want := strcase.UpperCamelCase(strings.ReplaceAll(f.GetName(), ".", "_"))
+			filename := f.GetName()
+			if ix := strings.LastIndex(filename, "/"); ix != -1 {
+				filename = filename[ix+1:]
+			}
+			want := strcase.UpperCamelCase(strings.ReplaceAll(filename, ".", "_"))
 			return []lint.Problem{{
 				Message: fmt.Sprintf(
 					"Proto files should set `option java_outer_classname = %q`.",

--- a/rules/aip0191/java_outer_classname.go
+++ b/rules/aip0191/java_outer_classname.go
@@ -16,6 +16,7 @@ package aip0191
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
@@ -29,10 +30,7 @@ var javaOuterClassname = &lint.FileRule{
 	OnlyIf: hasPackage,
 	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
 		if f.GetFileOptions().GetJavaOuterClassname() == "" {
-			filename := f.GetName()
-			if ix := strings.LastIndex(filename, "/"); ix != -1 {
-				filename = filename[ix+1:]
-			}
+			filename := filepath.Base(f.GetName())
 			want := strcase.UpperCamelCase(strings.ReplaceAll(filename, ".", "_"))
 			return []lint.Problem{{
 				Message: fmt.Sprintf(

--- a/rules/aip0191/java_outer_classname_test.go
+++ b/rules/aip0191/java_outer_classname_test.go
@@ -24,12 +24,15 @@ import (
 func TestJavaOuterClassname(t *testing.T) {
 	for _, test := range []struct {
 		name       string
+		filename   string
 		statements []string
 		problems   testutils.Problems
 	}{
-		{"Valid", []string{"package foo.v1;", `option java_outer_classname = "TestProto";`}, testutils.Problems{}},
-		{"Invalid", []string{"package foo.v1;", ""}, testutils.Problems{{Message: `java_outer_classname = "TestProto"`}}},
-		{"Ignored", []string{"", ""}, testutils.Problems{}},
+		{"Valid", "test.proto", []string{"package foo.v1;", `option java_outer_classname = "TestProto";`}, testutils.Problems{}},
+		{"ValidWithPath", "foo/bar/test.proto", []string{"package foo.v1;", `option java_outer_classname = "TestProto";`}, testutils.Problems{}},
+		{"Invalid", "test.proto", []string{"package foo.v1;", ""}, testutils.Problems{{Message: `java_outer_classname = "TestProto"`}}},
+		{"InvalidWithPath", "foo/bar/test.proto", []string{"package foo.v1;"}, testutils.Problems{{Message: `java_outer_classname = "TestProto"`}}},
+		{"Ignored", "test.proto", []string{"", ""}, testutils.Problems{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3String(t, strings.Join(test.statements, "\n"))

--- a/rules/internal/testutils/parse.go
+++ b/rules/internal/testutils/parse.go
@@ -37,14 +37,14 @@ import (
 //
 // It dedents the string before parsing.
 // It is unable to handle imports, and calls t.Fatalf if there is any error.
-func ParseProtoString(t *testing.T, src string) *desc.FileDescriptor {
+func ParseProtoString(t *testing.T, src string, filename string) *desc.FileDescriptor {
 	// Make a map of filenames and file contents.
 	// We hard-code "test.proto"; we do not care what the filename is.
 	//
 	// Include the common protos here too, so our proto may safely import them
 	// if needed.
 	fileContents := map[string]string{
-		"test.proto": strings.TrimSpace(dedent.Dedent(src)),
+		filename: strings.TrimSpace(dedent.Dedent(src)),
 	}
 
 	// Parse the file.
@@ -69,7 +69,7 @@ func ParseProto3String(t *testing.T, src string) *desc.FileDescriptor {
 	return ParseProtoString(t, fmt.Sprintf(
 		"syntax = \"proto3\";\n\n%s",
 		strings.TrimSpace(dedent.Dedent(src)),
-	))
+	), "test.proto")
 }
 
 // ParseProto3Tmpl parses a template string representing a proto file, and

--- a/rules/internal/testutils/parse_test.go
+++ b/rules/internal/testutils/parse_test.go
@@ -36,7 +36,7 @@ func TestParseProtoString(t *testing.T) {
 			string eggs = 2;
 			google.protobuf.Timestamp create_time = 3;
 		}
-	`)
+	`, "test.proto")
 	if !fd.IsProto3() {
 		t.Errorf("Expected a proto3 file descriptor.")
 	}
@@ -73,7 +73,7 @@ func TestParseProtoStringError(t *testing.T) {
 			syntax = "proto3";
 			message Foo {}
 			The quick brown fox jumped over the lazy dogs.
-		`)
+		`, "test.proto")
 	}()
 	wg.Wait()
 


### PR DESCRIPTION
Previously it was taking the directory into account
when determining the `java_outer_classname` value,
which was wrong.