### PR TITLE
Don't enforce AIP-0123 on Response messages

### DIFF
--- a/rules/aip0123/aip0123.go
+++ b/rules/aip0123/aip0123.go
@@ -38,7 +38,8 @@ func AddRules(r lint.RuleRegistry) error {
 }
 
 func isResourceMessage(m *desc.MessageDescriptor) bool {
-	return m.FindFieldByName("name") != nil && !strings.HasSuffix(m.GetName(), "Request")
+	return m.FindFieldByName("name") != nil && !strings.HasSuffix(m.GetName(), "Request") &&
+		!strings.HasSuffix(m.GetName(), "Response")
 }
 
 func hasResourceAnnotation(m *desc.MessageDescriptor) bool {

--- a/rules/aip0123/resource_annotation_test.go
+++ b/rules/aip0123/resource_annotation_test.go
@@ -48,6 +48,7 @@ func TestResourceAnnotation(t *testing.T) {
 	}{
 		{"ValidNoNameField", "Book", "title", testutils.Problems{}},
 		{"ValidRequestMessage", "GetBookRequest", "name", testutils.Problems{}},
+		{"ValidResponseMessage", "GetBookResponse", "name", testutils.Problems{}},
 		{"Invalid", "Book", "name", testutils.Problems{{Message: "google.api.resource"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
In Cloud KMS, we echo the name of the resource used for cryptographic
operations in response messages, so that callers can verify that the
correct resource was used.

(Corruption of a single bit in the `name` field of a request message
could end up with the wrong key being used. We'd like for a caller to be
able to detect when that's happened.)