### PR TITLE
Fix snake_case for plural resource name

### DIFF
--- a/rules/aip0136/http_parent_variable.go
+++ b/rules/aip0136/http_parent_variable.go
@@ -37,8 +37,8 @@ var httpParentVariable = &lint.MethodRule{
 			if _, ok := vars["parent"]; ok {
 				// Determine the resource.
 				segs := strings.Split(strings.Split(http.GetPlainURI(), ":")[0], "/")
-				plural := segs[len(segs)-1]
-				singular := strcase.SnakeCase(p.Singular(plural))
+				plural := strcase.SnakeCase(segs[len(segs)-1])
+				singular := p.Singular(plural)
 
 				// Does the RPC name end in the singular or plural name of the resource?
 				// If not, complain.

--- a/rules/aip0136/http_parent_variable_test.go
+++ b/rules/aip0136/http_parent_variable_test.go
@@ -34,6 +34,7 @@ func TestHTTPParentVariable(t *testing.T) {
 		{"ValidBookVar", "WritePage", "/v1/{book=publishers/*/books/*}:writePage", testutils.Problems{}},
 		{"ValidBatchGet", "BatchGetBooks", "/v1/{parent=publishers/*}/books:batchGet", testutils.Problems{}},
 		{"ValidBatchCreate", "BatchCreateBooks", "/v1/{parent=publishers/*}/books:batchCreate", testutils.Problems{}},
+		{"ValidTwoWordNoudBatch", "BatchUpdateAudioBooks", "/v1/{parent=publishers/*}/audioBooks:batchUpdate", testutils.Problems{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0136/http_parent_variable_test.go
+++ b/rules/aip0136/http_parent_variable_test.go
@@ -34,7 +34,7 @@ func TestHTTPParentVariable(t *testing.T) {
 		{"ValidBookVar", "WritePage", "/v1/{book=publishers/*/books/*}:writePage", testutils.Problems{}},
 		{"ValidBatchGet", "BatchGetBooks", "/v1/{parent=publishers/*}/books:batchGet", testutils.Problems{}},
 		{"ValidBatchCreate", "BatchCreateBooks", "/v1/{parent=publishers/*}/books:batchCreate", testutils.Problems{}},
-		{"ValidTwoWordNoudBatch", "BatchUpdateAudioBooks", "/v1/{parent=publishers/*}/audioBooks:batchUpdate", testutils.Problems{}},
+		{"ValidTwoWordNounBatch", "BatchUpdateAudioBooks", "/v1/{parent=publishers/*}/audioBooks:batchUpdate", testutils.Problems{}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
plural is not currently converted to snake_case, but is used in comparison on line 46