### PR TITLE
Fix typo in core::0142 disabling command

### DIFF
--- a/docs/rules/0142/time-field-names.md
+++ b/docs/rules/0142/time-field-names.md
@@ -54,7 +54,7 @@ If you need to violate this rule, use a leading comment above the method.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto
-// (-- api-linter: core::0142::time-field-name=disabled
+// (-- api-linter: core::0142::time-field-names=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
 message Book {
   string name = 1;


### PR DESCRIPTION
Should be "names", not "name"