### PR TITLE
Only detect closing tags in no-html lint

### DIFF
--- a/rules/aip0192/no_html.go
+++ b/rules/aip0192/no_html.go
@@ -42,10 +42,10 @@ var noHTML = &lint.DescriptorRule{
 // Yes, yes, I know: https://stackoverflow.com/questions/1732348/
 // Even Jon Skeet cannot parse HTML using regular expressions.
 //
-// That said, we really only want to pick up "basic HTML smell", and are
+// That said, we really only want to pick up "basic HTML smell" and are
 // disinterested in actually doing any manipulation, and we can be at least
 // a little tolerant of false positives/negatives.
 //
 // Therefore, in this case, a regex seems better than taking a dependency
 // just for this.
-var htmlTag = regexp.MustCompile(`</?[a-zA-Z]+( /)?>`)
+var htmlTag = regexp.MustCompile(`(</[a-zA-Z-]+>|<[a-zA-Z-]+ */>)`)


### PR DESCRIPTION
Fixes #500

There are plenty of places where angle brackets are used to delimit e.g. a placeholder value.
For example: `projects/<proj-id>/...` is a common example format.

This change detects only closing tags which should be a less expansive means of detecting actual
HTML usage in comments.