### PR TITLE
chore: Update go-pluralize again.

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,11 +2,6 @@
   extends: ["config:base"],
   commitMessagePrefix: "chore: ",
   groupName: "all",
-  ignoreDeps: [
-    // The current version is broken:
-    // https://github.com/gertd/go-pluralize/issues/8
-    "github.com/gertd/go-pluralize",
-  ],
   packageRules: [
     {
       // The genproto package is updated every time that any API published by


### PR DESCRIPTION
The author fixed the issue that forced us to peg to v0.1.1.
Once this is merged, Renovate will send update PRs for it again.