### PR TITLE
[AIP-136] Add batch method tests.

### DIFF
--- a/rules/aip0136/http_parent_variable_test.go
+++ b/rules/aip0136/http_parent_variable_test.go
@@ -32,6 +32,8 @@ func TestHTTPParentVariable(t *testing.T) {
 		{"ValidTwoWordNoun", "WriteAudioBook", "/v1/{parent=publishers/*}/audioBooks:write", testutils.Problems{}},
 		{"Invalid", "WritePage", "/v1/{parent=publishers/*/books/*}:writePage", testutils.Problems{{Message: "parent variable"}}},
 		{"ValidBookVar", "WritePage", "/v1/{book=publishers/*/books/*}:writePage", testutils.Problems{}},
+		{"ValidBatchGet", "BatchGetBooks", "/v1/{parent=publishers/*}/books:batchGet", testutils.Problems{}},
+		{"ValidBatchCreate", "BatchCreateBooks", "/v1/{parent=publishers/*}/books:batchCreate", testutils.Problems{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
Ensure that there is no false positive on the rule that
requires the parent variable to match the method name.