### PR TITLE
Fix #500 - Check for closing HTML tags via regex.

### DIFF
--- a/rules/aip0192/no_html.go
+++ b/rules/aip0192/no_html.go
@@ -44,8 +44,10 @@ var noHTML = &lint.DescriptorRule{
 //
 // That said, we really only want to pick up "basic HTML smell", and are
 // disinterested in actually doing any manipulation, and we can be at least
-// a little tolerant of false positives/negatives.
+// a little tolerant of false positives/negatives. To do this, we'll look for
+// closing tags (e.g., <foo /> or </foo>) since opening tags are likely to be
+// used for variable placeholders (e.g., http://<server>/<path>).
 //
-// Therefore, in this case, a regex seems better than taking a dependency
-// just for this.
-var htmlTag = regexp.MustCompile(`</?[a-zA-Z]+( /)?>`)
+// TL;DR: In this case, a regex seems better than taking a dependency just for
+// checking if HTML exists in comments.
+var htmlTag = regexp.MustCompile(`(</ *[a-zA-Z-]+>|<[a-zA-Z-]+ */>)`)

--- a/rules/aip0192/no_html_test.go
+++ b/rules/aip0192/no_html_test.go
@@ -22,19 +22,23 @@ import (
 )
 
 func TestNoHTML(t *testing.T) {
+	rawHtmlProblem := testutils.Problems{{Message: "must not include raw HTML"}}
+	noProblems := testutils.Problems{}
+
 	for _, test := range []struct {
 		name     string
 		comment  string
 		problems testutils.Problems
 	}{
-		{"Valid", "It is **great!**", testutils.Problems{}},
-		{"ValidMath", "x < 10", testutils.Problems{}},
-		{"ValidMoreMath", "x < 10 > y", testutils.Problems{}},
-		{"InvalidBold", "It is <b>great!</b>", testutils.Problems{{Message: "raw HTML"}}},
-		{"InvalidCode", "This is <code>code font</code>.", testutils.Problems{{Message: "raw HTML"}}},
-		{"InvalidBreak", "This spans<br />two lines.", testutils.Problems{{Message: "raw HTML"}}},
-		{"InternionalFalseNegativeComplexTag", `<img src="https://foo.bar/mickey" />`, testutils.Problems{}},
-		{"IntentionalFalseNegativeInnerSpace", "Something < b > bold < /b >", testutils.Problems{}},
+		{"Valid", "It is **great!**", noProblems},
+		{"ValidMath", "x < 10", noProblems},
+		{"ValidMoreMath", "x < 10 > y", noProblems},
+		{"ValidAngleBracketPlaceholders", "Format: http://<server>/<path>", noProblems},
+		{"ValidComplexTag", `<img src="https://foo.bar/mickey" />`, noProblems},
+		{"InvalidBold", "It is <b>great!</b>", rawHtmlProblem},
+		{"InvalidCode", "This is <code>code font</code>.", rawHtmlProblem},
+		{"InvalidBreak", "This spans<br />two lines.", rawHtmlProblem},
+		{"IntentionalFalseNegativeInnerSpace", "Something < b > bold < /b >", noProblems},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3String(t, strings.ReplaceAll(`


### PR DESCRIPTION
This builds off of @msuozzo's idea to check for closing tags (see #501) but adds some extra tests and clean up.