### PR TITLE
fix: Permit top-level resources to have batch methods.

### DIFF
--- a/rules/aip0136/http_uri_suffix.go
+++ b/rules/aip0136/http_uri_suffix.go
@@ -51,13 +51,12 @@ var uriSuffix = &lint.MethodRule{
 			// There are some known exceptions, particularly around "Batch".
 			// ----------------------------------------------------------------------
 			// If the URI contains `{name=` or `{parent=`, expect `:verb`.
-			if strings.Contains(httpRule.URI, "{name=") || strings.Contains(httpRule.URI, "{parent=") {
+			if strings.Contains(httpRule.URI, ":batch") {
 				rpcSlice := strings.Split(strcase.SnakeCase(m.GetName()), "_")
-				if rpcSlice[0] == "batch" {
-					want = ":" + strcase.LowerCamelCase(rpcSlice[0]+"_"+rpcSlice[1])
-				} else {
-					want = ":" + rpcSlice[0]
-				}
+				want = ":" + strcase.LowerCamelCase(rpcSlice[0]+"_"+rpcSlice[1])
+			} else if strings.Contains(httpRule.URI, "{name=") || strings.Contains(httpRule.URI, "{parent=") {
+				rpcSlice := strings.Split(strcase.SnakeCase(m.GetName()), "_")
+				want = ":" + rpcSlice[0]
 			}
 
 			// AIP-162 introduces some special cases around revisions, where

--- a/rules/aip0231/aip0231.go
+++ b/rules/aip0231/aip0231.go
@@ -32,8 +32,8 @@ func AddRules(r lint.RuleRegistry) error {
 		outputName,
 		httpBody,
 		httpVerb,
-		parentField,
 		namesField,
+		requestParentField,
 		resourceField,
 		uriSuffix,
 	)

--- a/rules/aip0231/request_parent_field.go
+++ b/rules/aip0231/request_parent_field.go
@@ -16,17 +16,41 @@ package aip0231
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
+	"github.com/stoewer/go-strcase"
 )
 
 // The Batch Get request message should have parent field.
-var parentField = &lint.MessageRule{
-	Name:   lint.NewRuleName(231, "request-parent-field"),
-	OnlyIf: isBatchGetRequestMessage,
+var requestParentField = &lint.MessageRule{
+	Name: lint.NewRuleName(231, "request-parent-field"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		// Sanity check: If the resource has a pattern, and that pattern
+		// contains only one variable, then a parent field is not expected.
+		//
+		// In order to parse out the pattern, we get the resource message
+		// from the response, then get the resource annotation from that,
+		// and then inspect the pattern there (oy!).
+		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchGet")
+		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchGet%sResponse", plural)); resp != nil {
+			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
+				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
+					for _, pattern := range resource.GetPattern() {
+						if strings.Count(pattern, "{") == 1 {
+							return false
+						}
+					}
+				}
+			}
+		}
+
+		return isBatchGetRequestMessage(m)
+	},
 	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
 		// Rule check: Establish that a `parent` field is present.
 		parentField := m.FindFieldByName("parent")

--- a/rules/aip0234/request_parent_field.go
+++ b/rules/aip0234/request_parent_field.go
@@ -16,23 +16,47 @@ package aip0234
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
+	"github.com/stoewer/go-strcase"
 )
 
 // The Batch Update request message should have parent field.
 var requestParentField = &lint.MessageRule{
-	Name:   lint.NewRuleName(234, "request-parent-field"),
-	OnlyIf: isBatchUpdateRequestMessage,
+	Name: lint.NewRuleName(234, "request-parent-field"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		// Sanity check: If the resource has a pattern, and that pattern
+		// contains only one variable, then a parent field is not expected.
+		//
+		// In order to parse out the pattern, we get the resource message
+		// from the response, then get the resource annotation from that,
+		// and then inspect the pattern there (oy!).
+		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchUpdate")
+		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchUpdate%sResponse", plural)); resp != nil {
+			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
+				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
+					for _, pattern := range resource.GetPattern() {
+						if strings.Count(pattern, "{") == 1 {
+							return false
+						}
+					}
+				}
+			}
+		}
+
+		return isBatchUpdateRequestMessage(m)
+	},
 	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
 		// Rule check: Establish that a `parent` field is present.
 		parentField := m.FindFieldByName("parent")
 		if parentField == nil {
 			return []lint.Problem{{
-				Message:    fmt.Sprintf(`Message %q has no "parent" field`, m.GetName()),
+				Message:    fmt.Sprintf("Message %q has no `parent` field.", m.GetName()),
 				Descriptor: m,
 			}}
 		}
@@ -40,7 +64,7 @@ var requestParentField = &lint.MessageRule{
 		// Rule check: Establish that the parent field is a string.
 		if parentField.GetType() != builder.FieldTypeString().GetType() {
 			return []lint.Problem{{
-				Message:    `"parent" field on Update request message must be a string`,
+				Message:    "`parent` field on Update request message must be a string.",
 				Descriptor: parentField,
 				Location:   locations.FieldType(parentField),
 				Suggestion: "string",


### PR DESCRIPTION
Also, I rewrote the tests for these rules from scratch, as they
were in a weird state.

Fixes #615.