### PR TITLE
[AIP-216] Add lint rule for common state value synonyms.

### DIFF
--- a/docs/rules/0216/value-synonyms.md
+++ b/docs/rules/0216/value-synonyms.md
@@ -1,0 +1,63 @@
+---
+rule:
+  aip: 216
+  name: [core, '0216', value-synonyms]
+  summary: Enforce common state values.
+permalink: /216/value-synonyms
+redirect_from:
+  - /0216/value-synonyms
+---
+
+# Value synonyms
+
+This rule enforces the use of state values enumerated in [AIP-216][] over
+common synonyms.
+
+## Details
+
+This rule iterates over enumerations that end in `State` and looks for enum
+values that are common synonyms or alternate spellings of the states listed at
+the end of [AIP-216][], and suggests the use of the canonical value instead.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+enum State {
+  STATE_UNSPECIFIED = 0;
+  SUCCESSFUL = 1;  // Should be `SUCCEEDED`.
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+enum State {
+  STATE_UNSPECIFIED = 0;
+  SUCCEEDED = 1;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the enum value.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// Incorrect.
+enum State {
+  STATE_UNSPECIFIED = 0;
+  // (-- api-linter: core::0216::value-synonyms=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  SUCCESSFUL = 1;  // Should be `SUCCEEDED`.
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-216]: https://aip.dev/216
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0216/aip0216.go
+++ b/rules/aip0216/aip0216.go
@@ -24,5 +24,6 @@ func AddRules(r lint.RuleRegistry) error {
 		216,
 		nesting,
 		synonyms,
+		valueSynonyms,
 	)
 }

--- a/rules/aip0216/value_synonyms.go
+++ b/rules/aip0216/value_synonyms.go
@@ -1,0 +1,54 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0216
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var valueSynonyms = &lint.EnumValueRule{
+	Name: lint.NewRuleName(216, "value-synonyms"),
+	OnlyIf: func(v *desc.EnumValueDescriptor) bool {
+		if strings.HasSuffix(v.GetEnum().GetName(), "State") {
+			return true
+		}
+		return false
+	},
+	LintEnumValue: func(v *desc.EnumValueDescriptor) []lint.Problem {
+		for bad, good := range map[string]string{
+			"CANCELED":   "CANCELLED",
+			"FAIL":       "FAILED",
+			"FAILURE":    "FAILED",
+			"READY":      "ACTIVE",
+			"SUCCESS":    "SUCCEEDED",
+			"SUCCESSFUL": "SUCCEEDED",
+		} {
+			if v.GetName() == bad {
+				return []lint.Problem{{
+					Message:    fmt.Sprintf("Prefer %q over %q for state names.", good, bad),
+					Suggestion: good,
+					Descriptor: v,
+					Location:   locations.DescriptorName(v),
+				}}
+			}
+		}
+		return nil
+	},
+}

--- a/rules/aip0216/value_synonyms.go
+++ b/rules/aip0216/value_synonyms.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2020 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,10 +26,7 @@ import (
 var valueSynonyms = &lint.EnumValueRule{
 	Name: lint.NewRuleName(216, "value-synonyms"),
 	OnlyIf: func(v *desc.EnumValueDescriptor) bool {
-		if strings.HasSuffix(v.GetEnum().GetName(), "State") {
-			return true
-		}
-		return false
+		return strings.HasSuffix(v.GetEnum().GetName(), "State")
 	},
 	LintEnumValue: func(v *desc.EnumValueDescriptor) []lint.Problem {
 		for bad, good := range map[string]string{

--- a/rules/aip0216/value_synonyms_test.go
+++ b/rules/aip0216/value_synonyms_test.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0216
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestValueSynonyms(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		EnumName  string
+		ValueName string
+		problems  testutils.Problems
+	}{
+		{"ValidSucceeded", "State", "SUCCEEDED", nil},
+		{"ValidDeleted", "State", "DELETED", nil},
+		{"InvalidSuccess", "State", "SUCCESS", testutils.Problems{{Suggestion: "SUCCEEDED"}}},
+		{"InvalidSuccessful", "State", "SUCCESSFUL", testutils.Problems{{Suggestion: "SUCCEEDED"}}},
+		{"InvalidCanceled", "State", "CANCELED", testutils.Problems{{Suggestion: "CANCELLED"}}},
+		{"InvalidFail", "State", "FAIL", testutils.Problems{{Suggestion: "FAILED"}}},
+		{"InvalidFailure", "State", "FAILURE", testutils.Problems{{Suggestion: "FAILED"}}},
+		{"Ireelevant", "Foo", "SUCCESSFUL", nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				enum {{.EnumName}} {
+					{{.EnumName}}_UNSPECIFIED = 0;
+					{{.ValueName}} = 1;
+				}
+			`, test)
+			ev := file.GetEnumTypes()[0].GetValues()[1]
+			if diff := test.problems.SetDescriptor(ev).Diff(valueSynonyms.Lint(file)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0216/value_synonyms_test.go
+++ b/rules/aip0216/value_synonyms_test.go
@@ -34,7 +34,7 @@ func TestValueSynonyms(t *testing.T) {
 		{"InvalidCanceled", "State", "CANCELED", testutils.Problems{{Suggestion: "CANCELLED"}}},
 		{"InvalidFail", "State", "FAIL", testutils.Problems{{Suggestion: "FAILED"}}},
 		{"InvalidFailure", "State", "FAILURE", testutils.Problems{{Suggestion: "FAILED"}}},
-		{"Ireelevant", "Foo", "SUCCESSFUL", nil},
+		{"Irrelevant", "Foo", "SUCCESSFUL", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
This rule catches common State mistakes like `SUCCESSFUL` and
`SUCCESS` and corrects them.

It also catches `CANCELED` and asks for the two-L spelling:
`CANCELLED`. Both are correct, but we should use one consistently
and the AIP uses the two-L version.