### PR TITLE
[AIP-136] Enforce parent variable consistency.

### DIFF
--- a/docs/rules/0136/http-parent-variable.md
+++ b/docs/rules/0136/http-parent-variable.md
@@ -1,22 +1,23 @@
 ---
 rule:
   aip: 136
-  name: [core, '0136', http-name-variable]
-  summary:
-    Custom methods should only use `name` if the RPC noun matches the resource.
-permalink: /136/http-name-variable
+  name: [core, '0136', http-parent-variable]
+  summary: |
+    Custom methods should only use `parent` if the RPC noun matches the
+    resource.
+permalink: /136/http-parent-variable
 redirect_from:
-  - /0136/http-name-variable
+  - /0136/http-parent-variable
 ---
 
-# Custom methods: HTTP name variable
+# Custom methods: HTTP parent variable
 
-This rule enforces that custom methods only use the `name` variable if the RPC
-noun matches the resource, as mandated in [AIP-136][].
+This rule enforces that custom methods only use the `parent` variable if the
+RPC noun matches the resource, as mandated in [AIP-136][].
 
 ## Details
 
-This rule looks at custom methods and, if the URI contains a `name` variable,
+This rule looks at custom methods and, if the URI contains a `parent` variable,
 it ensures that the RPC name ends with the same text as the final component in
 the URI (after adjusting for case).
 
@@ -29,7 +30,7 @@ the URI (after adjusting for case).
 // The variable should be "book", or the RPC name should change.
 rpc WritePage(WritePageRequest) return (WritePageResponse) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:writePage"
+    post: "/v1/{parent=publishers/*/books/*}:writePage"
     body: "*"
   };
 }
@@ -51,18 +52,18 @@ rpc WritePage(WritePageRequest) return (WritePageResponse) {
 
 ```proto
 // Correct.
-// If Page is a first-class, already-created resource, use `name` as the
+// If Page is a first-class, not-yet-created resource, use `parent` as the
 // variable name and a verb-only suffix.
 rpc WritePage(WritePageRequest) return (WritePageResponse) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*/pages/*}:write"
+    post: "/v1/{parent=publishers/*/books/*}/pages:write"
     body: "*"
   };
 }
 ```
 
-See also the [http-parent-variable][] rule (for first-class resources that are
-created by the custom RPC).
+See also the [http-name-variable][] rule (for first-class resources that are
+already created).
 
 ## Disabling
 
@@ -70,11 +71,11 @@ If you need to violate this rule, use a leading comment above the method.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto
-// (-- api-linter: core::0136::http-name-variable=disabled
+// (-- api-linter: core::0136::http-parent-variable=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
 rpc WritePage(WritePageRequest) return (WritePageResponse) {
   option (google.api.http) = {
-    post: "/v1/{name=publishers/*/books/*}:writePage"
+    post: "/v1/{parent=publishers/*/books/*}:writePage"
     body: "*"
   };
 }
@@ -85,4 +86,4 @@ top of the file.
 
 [aip-136]: https://aip.dev/136
 [aip.dev/not-precedent]: https://aip.dev/not-precedent
-[http-parent-variable]: ./http-parent-variable.md
+[http-name-variable]: ./http-name-variable.md

--- a/docs/rules/0136/http-uri-suffix.md
+++ b/docs/rules/0136/http-uri-suffix.md
@@ -22,6 +22,10 @@ the appropriate suffix at the end of the URI. More specifically:
   the end of the URI.
 - Otherwise, it expects `:verbNoun` at the end of the URI.
 
+**Note:** This rule will not run if the [http-name-variable][] or
+[http-parent-variable][] rules raise an issue, as a significant number of
+issues raised by this rule are _actually_ violations of one of those.
+
 ## Examples
 
 ### Verb only
@@ -99,3 +103,5 @@ top of the file.
 
 [aip-136]: https://aip.dev/136
 [aip.dev/not-precedent]: https://aip.dev/not-precedent
+[http-name-variable]: ./http-name-variable.md
+[http-parent-variable]: ./http-parent-variable.md

--- a/rules/aip0136/aip0136.go
+++ b/rules/aip0136/aip0136.go
@@ -30,6 +30,7 @@ func AddRules(r lint.RuleRegistry) error {
 		httpBody,
 		httpMethod,
 		httpNameVariable,
+		httpParentVariable,
 		noPrepositions,
 		uriSuffix,
 		verbNoun,

--- a/rules/aip0136/http_parent_variable.go
+++ b/rules/aip0136/http_parent_variable.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"strings"
+
+	pluralize "github.com/gertd/go-pluralize"
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+	"github.com/stoewer/go-strcase"
+)
+
+var httpParentVariable = &lint.MethodRule{
+	Name:   lint.NewRuleName(136, "http-parent-variable"),
+	OnlyIf: isCustomMethod,
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		p := pluralize.NewClient()
+		for _, http := range utils.GetHTTPRules(m) {
+			vars := http.GetVariables()
+
+			// If there is a "parent" variable, the noun should be present
+			// in the RPC name.
+			if _, ok := vars["parent"]; ok {
+				// Determine the resource.
+				segs := strings.Split(strings.Split(http.GetPlainURI(), ":")[0], "/")
+				plural := segs[len(segs)-1]
+				singular := p.Singular(plural)
+
+				// Does the RPC name end in the singular or plural name of the resource?
+				// If not, complain.
+				snakeName := strcase.SnakeCase(m.GetName())
+				if !strings.HasSuffix(snakeName, plural) && !strings.HasSuffix(snakeName, singular) {
+					return []lint.Problem{{
+						Message:    "The parent variable should only be used if the RPC noun matches the URI.",
+						Descriptor: m,
+					}}
+				}
+			}
+		}
+		return nil
+	},
+}

--- a/rules/aip0136/http_parent_variable_test.go
+++ b/rules/aip0136/http_parent_variable_test.go
@@ -1,0 +1,56 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0136
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestHTTPParentVariable(t *testing.T) {
+	for _, test := range []struct {
+		name       string
+		MethodName string
+		URI        string
+		problems   testutils.Problems
+	}{
+		{"Valid", "WriteBook", "/v1/{parent=publishers/*}/books:write", testutils.Problems{}},
+		{"ValidPlural", "WriteBook", "/v1/{parent=publishers/*}/books:write", testutils.Problems{}},
+		{"Invalid", "WritePage", "/v1/{parent=publishers/*/books/*}:writePage", testutils.Problems{{Message: "parent variable"}}},
+		{"ValidBookVar", "WritePage", "/v1/{book=publishers/*/books/*}:writePage", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/annotations.proto";
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request)
+							returns ({{.MethodName}}Response) {
+						option (google.api.http) = {
+							post: "{{.URI}}"
+							body: "*"
+						};
+					}
+				}
+				message {{.MethodName}}Request {}
+				message {{.MethodName}}Response {}
+			`, test)
+			m := f.GetServices()[0].GetMethods()[0]
+			if diff := test.problems.SetDescriptor(m).Diff(httpParentVariable.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0136/http_uri_suffix.go
+++ b/rules/aip0136/http_uri_suffix.go
@@ -29,7 +29,7 @@ import (
 var uriSuffix = &lint.MethodRule{
 	Name: lint.NewRuleName(136, "http-uri-suffix"),
 	OnlyIf: func(m *desc.MethodDescriptor) bool {
-		return isCustomMethod(m) && httpNameVariable.LintMethod(m) == nil
+		return isCustomMethod(m) && httpNameVariable.LintMethod(m) == nil && httpParentVariable.LintMethod(m) == nil
 	},
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {


### PR DESCRIPTION
The AIP-136 [http-uri-suffix](https://linter.aip.dev/136/http-uri-suffix) rule continues to be the single most confusing for people. The false positive rate is basically zero, but the problems it finds are varied and subtle and so the error message is useless a lot of the time.

This adds a new rule, http-parent-variable, for catching a common case that _looks_ like a false positive (but is not) and quiets the http-uri-suffix rule if the other rule is noisy.