### PR TITLE
[AIP-136] suffix: add test for no parent

### DIFF
--- a/rules/aip0136/http_uri_suffix_test.go
+++ b/rules/aip0136/http_uri_suffix_test.go
@@ -41,6 +41,7 @@ func TestURISuffix(t *testing.T) {
 		{"ValidTagRevision", "TagBookRevision", "/v1/{name=publishers/*/books/*}:tagRevision", testutils.Problems{}},
 		{"ValidDeleteRevision", "DeleteBookRevision", "/v1/{name=publishers/*/books/*}:deleteRevision", testutils.Problems{}},
 		{"ValidCollection", "SortBooks", "/v1/{publisher=publishers/*}/books:sort", testutils.Problems{}},
+		{"ValidNoParent", "SearchBooks", "/v1/books:search", testutils.Problems{}},
 		{"InvalidListRevisions", "ListBookRevisions", "/v1/{name=publishers/*/books/*}:list", testutils.Problems{{Message: ":listRevisions"}}},
 		{"InvalidTagRevision", "TagBookRevision", "/v1/{name=publishers/*/books/*}:tag", testutils.Problems{{Message: ":tagRevision"}}},
 		{"InvalidDeleteRevision", "DeleteBookRevision", "/v1/{name=publishers/*/books/*}:delete", testutils.Problems{{Message: ":deleteRevision"}}},


### PR DESCRIPTION
This was already fixed, but add a test.

Fixes #532.