### PR TITLE
[AIP-146] Discourage Any.

### DIFF
--- a/docs/rules/0146/any.md
+++ b/docs/rules/0146/any.md
@@ -1,0 +1,55 @@
+---
+rule:
+  aip: 146
+  name: [core, '0146', any]
+  summary: Avoid `google.protobuf.Any` fields.
+permalink: /146/standardized-codes
+redirect_from:
+  - /0146/standardized-codes
+---
+
+# Any
+
+This rule discourages the use of `google.protobuf.Any`, as encouraged in
+[AIP-146][].
+
+## Details
+
+This rule complains if it sees a `google.protobuf.Any` field. Common packages
+(such as `google.api` or `google.longrunning`) are excluded.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  // google.protobuf.Any is discouraged.
+  google.protobuf.Any contents = 1;
+}
+```
+
+**Correct** code for this rule:
+
+The correct code is likely to vary substantially by use case. See [AIP-146][]
+for details and tradeoffs of various approaches for generic fields.
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0146::any=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message Book {
+  google.protobuf.Any contents = 1;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-146]: https://aip.dev/146
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0146/any.md
+++ b/docs/rules/0146/any.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Any
 
-This rule discourages the use of `google.protobuf.Any`, as encouraged in
+This rule discourages the use of `google.protobuf.Any`, as described in
 [AIP-146][].
 
 ## Details

--- a/docs/rules/0146/index.md
+++ b/docs/rules/0146/index.md
@@ -1,0 +1,10 @@
+---
+aip_listing: 146
+permalink: /146/
+redirect_from:
+  - /0146/
+---
+
+# Generic fields
+
+{% include linter-aip-listing.md aip=146 %}

--- a/rules/aip0146/aip0146.go
+++ b/rules/aip0146/aip0146.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0143 contains rules defined in https://aip.dev/143.
-package aip0143
+// Package aip0146 contains rules defined in https://aip.dev/146.
+package aip0146
 
 import (
 	"github.com/googleapis/api-linter/lint"
 )
 
-// AddRules adds all of the AIP-143 rules to the provided registry.
+// AddRules adds all of the AIP-146 rules to the provided registry.
 func AddRules(r lint.RuleRegistry) error {
 	return r.Register(
-		143,
-		fieldNames,
-		fieldTypes,
+		146,
+		any,
 	)
 }

--- a/rules/aip0146/aip0146_test.go
+++ b/rules/aip0146/aip0146_test.go
@@ -12,18 +12,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0143 contains rules defined in https://aip.dev/143.
-package aip0143
+package aip0146
 
 import (
+	"testing"
+
 	"github.com/googleapis/api-linter/lint"
 )
 
-// AddRules adds all of the AIP-143 rules to the provided registry.
-func AddRules(r lint.RuleRegistry) error {
-	return r.Register(
-		143,
-		fieldNames,
-		fieldTypes,
-	)
+func TestAddRules(t *testing.T) {
+	if err := AddRules(lint.NewRuleRegistry()); err != nil {
+		t.Errorf("AddRules got an error: %v", err)
+	}
 }

--- a/rules/aip0146/any.go
+++ b/rules/aip0146/any.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,45 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package aip0215
+package aip0146
 
 import (
-	"regexp"
-	"strings"
-
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
-var versionedPackages = &lint.FileRule{
-	Name: lint.NewRuleName(215, "versioned-packages"),
-	OnlyIf: func(f *desc.FileDescriptor) bool {
-		p := f.GetPackage()
-		if p == "" {
-			return false
-		}
-		for _, exemptSuffix := range []string{".master", ".type"} {
-			if strings.HasSuffix(p, exemptSuffix) {
-				return false
-			}
-		}
-		if utils.IsCommonProto(f) {
+var any = &lint.FieldRule{
+	Name: lint.NewRuleName(146, "any"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		if utils.IsCommonProto(f.GetFile()) {
 			return false
 		}
 		return true
 	},
-	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		if !version.MatchString(f.GetPackage()) {
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if utils.GetTypeName(f) == "google.protobuf.Any" {
 			return []lint.Problem{{
-				Message:    "API components should be in versioned packages.",
+				Message:    "Avoid using google.protobuf.Any fields in public APIs.",
 				Descriptor: f,
-				Location:   locations.FilePackage(f),
+				Location:   locations.FieldType(f),
 			}}
 		}
 		return nil
 	},
 }
-
-var version = regexp.MustCompile(`\.v[\d]+(p[\d]+)?(alpha|beta|eap|test)?[\d]*$`)

--- a/rules/aip0146/any.go
+++ b/rules/aip0146/any.go
@@ -24,10 +24,7 @@ import (
 var any = &lint.FieldRule{
 	Name: lint.NewRuleName(146, "any"),
 	OnlyIf: func(f *desc.FieldDescriptor) bool {
-		if utils.IsCommonProto(f.GetFile()) {
-			return false
-		}
-		return true
+		return !utils.IsCommonProto(f.GetFile())
 	},
 	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
 		if utils.GetTypeName(f) == "google.protobuf.Any" {

--- a/rules/aip0146/any_test.go
+++ b/rules/aip0146/any_test.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0146
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestAny(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		Package  string
+		Type     string
+		problems testutils.Problems
+	}{
+		{"Valid", "foo", "string", nil},
+		{"IgnoredCommon", "google.longrunning", "google.protobuf.Any", nil},
+		{"InvalidAny", "foo", "google.protobuf.Any", testutils.Problems{{Message: "Any"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				package {{.Package}};
+
+				import "google/protobuf/any.proto";
+
+				message Foo {
+					{{.Type}} foo = 1;
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(any.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0215/versioned_packages.go
+++ b/rules/aip0215/versioned_packages.go
@@ -27,6 +27,9 @@ import (
 var versionedPackages = &lint.FileRule{
 	Name: lint.NewRuleName(215, "versioned-packages"),
 	OnlyIf: func(f *desc.FileDescriptor) bool {
+		if utils.IsCommonProto(f) {
+			return false
+		}
 		p := f.GetPackage()
 		if p == "" {
 			return false
@@ -35,9 +38,6 @@ var versionedPackages = &lint.FileRule{
 			if strings.HasSuffix(p, exemptSuffix) {
 				return false
 			}
-		}
-		if utils.IsCommonProto(f) {
-			return false
 		}
 		return true
 	},

--- a/rules/internal/utils/common_proto.go
+++ b/rules/internal/utils/common_proto.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0143 contains rules defined in https://aip.dev/143.
-package aip0143
+package utils
 
 import (
-	"github.com/googleapis/api-linter/lint"
+	"strings"
+
+	"github.com/jhump/protoreflect/desc"
 )
 
-// AddRules adds all of the AIP-143 rules to the provided registry.
-func AddRules(r lint.RuleRegistry) error {
-	return r.Register(
-		143,
-		fieldNames,
-		fieldTypes,
-	)
+// IsCommonProto returns true if a proto file is considered "common".
+func IsCommonProto(f *desc.FileDescriptor) bool {
+	p := f.GetPackage()
+	for _, prefix := range []string{"google.api", "google.protobuf", "google.rpc", "google.longrunning"} {
+		if strings.HasPrefix(p, prefix) {
+			return true
+		}
+	}
+	return false
 }

--- a/rules/internal/utils/common_proto_test.go
+++ b/rules/internal/utils/common_proto_test.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestIsCommonProto(t *testing.T) {
+	for _, test := range []struct {
+		Package string
+		want    bool
+	}{
+		{"google.api", true},
+		{"google.longrunning", true},
+		{"google.protobuf", true},
+		{"google.rpc", true},
+		{"google.api.experimental", true},
+		{"google.cloud.speech.v1", false},
+	} {
+		t.Run(test.Package, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				package {{.Package}};
+			`, test)
+			if got := IsCommonProto(f); got != test.want {
+				t.Errorf("Got %v, expected %v", got, test.want)
+			}
+		})
+	}
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -65,6 +65,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0141"
 	"github.com/googleapis/api-linter/rules/aip0142"
 	"github.com/googleapis/api-linter/rules/aip0143"
+	"github.com/googleapis/api-linter/rules/aip0146"
 	"github.com/googleapis/api-linter/rules/aip0151"
 	"github.com/googleapis/api-linter/rules/aip0156"
 	"github.com/googleapis/api-linter/rules/aip0158"
@@ -98,6 +99,7 @@ var aipAddRulesFuncs = []addRulesFuncType{
 	aip0141.AddRules,
 	aip0142.AddRules,
 	aip0143.AddRules,
+	aip0146.AddRules,
 	aip0151.AddRules,
 	aip0156.AddRules,
 	aip0158.AddRules,


### PR DESCRIPTION
Note: Do not merge this until AIP-146 itself is merged.

This also refactors the common proto check in AIP-215 into a
utility function so it can be reused here.