### PR TITLE
Fix php_namespace linter suggestions with extra backslashes.

### DIFF
--- a/rules/aip0191/php_namespace.go
+++ b/rules/aip0191/php_namespace.go
@@ -47,10 +47,11 @@ var phpNamespace = &lint.FileRule{
 				return []lint.Problem{{
 					Message: "PHP namespaces use UpperCamelCase.",
 					Suggestion: fmt.Sprintf(
-						"option php_namespace = %q;",
+						"option php_namespace = %s;",
 						// Even though the string value is a single backslash, we want
 						// to suggest two backslashes, because that is what should be
-						// typed into the editor.
+						// typed into the editor. We use %s to avoid additional escaping
+						// of backslashes by Sprintf.
 						strings.ReplaceAll(want, `\`, `\\`),
 					),
 					Descriptor: f,

--- a/rules/aip0191/php_namespace_test.go
+++ b/rules/aip0191/php_namespace_test.go
@@ -31,13 +31,13 @@ func TestPhpNamespace(t *testing.T) {
 		{"ValidBeta", `Google\\Example\\V1beta1`, testutils.Problems{}},
 		{"InvalidBadChars", "Google:Example:V1", testutils.Problems{{Message: "Invalid characters"}}},
 		{"Invalid", `google\\example\\v1`, testutils.Problems{{
-			Suggestion: fmt.Sprintf("option php_namespace = %q;", `Google\\Example\\V1`),
+			Suggestion: fmt.Sprintf("option php_namespace = %s;", `Google\\Example\\V1`),
 		}}},
 		{"InvalidVersion", `Google\\Example\\v1`, testutils.Problems{{
-			Suggestion: fmt.Sprintf("option php_namespace = %q;", `Google\\Example\\V1`),
+			Suggestion: fmt.Sprintf("option php_namespace = %s;", `Google\\Example\\V1`),
 		}}},
 		{"InvalidBeta", `Google\\Example\\V1Beta1`, testutils.Problems{{
-			Suggestion: fmt.Sprintf("option php_namespace = %q;", `Google\\Example\\V1beta1`),
+			Suggestion: fmt.Sprintf("option php_namespace = %s;", `Google\\Example\\V1beta1`),
 		}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
Suggested backslashes were being doubled by fmt.Sprintf escaping added by %q. Unit tests also verified data with %q, so the incorrect expected values were not readily apparent.