### PR TITLE
[chore] Fix Renovate updates.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,0 @@
-{
-  "extends": ["config:base"],
-  "commitMessagePrefix": "[chore] ",
-  "groupName": "all",
-  "postUpdateOptions": ["gomodTidy"]
-}

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,15 @@
+{
+  extends: ["config:base"],
+  commitMessagePrefix: "[chore] ",
+  groupName: "all",
+  ignoreDeps: [
+    // The current version is broken:
+    // https://github.com/gertd/go-pluralize/issues/8
+    "github.com/gertd/go-pluralize",
+
+    // Excessively annoying because any update to any API published by
+    // Google triggers an update to this.
+    "google.golang.org/genproto",
+  ],
+  postUpdateOptions: ["gomodTidy"],
+}


### PR DESCRIPTION
Ignore `go-pluralize`, which has been broken for a month, and `genproto`, which is just irritating.

Also convert to JSON5, which Renovate supports, so we can have comments.