### PR TITLE
[feat] return non-zero exit status when lint problems found

### DIFF
--- a/cmd/api-linter/cli_test.go
+++ b/cmd/api-linter/cli_test.go
@@ -34,6 +34,17 @@ func TestNewCli(t *testing.T) {
 				ProtoFiles:       []string{"a.proto", "b.proto"},
 			},
 		},
+		{
+			name: "ExitStatusOnLintFailure",
+			inputArgs: []string{
+				"--set-exit-status",
+			},
+			wantCli: &cli{
+				ExitStatusOnLintFailure: true,
+				ProtoImportPaths:        []string{"."},
+				ProtoFiles:              []string{},
+			},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -132,7 +132,7 @@ func TestRules_DisabledByConfig(t *testing.T) {
 func TestBuildErrors(t *testing.T) {
 	expected := `internal/testdata/build_errors.proto:8:1: syntax error: unexpected '}', expecting ';' or '['
 internal/testdata/build_errors.proto:13:1: syntax error: unexpected '}', expecting ';' or '['`
-	err := runCLI([]string{"internal/testdata/build_errors.proto"})
+	_, err := runCLI([]string{"internal/testdata/build_errors.proto"})
 	if err == nil {
 		t.Fatal("expected build error for build_errors.proto")
 	}
@@ -142,7 +142,50 @@ internal/testdata/build_errors.proto:13:1: syntax error: unexpected '}', expecti
 	}
 }
 
+func TestExitStatusForLintFailure(t *testing.T) {
+	for _, test := range testCases {
+
+		// checks lint failure = true when lint problems found
+		t.Run(test.testName+"ReturnsFailure", func(t *testing.T) {
+			proto := test.proto
+			lintFailureStatus, result := runLinterWithFailureStatus(t, proto, "", []string{"--set-exit-status"})
+			expected := result != ""
+			if lintFailureStatus != expected {
+				t.Fatalf("Expected: %v Actual: %v", expected, lintFailureStatus)
+			}
+		})
+
+		// checks lint failure = false when no problems found
+		t.Run(test.testName+"ReturnsNoFailure", func(t *testing.T) {
+			disableInline := fmt.Sprintf("(-- api-linter: %s=disabled --)", test.rule)
+			proto := strings.Replace(test.proto, "disable-me-here", disableInline, -1)
+			lintFailureStatus, result := runLinterWithFailureStatus(t, proto, "", []string{"--set-exit-status"})
+			expected := result != ""
+			if lintFailureStatus != expected {
+				t.Fatalf("Expected: %v Actual: %v", expected, lintFailureStatus)
+			}
+		})
+	}
+
+	// checks lint failure = false when lint problems found but --set-exit-status not set
+	for _, test := range testCases {
+		t.Run(test.testName, func(t *testing.T) {
+			proto := test.proto
+			lintFailureStatus, result := runLinterWithFailureStatus(t, proto, "", []string{})
+			expected := result == ""
+			if lintFailureStatus != expected {
+				t.Fatalf("Expected: %v Actual: %v", expected, lintFailureStatus)
+			}
+		})
+	}
+}
+
 func runLinter(t *testing.T, protoContent, configContent string) string {
+	_, result := runLinterWithFailureStatus(t, protoContent, configContent, []string{})
+	return result
+}
+
+func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string, appendArgs []string) (bool, string) {
 	tempDir, err := ioutil.TempDir("", "test")
 	if err != nil {
 		t.Fatal(err)
@@ -175,8 +218,10 @@ func runLinter(t *testing.T, protoContent, configContent string) string {
 		t.Fatal(err)
 	}
 	args = append(args, protoFileName)
+	args = append(args, appendArgs...)
 
-	if err := runCLI(args); err != nil {
+	lintFailure, err := runCLI(args)
+	if err != nil {
 		t.Fatal(err)
 	}
 
@@ -184,7 +229,7 @@ func runLinter(t *testing.T, protoContent, configContent string) string {
 	if err != nil {
 		t.Fatal(err)
 	}
-	return string(out)
+	return lintFailure, string(out)
 }
 
 func writeFile(path, content string) error {

--- a/cmd/api-linter/main.go
+++ b/cmd/api-linter/main.go
@@ -34,12 +34,17 @@ func init() {
 }
 
 func main() {
-	if err := runCLI(os.Args[1:]); err != nil {
+	lintFail, err := runCLI(os.Args[1:])
+	if err != nil {
 		log.Fatalln(err)
+	}
+
+	if lintFail {
+		os.Exit(1)
 	}
 }
 
-func runCLI(args []string) error {
+func runCLI(args []string) (bool, error) {
 	c := newCli(args)
 	return c.lint(globalRules, globalConfigs)
 }

--- a/cmd/api-linter/main.go
+++ b/cmd/api-linter/main.go
@@ -34,17 +34,12 @@ func init() {
 }
 
 func main() {
-	lintFail, err := runCLI(os.Args[1:])
-	if err != nil {
+	if err := runCLI(os.Args[1:]); err != nil {
 		log.Fatalln(err)
-	}
-
-	if lintFail {
-		os.Exit(1)
 	}
 }
 
-func runCLI(args []string) (bool, error) {
+func runCLI(args []string) error {
 	c := newCli(args)
 	return c.lint(globalRules, globalConfigs)
 }


### PR DESCRIPTION
This change introduces a new flag `--set-exit-status` which will return
a non-zero exit status when lint problems are found. This is a non
breaking change that allows api-linter to be used in CI environments.

This addresses issue #522