### PR TITLE
Fix a typo in the disabling logic for core::0216

### DIFF
--- a/docs/rules/0216/nesting.md
+++ b/docs/rules/0216/nesting.md
@@ -57,7 +57,7 @@ message Book {
   BookState book_state = 1;
 }
 
-// (-- api-linter: core::0216::synonyms=disabled
+// (-- api-linter: core::0216::nesting=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
 enum BookState {
   BOOK_STATE_UNSPECIFIED = 0;


### PR DESCRIPTION
Looks like a copy/paste mistake, should be core::0216::nesting