### PR TITLE
feat: Add initial rules for AIP-235.

### DIFF
--- a/docs/rules/0235/http-body.md
+++ b/docs/rules/0235/http-body.md
@@ -1,0 +1,66 @@
+---
+rule:
+  aip: 235
+  name: [core, '0235', http-body]
+  summary: Batch Delete methods should use `*` as the HTTP body.
+permalink: /235/http-body
+redirect_from:
+  - /0235/http-body
+---
+
+# Batch Delete methods: HTTP body 
+
+This rule enforces that all `BatchDelete` RPCs use `*` as the HTTP `body`, as 
+mandated in [AIP-235][].
+
+## Details
+
+This rule looks at any RPC methods matching beginning with `BatchDelete`, and
+complains if HTTP `body` field is anything other than `*`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books:batchDelete"
+    body: ""  // The http body should be "*".
+  };
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books:batchDelete"
+    body: "*"
+  };
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0235::http-body=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books:batchDelete"
+  };
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-235]: https://aip.dev/235
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0235/http-method.md
+++ b/docs/rules/0235/http-method.md
@@ -1,0 +1,67 @@
+---
+rule:
+  aip: 235
+  name: [core, '0235', http-method]
+  summary: Batch Delete methods must use the POST HTTP verb.
+permalink: /235/http-method
+redirect_from:
+  - /0235/http-method
+---
+
+# Batch Delete methods: POST HTTP verb
+
+This rule enforces that all `BatchDelete` RPCs use the `POST` HTTP verb, as
+mandated in [AIP-235][].
+
+## Details
+
+This rule looks at any RPCs with the name beginning with `BatchDelete`, and
+complains if the HTTP verb is anything other than `POST`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    delete: "/v1/{parent=publishers/*}/books:batchDelete" // Should be `post:`.
+    body: "*"
+  };
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{parent=publishers/*}/books:batchDelete"
+    body: "*"
+  };
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0235::http-method=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    delete: "/v1/{parent=publishers/*}/books:batchDelete" // Should be `post:`.
+    body: "*"
+  };
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-235]: https://aip.dev/235
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0235/index.md
+++ b/docs/rules/0235/index.md
@@ -1,0 +1,11 @@
+---
+aip_listing: 235
+permalink: /235/
+redirect_from:
+  - /0235/
+prose_title: batch delete methods
+---
+
+# Batch methods: Delete
+
+{% include linter-aip-listing.md aip=235 %}

--- a/docs/rules/0235/request-message-name.md
+++ b/docs/rules/0235/request-message-name.md
@@ -1,0 +1,69 @@
+---
+rule:
+  aip: 235
+  name: [core, '0235', request-message-name]
+  summary: Batch Delete methods must have standardized request message names.
+permalink: /235/request-message-name
+redirect_from:
+  - /0235/request-message-name
+---
+
+# Batch Delete methods: Request message
+
+This rule enforces that all `BatchDelete` RPCs have a request message name of
+`BatchDelete*Request`, as mandated in [AIP-235][].
+
+## Details
+
+This rule looks at any message matching beginning with `BatchDelete`, and complains
+if the name of the corresponding input message does not match the name of the
+RPC with the suffix `Request` appended.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+// Should be `BatchDeleteBooksRequest`.
+rpc BatchDeleteBooks(Book) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:batchDelete"
+    body: "*"
+  };
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:batchDelete"
+    body: "*"
+  };
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0235::request-message-name=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+rpc BatchDeleteBooks(Book) returns (google.protobuf.Empty) {
+  option (google.api.http) = {
+    post: "/v1/{name=publishers/*/books/*}:batchDelete"
+    body: "*"
+  };
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-235]: https://aip.dev/235
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0235/aip0235.go
+++ b/rules/aip0235/aip0235.go
@@ -1,0 +1,41 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aip0235 contains rules defined in https://aip.dev/235.
+package aip0235
+
+import (
+	"regexp"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// AddRules accepts a register function and registers each of
+// this AIP's rules to it.
+func AddRules(r lint.RuleRegistry) error {
+	return r.Register(
+		235,
+		httpBody,
+		httpMethod,
+		requestMessageName,
+	)
+}
+
+var batchDeleteMethodRegexp = regexp.MustCompile("^BatchDelete(?:[A-Z]|$)")
+
+// Returns true if this is a AIP-235 Batch Delete method, false otherwise.
+func isBatchDeleteMethod(m *desc.MethodDescriptor) bool {
+	return batchDeleteMethodRegexp.MatchString(m.GetName())
+}

--- a/rules/aip0235/aip0235_test.go
+++ b/rules/aip0235/aip0235_test.go
@@ -1,0 +1,13 @@
+package aip0235
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+func TestAddRules(t *testing.T) {
+	if err := AddRules(lint.NewRuleRegistry()); err != nil {
+		t.Errorf("AddRules got an error: %v", err)
+	}
+}

--- a/rules/aip0235/http_body.go
+++ b/rules/aip0235/http_body.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Batch Delete methods should use "*" as the HTTP body.
+var httpBody = &lint.MethodRule{
+	Name:   lint.NewRuleName(235, "http-body"),
+	OnlyIf: isBatchDeleteMethod,
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		// Establish that the RPC has correct HTTP body.
+		for _, httpRule := range utils.GetHTTPRules(m) {
+			if httpRule.Body != "*" {
+				return []lint.Problem{{
+					Message:    `Batch Delete methods should use "*" as the HTTP body.`,
+					Descriptor: m,
+				}}
+			}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0235/http_body_test.go
+++ b/rules/aip0235/http_body_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"strings"
+	"testing"
+
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/jhump/protoreflect/desc/builder"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHttpBody(t *testing.T) {
+	tests := []struct {
+		testName   string
+		body       string
+		methodName string
+		msg        string
+	}{
+		{"Valid", "*", "BatchDeleteBooks", ""},
+		{"Invalid", "", "BatchDeleteBooks", "HTTP body"},
+		{"Irrelevant", "*", "AcquireBook", ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			// Create a MethodOptions with the annotation set.
+			opts := &dpb.MethodOptions{}
+			httpRule := &annotations.HttpRule{
+				Pattern: &annotations.HttpRule_Post{
+					Post: "/v1/{name=publishers/*/books/*}",
+				},
+				Body: test.body,
+			}
+			proto.SetExtension(opts, annotations.E_Http, httpRule)
+
+			// Create a minimal service with a AIP-235 Batch Delete method
+			// (or with a different method, in the "Irrelevant" case).
+			service, err := builder.NewService("Library").AddMethod(builder.NewMethod(test.methodName,
+				builder.RpcTypeMessage(builder.NewMessage("BatchDeleteBooksRequest"), false),
+				builder.RpcTypeMessage(builder.NewMessage("Book"), false),
+			).SetOptions(opts)).Build()
+			if err != nil {
+				t.Fatalf("Could not build %s method.", test.methodName)
+			}
+
+			// Run the method, ensure we get what we expect.
+			problems := httpBody.Lint(service.GetFile())
+			if test.msg == "" && len(problems) > 0 {
+				t.Errorf("Got %v, expected no problems.", problems)
+			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {
+				t.Errorf("Got %q, expected message containing %q", problems[0].Message, test.msg)
+			}
+		})
+	}
+}

--- a/rules/aip0235/http_method.go
+++ b/rules/aip0235/http_method.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Batch Delete methods should use the HTTP POST method.
+var httpMethod = &lint.MethodRule{
+	Name:   lint.NewRuleName(235, "http-method"),
+	OnlyIf: isBatchDeleteMethod,
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		// Rule check: Establish that the RPC uses HTTP POST.
+		for _, httpRule := range utils.GetHTTPRules(m) {
+			if httpRule.Method != "POST" {
+				return []lint.Problem{{
+					Message:    "Batch Delete methods must use the HTTP POST verb.",
+					Descriptor: m,
+				}}
+			}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0235/http_method_test.go
+++ b/rules/aip0235/http_method_test.go
@@ -1,0 +1,78 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"strings"
+	"testing"
+
+	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
+	"github.com/jhump/protoreflect/desc/builder"
+	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/proto"
+)
+
+func TestHttpMethod(t *testing.T) {
+	// Set up POST and DELETE HTTP annotations.
+	httpPost := &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Post{
+			Post: "/v1/{name=publishers/*/books/*}",
+		},
+	}
+	httpDelete := &annotations.HttpRule{
+		Pattern: &annotations.HttpRule_Delete{
+			Delete: "/v1/{name=publishers/*/books/*}",
+		},
+	}
+
+	// Set up testing permutations.
+	tests := []struct {
+		testName   string
+		httpRule   *annotations.HttpRule
+		methodName string
+		msg        string
+	}{
+		{"Valid", httpPost, "BatchDeleteBooks", ""},
+		{"Invalid", httpDelete, "BatchDeleteBooks", "HTTP POST"},
+		{"Irrelevant", httpPost, "AcquireBook", ""},
+	}
+
+	// Run each test.
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			// Create a MethodOptions with the annotation set.
+			opts := &dpb.MethodOptions{}
+			proto.SetExtension(opts, annotations.E_Http, test.httpRule)
+
+			// Create a minimal service with a AIP-235 Batch Delete method
+			// (or with a different method, in the "Irrelevant" case).
+			service, err := builder.NewService("Library").AddMethod(builder.NewMethod(test.methodName,
+				builder.RpcTypeMessage(builder.NewMessage("BatchDeleteBookRequests"), false),
+				builder.RpcTypeMessage(builder.NewMessage("Book"), false),
+			).SetOptions(opts)).Build()
+			if err != nil {
+				t.Fatalf("Could not build %s method.", test.methodName)
+			}
+
+			// Run the method, ensure we get what we expect.
+			problems := httpMethod.Lint(service.GetFile())
+			if test.msg == "" && len(problems) > 0 {
+				t.Errorf("Got %v, expected no problems.", problems)
+			} else if test.msg != "" && !strings.Contains(problems[0].Message, test.msg) {
+				t.Errorf("Got %q, expected message containing %q", problems[0].Message, test.msg)
+			}
+		})
+	}
+}

--- a/rules/aip0235/request_message_name.go
+++ b/rules/aip0235/request_message_name.go
@@ -1,0 +1,46 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"fmt"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Batch Delete messages should have a properly named Request message.
+var requestMessageName = &lint.MethodRule{
+	Name:   lint.NewRuleName(235, "request-message-name"),
+	OnlyIf: isBatchDeleteMethod,
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		// Rule check: Establish that for methods such as `BatchDeleteFoos`, the request
+		// message is named `BatchDeleteFoosRequest`.
+		if got, want := m.GetInputType().GetName(), m.GetName()+"Request"; got != want {
+			return []lint.Problem{{
+				Message: fmt.Sprintf(
+					"Batch Delete RPCs should have a request message named after the RPC, such as %q.",
+					want,
+				),
+				Suggestion: want,
+				Descriptor: m,
+				Location:   locations.MethodRequestType(m),
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0235/request_message_name_test.go
+++ b/rules/aip0235/request_message_name_test.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+	"github.com/jhump/protoreflect/desc/builder"
+)
+
+func TestRequestMessageName(t *testing.T) {
+	// Set up the testing permutations.
+	tests := []struct {
+		testName       string
+		methodName     string
+		reqMessageName string
+		problems       testutils.Problems
+	}{
+		{"Valid", "BatchDeleteBooks", "BatchDeleteBooksRequest", testutils.Problems{}},
+		{"Invalid", "BatchDeleteBooks", "Book", testutils.Problems{{Suggestion: "BatchDeleteBooksRequest"}}},
+		{"Irrelevant", "AcquireBook", "Book", testutils.Problems{}},
+	}
+
+	// Run each test individually.
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			// Create a minimal service with a AIP-235 Batch Delete method
+			// (or with a different method, in the "Irrelevant" case).
+			service, err := builder.NewService("Library").AddMethod(builder.NewMethod(test.methodName,
+				builder.RpcTypeMessage(builder.NewMessage(test.reqMessageName), false),
+				builder.RpcTypeMessage(builder.NewMessage("Book"), false),
+			)).Build()
+			if err != nil {
+				t.Fatalf("Could not build %s method.", test.methodName)
+			}
+
+			// Run the lint rule, and establish that it returns the expected problems.
+			problems := requestMessageName.Lint(service.GetFile())
+			if diff := test.problems.SetDescriptor(service.GetMethods()[0]).Diff(problems); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -82,6 +82,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0231"
 	"github.com/googleapis/api-linter/rules/aip0233"
 	"github.com/googleapis/api-linter/rules/aip0234"
+	"github.com/googleapis/api-linter/rules/aip0235"
 )
 
 type addRulesFuncType func(lint.RuleRegistry) error
@@ -118,6 +119,7 @@ var aipAddRulesFuncs = []addRulesFuncType{
 	aip0231.AddRules,
 	aip0233.AddRules,
 	aip0234.AddRules,
+	aip0235.AddRules,
 }
 
 // Add all rules to the given registry.


### PR DESCRIPTION
These are adapted from AIP-135 and AIP-231.

We still need lints for the following, and possibly others, for #612:
- request URI
- request message resource reference
- request message unknown fields
- response message