### PR TITLE
Fix a logical typo: below -> above

### DIFF
--- a/docs/rules/0191/file-layout.md
+++ b/docs/rules/0191/file-layout.md
@@ -19,7 +19,7 @@ This rule checks for common file layout mistakes, but does not currently check
 the exhaustive file layout in AIP-191. This rule currently complains if:
 
 - Services appear below messages.
-- Top-level enums appear below messages.
+- Top-level enums appear above messages.
 
 ## Examples
 


### PR DESCRIPTION
https://aip.dev/191#file-layout says enum defs should be at the end so we should not complain if they are after messages.