### PR TITLE
chore: Update module bmatcuk/doublestar to v2.0.0.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.13
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.8
-	github.com/bmatcuk/doublestar v1.3.1
+	github.com/bmatcuk/doublestar/v2 v2.0.0
 	github.com/gertd/go-pluralize v0.1.7
 	github.com/golang/protobuf v1.4.2
 	github.com/google/go-cmp v0.5.1

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,8 @@ cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMT
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/bmatcuk/doublestar v1.3.1 h1:rT8rxDPsavp9G+4ZULzqhhUSaI/OPsTZNG88Z3i0xvY=
 github.com/bmatcuk/doublestar v1.3.1/go.mod h1:wiQtGV+rzVYxB7WIlirSN++5HPtPlXEo9MEoZQC/PmE=
+github.com/bmatcuk/doublestar/v2 v2.0.0 h1:G6Tb0DmBWsw7z6wYMzbPYcQh0iGqpOS+x/Snj6wXW8w=
+github.com/bmatcuk/doublestar/v2 v2.0.0/go.mod h1:QMmcs3H2AUQICWhfzLXz+IYln8lRQmTZRptLie8RgRw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/creachadair/staticfile v0.1.2/go.mod h1:a3qySzCIXEprDGxk6tSxSI+dBBdLzqeBOMhZ+o2d3pM=

--- a/lint/config.go
+++ b/lint/config.go
@@ -23,7 +23,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/bmatcuk/doublestar"
+	"github.com/bmatcuk/doublestar/v2"
 	"gopkg.in/yaml.v2"
 )
 


### PR DESCRIPTION
Closes #588. (Renovate was not able to automate this one.)