### PR TITLE
fix detection of lint problems for exit status

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -190,11 +190,20 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 
 	// Return error on lint failure which subsequently
 	// exits with a non-zero status code
-	if c.ExitStatusOnLintFailure && len(results) > 0 {
+	if c.ExitStatusOnLintFailure && anyProblems(results) {
 		return ExitForLintFailure
 	}
 
 	return nil
+}
+
+func anyProblems(results []lint.Response) bool {
+	for i := range results {
+		if len(results[i].Problems) > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 func loadFileDescriptors(filePaths ...string) (map[string]*desc.FileDescriptor, error) {


### PR DESCRIPTION
This PR fixes a false positive reading of the lint results by checking `result[*].Problems` for lint results per file

see https://github.com/googleapis/api-linter/pull/534#discussion_r416489984