### PR TITLE
chore: Binary releases.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-linux-amd64.tar.gz
+          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the linux/arm release.
         uses: actions/upload-release-asset@v1
@@ -55,7 +55,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-linux-arm.tar.gz
+          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-linux-arm.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the darwin/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -64,7 +64,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-darwin-amd64.tar.gz
+          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-darwin-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the windows/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -73,5 +73,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-windows-amd64.tar.gz
+          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-windows-amd64.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,74 @@
+---
+name: release
+on:
+  push:
+    tags:
+      - /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: golang:1.14
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install the cross-platform build tool.
+        run: |
+          go get github.com/mitchellh/gox
+          go get github.com/inconshreveable/mousetrap
+      - name: Set the version number.
+        run: |
+          cat > cmd/api-linter/version.go <<EOF
+          package main
+          const version = "${{ github.ref }}"
+          EOF
+      - name: Build for the major platforms.
+        run: |
+          for arch in "linux/amd64" "linux/arm" "darwin/amd64" "windows/amd64"; do
+            gox -osarch $arch -output api-linter ./... && \
+            tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
+          done
+      - name: Create the ${{ github.ref }} GitHub release.
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: api-linter ${{ github.ref }}
+          draft: true # change to false once done thrashing
+          prerelease: true # change to false once done thrashing
+      - name: Upload the linux/amd64 release.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./api-linter-linux-amd64.tar.gz
+          asset_name: aip-linter-linux-amd64.tar.gz
+          asset_content_type: application/tar+gzip
+      - name: Upload the linux/arm release.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./api-linter-linux-arm.tar.gz
+          asset_name: aip-linter-linux-arm.tar.gz
+          asset_content_type: application/tar+gzip
+      - name: Upload the darwin/amd64 release.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./api-linter-darwin-amd64.tar.gz
+          asset_name: aip-linter-darwin-amd64.tar.gz
+          asset_content_type: application/tar+gzip
+      - name: Upload the windows/amd64 release.
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: ./api-linter-windows-amd64.tar.gz
+          asset_name: aip-linter-windows-amd64.tar.gz
+          asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,9 +25,10 @@ jobs:
           go get github.com/inconshreveable/mousetrap
 
       # GitHub will only send "refs/tags/vX.Y.Z" rather than the actual
-      # tag name. In addition to writing the Go file so the version is
-      # compiled into the binary, this step stores the "vX.Y.Z" string as
-      # output so that later steps can use it.
+      # tag name. We solve that problem in version.go by just slicing it in Go.
+      # In addition to writing the Go file so the version is compiled into
+      # the binary, this step stores the "vX.Y.Z" string as output so that
+      # later steps can use it.
       - name: Set the version number.
         id: version
         run: |
@@ -35,7 +36,7 @@ jobs:
           package main
           var version = "${{ github.ref }}"[10:]
           EOF
-          echo "::set-output name=version::${${{ github.ref }}:10}"
+          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
       # Platforms to build on are hard-coded here.
       # We iterate over them separately so we can tar them and only have

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,7 +70,7 @@ jobs:
       # `api-linter` as the binary name once un-tarred.
       - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |
-          gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter ./... && \
+          gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter* ./... && \
           tar cvfz api-linter.tar.gz api-linter
 
       # This creates the GitHub release.

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,10 +5,12 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+
 jobs:
-  build:
+  release:
     runs-on: ubuntu-latest
-    container: golang:1.14
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "1.14"
       - uses: actions/checkout@v2
       - name: Install the cross-platform build tool.
         run: |
@@ -18,7 +20,7 @@ jobs:
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
-          const version = "${{ github.ref }}"
+          const version = "${{ github.ref[10:] }}"
           EOF
       - name: Build for the major platforms.
         run: |
@@ -26,28 +28,25 @@ jobs:
             gox -osarch $arch -output api-linter ./... && \
             tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
           done
-  upload:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
+        shell: bash
       - name: Create the ${{ github.ref }} GitHub release.
         id: create_release
         uses: actions/create-release@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: api-linter ${{ github.ref }}
+          tag_name: ${{ github.ref[10:] }}
+          release_name: api-linter ${{ github.ref[10:] }}
           draft: true # change to false once done thrashing
           prerelease: true # change to false once done thrashing
       - name: Upload the linux/amd64 release.
         uses: actions/upload-release-asset@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: aip-linter-linux-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref[10:] }}-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the linux/arm release.
         uses: actions/upload-release-asset@v1
@@ -56,7 +55,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: aip-linter-linux-arm.tar.gz
+          asset_name: aip-linter-${{ github.ref[10:] }}-linux-arm.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the darwin/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -65,7 +64,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: aip-linter-darwin-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref[10:] }}-darwin-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the windows/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -74,5 +73,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: aip-linter-windows-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref[10:] }}-windows-amd64.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,8 +70,8 @@ jobs:
       # `api-linter` as the binary name once un-tarred.
       - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |
-          gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter* ./... && \
-          tar cvfz api-linter.tar.gz api-linter
+          gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter ./... && \
+          tar cvfz api-linter.tar.gz api-linter*
 
       # This creates the GitHub release.
       # Note: A failure after this point will leave a half-completed job

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,10 +12,22 @@ jobs:
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
+
+      # The API linter does not use these,  but we need them to build the
+      # binaries.
+      #
+      # Mousetrap is installed individually because it is needed for the
+      # Windows build. Since we are building on Linux, it is not installed
+      # automatically as a dependency.
       - name: Install the cross-platform build tool.
         run: |
           go get github.com/mitchellh/gox
           go get github.com/inconshreveable/mousetrap
+
+      # GitHub will only send "refs/tags/vX.Y.Z" rather than the actual
+      # tag name. In addition to writing the Go file so the version is
+      # compiled into the binary, this step stores the "vX.Y.Z" string as
+      # output so that later steps can use it.
       - name: Set the version number.
         id: version
         run: |
@@ -24,9 +36,10 @@ jobs:
           var version = "${{ github.ref }}"[10:]
           EOF
           echo "::set-output name=version::${${{ github.ref }}:10}"
-        outputs:
-          version:
-            description: The version number.
+
+      # Platforms to build on are hard-coded here.
+      # We iterate over them separately so we can tar them and only have
+      # `api-linter` as the binary name once un-tarred.
       - name: Build for the major platforms.
         run: |
           for arch in "linux/amd64" "linux/arm" "darwin/amd64" "windows/amd64"; do
@@ -34,6 +47,10 @@ jobs:
             tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
           done
         shell: bash
+
+      # This creates the GitHub release.
+      # Note: A failure after this point will leave a half-completed job
+      # on GitHub and probably require manual intervention.
       - name: Create the GitHub release.
         id: create_release
         uses: actions/create-release@v1
@@ -44,6 +61,8 @@ jobs:
           release_name: api-linter ${{ github.ref }}
           draft: true # change to false once done thrashing
           prerelease: true # change to false once done thrashing
+
+      # Upload the binaries to the release.
       - name: Upload the linux/amd64 release.
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,6 +8,37 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Set the version number.
+        id: version
+        run: echo ::set-output name=version::${GITHUB_REF#refs/tags/v}
+      - name: Create the GitHub release.
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: api-linter ${{ steps.version.outputs.version }}
+          draft: true # change to false once done thrashing
+          prerelease: true # change to false once done thrashing
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      upload_url: ${{ steps.create_release.outputs.upload_url }}
+  build:
+    runs-on: ubuntu-latest
+    needs: release
+    strategy:
+      matrix:
+        osarch:
+          - os: linux
+            arch: amd64
+          - os: linux
+            arch: arm
+          - os: darwin
+            arch: amd64
+          - os: windows
+            arch: amd64
+    steps:
       - uses: actions/setup-go@v2
         with:
           go-version: "1.14"
@@ -24,79 +55,35 @@ jobs:
           go get github.com/mitchellh/gox
           go get github.com/inconshreveable/mousetrap
 
-      # GitHub will only send "refs/tags/vX.Y.Z" rather than the actual
-      # tag name. We solve that problem in version.go by just slicing it in Go.
-      # In addition to writing the Go file so the version is compiled into
-      # the binary, this step stores the "vX.Y.Z" string as output so that
-      # later steps can use it.
+      # This makes the compiled binary respond correctly to `--version`
+      # in the CLI.
       - name: Set the version number.
         id: version
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
-          var version = "${{ github.ref }}"[10:]
+          var version = "${{ needs.release.outputs.version }}"
           EOF
-          echo ::set-output name=version::${GITHUB_REF#refs/tags/}
 
       # Platforms to build on are hard-coded here.
       # We iterate over them separately so we can tar them and only have
       # `api-linter` as the binary name once un-tarred.
-      - name: Build for the major platforms.
+      - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |
-          for arch in "linux/amd64" "linux/arm" "darwin/amd64" "windows/amd64"; do
-            gox -osarch $arch -output api-linter ./... && \
-            tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
-          done
-        shell: bash
+          gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter ./... && \
+          tar cvfz api-linter.tar.gz api-linter
 
       # This creates the GitHub release.
       # Note: A failure after this point will leave a half-completed job
       # on GitHub and probably require manual intervention.
-      - name: Create the GitHub release.
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: api-linter ${{ github.ref }}
-          draft: true # change to false once done thrashing
-          prerelease: true # change to false once done thrashing
 
       # Upload the binaries to the release.
-      - name: Upload the linux/amd64 release.
+      - name: Upload the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} release.
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: api-linter-${{ steps.version.outputs.version }}-linux-amd64.tar.gz
-          asset_content_type: application/tar+gzip
-      - name: Upload the linux/arm release.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: api-linter-${{ steps.version.outputs.version }}-linux-arm.tar.gz
-          asset_content_type: application/tar+gzip
-      - name: Upload the darwin/amd64 release.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: api-linter-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz
-          asset_content_type: application/tar+gzip
-      - name: Upload the windows/amd64 release.
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: api-linter-${{ steps.version.outputs.version }}-windows-amd64.tar.gz
+          upload_url: ${{ needs.release.outputs.upload_url }}
+          asset_path: ./api-linter.tar.gz
+          asset_name: api-linter-${{ needs.release.outputs.version }}-${{ matrix.osarch.os }}-${{ matrix.osarch.arch }}.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
-          const version = "${{ github.ref[10:] }}"
+          const version = "${{ github.ref }}"
           EOF
       - name: Build for the major platforms.
         run: |
@@ -35,8 +35,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         with:
-          tag_name: ${{ github.ref[10:] }}
-          release_name: api-linter ${{ github.ref[10:] }}
+          tag_name: ${{ github.ref }}
+          release_name: api-linter ${{ github.ref }}
           draft: true # change to false once done thrashing
           prerelease: true # change to false once done thrashing
       - name: Upload the linux/amd64 release.
@@ -46,7 +46,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref[10:] }}-linux-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref }}-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the linux/arm release.
         uses: actions/upload-release-asset@v1
@@ -55,7 +55,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: aip-linter-${{ github.ref[10:] }}-linux-arm.tar.gz
+          asset_name: aip-linter-${{ github.ref }}-linux-arm.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the darwin/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -64,7 +64,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref[10:] }}-darwin-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref }}-darwin-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the windows/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -73,5 +73,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref[10:] }}-windows-amd64.tar.gz
+          asset_name: aip-linter-${{ github.ref }}-windows-amd64.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
           package main
           var version = "${{ github.ref }}"[10:]
           EOF
-          echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
+          echo ::set-output name=version::${GITHUB_REF#refs/tags/}
 
       # Platforms to build on are hard-coded here.
       # We iterate over them separately so we can tar them and only have

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,6 @@ jobs:
         with:
           go-version: "1.14"
       - uses: actions/checkout@v2
-
       # The API linter does not use these,  but we need them to build the
       # binaries.
       #
@@ -54,30 +53,17 @@ jobs:
         run: |
           go get github.com/mitchellh/gox
           go get github.com/inconshreveable/mousetrap
-
-      # This makes the compiled binary respond correctly to `--version`
-      # in the CLI.
-      - name: Set the version number.
+      - name: Set the version number in the binary (for `api-linter --version`).
         id: version
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
           var version = "${{ needs.release.outputs.version }}"
           EOF
-
-      # Platforms to build on are hard-coded here.
-      # We iterate over them separately so we can tar them and only have
-      # `api-linter` as the binary name once un-tarred.
       - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |
           gox -osarch ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} -output api-linter ./... && \
           tar cvfz api-linter.tar.gz api-linter*
-
-      # This creates the GitHub release.
-      # Note: A failure after this point will leave a half-completed job
-      # on GitHub and probably require manual intervention.
-
-      # Upload the binaries to the release.
       - name: Upload the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} release.
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -58,7 +58,7 @@ jobs:
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
-          var version = "${{ needs.release.outputs.version }}"
+          const version = "${{ needs.release.outputs.version }}"
           EOF
       - name: Build for the ${{ matrix.osarch.os }}/${{ matrix.osarch.arch }} platform.
         run: |

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,9 +3,9 @@ name: release
 on:
   push:
     tags:
-      - /^v\d+\.\d+\.\d+$|^v\d+\.\d+\.\d+-[a-z]+$/
+      - v[0-9]+.[0-9]+.[0-9]+
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     container: golang:1.14
     steps:
@@ -26,6 +26,10 @@ jobs:
             gox -osarch $arch -output api-linter ./... && \
             tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
           done
+  upload:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
       - name: Create the ${{ github.ref }} GitHub release.
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,7 +20,7 @@ jobs:
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
-          const version = "${{ github.ref }}"
+          var version = "${{ github.ref }}"[10:]
           EOF
       - name: Build for the major platforms.
         run: |
@@ -29,7 +29,7 @@ jobs:
             tar cvfz api-linter-${arch/\//-}.tar.gz api-linter
           done
         shell: bash
-      - name: Create the ${{ github.ref }} GitHub release.
+      - name: Create the GitHub release.
         id: create_release
         uses: actions/create-release@v1
         env:
@@ -46,7 +46,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref }}-linux-amd64.tar.gz
+          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the linux/arm release.
         uses: actions/upload-release-asset@v1
@@ -55,7 +55,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: aip-linter-${{ github.ref }}-linux-arm.tar.gz
+          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-linux-arm.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the darwin/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -64,7 +64,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref }}-darwin-amd64.tar.gz
+          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-darwin-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the windows/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -73,5 +73,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: aip-linter-${{ github.ref }}-windows-amd64.tar.gz
+          asset_name: aip-linter-${{ steps.create_release.outputs.name }}-windows-amd64.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -17,11 +17,16 @@ jobs:
           go get github.com/mitchellh/gox
           go get github.com/inconshreveable/mousetrap
       - name: Set the version number.
+        id: version
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main
           var version = "${{ github.ref }}"[10:]
           EOF
+          echo "::set-output name=version::${${{ github.ref }}:10}"
+        outputs:
+          version:
+            description: The version number.
       - name: Build for the major platforms.
         run: |
           for arch in "linux/amd64" "linux/arm" "darwin/amd64" "windows/amd64"; do
@@ -46,7 +51,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-amd64.tar.gz
-          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-linux-amd64.tar.gz
+          asset_name: api-linter-${{ steps.version.outputs.version }}-linux-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the linux/arm release.
         uses: actions/upload-release-asset@v1
@@ -55,7 +60,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-linux-arm.tar.gz
-          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-linux-arm.tar.gz
+          asset_name: api-linter-${{ steps.version.outputs.version }}-linux-arm.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the darwin/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -64,7 +69,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-darwin-amd64.tar.gz
-          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-darwin-amd64.tar.gz
+          asset_name: api-linter-${{ steps.version.outputs.version }}-darwin-amd64.tar.gz
           asset_content_type: application/tar+gzip
       - name: Upload the windows/amd64 release.
         uses: actions/upload-release-asset@v1
@@ -73,5 +78,5 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: ./api-linter-windows-amd64.tar.gz
-          asset_name: api-linter-${{ steps.create_release.outputs.tag_name }}-windows-amd64.tar.gz
+          asset_name: api-linter-${{ steps.version.outputs.version }}-windows-amd64.tar.gz
           asset_content_type: application/tar+gzip

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -54,7 +54,6 @@ jobs:
           go get github.com/mitchellh/gox
           go get github.com/inconshreveable/mousetrap
       - name: Set the version number in the binary (for `api-linter --version`).
-        id: version
         run: |
           cat > cmd/api-linter/version.go <<EOF
           package main

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,8 @@ jobs:
         with:
           tag_name: ${{ github.ref }}
           release_name: api-linter ${{ steps.version.outputs.version }}
-          draft: true # change to false once done thrashing
-          prerelease: true # change to false once done thrashing
+          draft: true # Change to false once release notes are automatic.
+          prerelease: false
     outputs:
       version: ${{ steps.version.outputs.version }}
       upload_url: ${{ steps.create_release.outputs.upload_url }}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,27 @@ When able, it also offers a suggestion for the correct fix.
 
 [_Read more ≫_](https://linter.aip.dev/)
 
+## Versioning
+
+The Google API linter does **not** follow semantic versioning. Semantic
+versioning is challenging for a tool like a linter because the addition or
+correction of virtually any rule is "breaking" (in the sense that a file that
+previously reported no problems may now do so).
+
+Therefore, the version numbers refer to the linter's core interface. In
+general:
+
+- Releases with only documentation, chores, dependency upgrades, and/or
+  bugfixes are patch releases.
+- Releases with new rules (or potentially removed rules) are minor releases.
+- Releases with core interface alterations are major releases. This could
+  include changes to the internal Go interface or the CLI user interface.
+
+**Note:** Releases that increment the Go version will be considered minor.
+
+This is an attempt to follow the spirit of semantic versioning while still
+being useful.
+
 ## License
 
 This software is made available under the [Apache 2.0][] license.

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -37,6 +37,7 @@ type cli struct {
 	FormatType              string
 	OutputPath              string
 	ExitStatusOnLintFailure bool
+	VersionFlag             bool
 	ProtoImportPaths        []string
 	ProtoFiles              []string
 	ProtoDescPath           []string
@@ -52,6 +53,7 @@ func newCli(args []string) *cli {
 	var fmtFlag string
 	var outFlag string
 	var setExitStatusOnLintFailure bool
+	var versionFlag bool
 	var protoImportFlag []string
 	var protoDescFlag []string
 	var ruleEnableFlag []string
@@ -63,6 +65,7 @@ func newCli(args []string) *cli {
 	fs.StringVar(&fmtFlag, "output-format", "", "The format of the linting results.\nSupported formats include \"yaml\", \"json\" and \"summary\" table.\nYAML is the default.")
 	fs.StringVarP(&outFlag, "output-path", "o", "", "The output file path.\nIf not given, the linting results will be printed out to STDOUT.")
 	fs.BoolVar(&setExitStatusOnLintFailure, "set-exit-status", false, "Return exit status 1 when lint errors are found.")
+	fs.BoolVar(&versionFlag, "version", false, "Print version and exit.")
 	fs.StringArrayVarP(&protoImportFlag, "proto-path", "I", nil, "The folder for searching proto imports.\nMay be specified multiple times; directories will be searched in order.\nThe current working directory is always used.")
 	fs.StringArrayVar(&protoDescFlag, "descriptor-set-in", nil, "The file containing a FileDescriptorSet for searching proto imports.\nMay be specified multiple times.")
 	fs.StringArrayVar(&ruleEnableFlag, "enable-rule", nil, "Enable a rule with the given name.\nMay be specified multiple times.")
@@ -84,10 +87,17 @@ func newCli(args []string) *cli {
 		EnabledRules:            ruleEnableFlag,
 		DisabledRules:           ruleDisableFlag,
 		ProtoFiles:              fs.Args(),
+		VersionFlag:             versionFlag,
 	}
 }
 
 func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
+	// Print version and exit if asked.
+	if c.VersionFlag {
+		fmt.Printf("api-linter %s\n", version)
+		return nil
+	}
+
 	// Pre-check if there are files to lint.
 	if len(c.ProtoFiles) == 0 {
 		return fmt.Errorf("no file to lint")

--- a/cmd/api-linter/version.go
+++ b/cmd/api-linter/version.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// 		https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+const version = `- HEAD version
+
+You got this from "go get", "go run", etc.; check go.mod for which
+version you have.
+
+Versioned binaries (independent of Go tooling) are distributed from:
+  https://github.com/googleapis/api-linter/releases`


### PR DESCRIPTION
This sets up CI/CD for binary releases when we make release tags.

Fixes #53.