### PR TITLE
fix: Permit `hour_of_day` and `day_of_week`.

### DIFF
--- a/rules/aip0140/prepositions.go
+++ b/rules/aip0140/prepositions.go
@@ -28,7 +28,7 @@ import (
 var noPrepositions = &lint.FieldRule{
 	Name: lint.NewRuleName(140, "prepositions"),
 	OnlyIf: func(f *desc.FieldDescriptor) bool {
-		return !stringset.New("order_by", "group_by").Contains(f.GetName())
+		return !stringset.New("order_by", "group_by", "hour_of_day", "day_of_week").Contains(f.GetName())
 	},
 	LintField: func(f *desc.FieldDescriptor) (problems []lint.Problem) {
 		for _, word := range strings.Split(f.GetName(), "_") {

--- a/rules/aip0140/prepositions_test.go
+++ b/rules/aip0140/prepositions_test.go
@@ -30,6 +30,8 @@ func TestNoPrepositions(t *testing.T) {
 		{"move_toward_shelf_at_front", testutils.Problems{{Message: "toward"}, {Message: "at"}}},
 		{"order_by", testutils.Problems{}},
 		{"group_by", testutils.Problems{}},
+		{"hour_of_day", testutils.Problems{}},
+		{"day_of_week", testutils.Problems{}},
 	}
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {


### PR DESCRIPTION
It makes no sense to flag on this because we called the message `google.type.DayOfWeek`.