### PR TITLE
Add rules for batch-request names-field annotations

### DIFF
--- a/docs/rules/0231/request-names-behavior.md
+++ b/docs/rules/0231/request-names-behavior.md
@@ -1,0 +1,69 @@
+---
+rule:
+  aip: 231
+  name: [core, '0231', request-names-behavior]
+  summary: |
+    Batch Get requests should annotate the `names` field with `google.api.field_behavior`.
+permalink: /231/request-names-behavior
+redirect_from:
+  - /0231/request-names-behavior
+---
+
+# Batch Get methods: Field behavior
+
+This rule enforces that all `BatchGet` requests have
+`google.api.field_behavior` set to `REQUIRED` on their `repeated string names` field, as
+mandated in [AIP-231][].
+
+## Details
+
+This rule looks at any message matching `BatchGet*Request` and complains if the
+`names` field does not have a `google.api.field_behavior` annotation with a
+value of `REQUIRED`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message BatchGetBooksRequest {
+  // The `google.api.field_behavior` annotation should also be included.
+  repeated string names = 1 [(google.api.resource_reference) = {
+    type: "library.googleapis.com/Book"
+  }];
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message BatchGetBooksRequest {
+  repeated string names = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message BatchGetBooksRequest {
+  // (-- api-linter: core::0231::request-names-behavior=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  repeated string names = 1 [(google.api.resource_reference) = {
+    type: "library.googleapis.com/Book"
+  }];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-231]: https://aip.dev/231
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0231/request-names-reference.md
+++ b/docs/rules/0231/request-names-reference.md
@@ -1,0 +1,64 @@
+---
+rule:
+  aip: 231
+  name: [core, '0231', request-names-reference]
+  summary: |
+    Batch Get requests should annotate the `names` field with `google.api.resource_reference`.
+permalink: /231/request-names-reference
+redirect_from:
+  - /0231/request-names-reference
+---
+
+# Batch Get methods: Resource reference
+
+This rule enforces that all `BatchGet` requests have
+`google.api.resource_reference` on their `repeated string names` field, as mandated in
+[AIP-231][].
+
+## Details
+
+This rule looks at the `names` field of any message matching `BatchGet*Request` and
+complains if it does not have a `google.api.resource_reference` annotation.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message BatchGetBooksRequest {
+  // The `google.api.resource_reference` annotation should also be included.
+  repeated string names = 1 [(google.api.field_behavior) = REQUIRED];
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message BatchGetBooksRequest {
+  repeated string names = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message BatchGetBooksRequest {
+  // (-- api-linter: core::0231::request-names-reference=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  repeated string names = 1 [(google.api.field_behavior) = REQUIRED];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-231]: https://aip.dev/231
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0235/request-names-behavior.md
+++ b/docs/rules/0235/request-names-behavior.md
@@ -1,0 +1,69 @@
+---
+rule:
+  aip: 235
+  name: [core, '0235', request-names-behavior]
+  summary: |
+    Batch Delete requests should annotate the `names` field with `google.api.field_behavior`.
+permalink: /235/request-names-behavior
+redirect_from:
+  - /0235/request-names-behavior
+---
+
+# Batch Delete methods: Field behavior
+
+This rule enforces that all `BatchDelete` requests have
+`google.api.field_behavior` set to `REQUIRED` on their `repeated string names` field, as
+mandated in [AIP-235][].
+
+## Details
+
+This rule looks at any message matching `BatchDelete*Request` and complains if the
+`names` field does not have a `google.api.field_behavior` annotation with a
+value of `REQUIRED`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message BatchDeleteBooksRequest {
+  // The `google.api.field_behavior` annotation should also be included.
+  repeated string names = 1 [(google.api.resource_reference) = {
+    type: "library.googleapis.com/Book"
+  }];
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message BatchDeleteBooksRequest {
+  repeated string names = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message BatchDeleteBooksRequest {
+  // (-- api-linter: core::0235::request-names-behavior=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  repeated string names = 1 [(google.api.resource_reference) = {
+    type: "library.googleapis.com/Book"
+  }];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-235]: https://aip.dev/235
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0235/request-names-reference.md
+++ b/docs/rules/0235/request-names-reference.md
@@ -1,0 +1,64 @@
+---
+rule:
+  aip: 235
+  name: [core, '0235', request-names-reference]
+  summary: |
+    Batch Delete requests should annotate the `names` field with `google.api.resource_reference`.
+permalink: /235/request-names-reference
+redirect_from:
+  - /0235/request-names-reference
+---
+
+# Batch Delete methods: Resource reference
+
+This rule enforces that all `BatchDelete` requests have
+`google.api.resource_reference` on their `repeated string names` field, as mandated in
+[AIP-235][].
+
+## Details
+
+This rule looks at the `names` field of any message matching `BatchDelete*Request` and
+complains if it does not have a `google.api.resource_reference` annotation.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message BatchDeleteBooksRequest {
+  // The `google.api.resource_reference` annotation should also be included.
+  repeated string names = 1 [(google.api.field_behavior) = REQUIRED];
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message BatchDeleteBooksRequest {
+  repeated string names = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message BatchDeleteBooksRequest {
+  // (-- api-linter: core::0235::request-names-reference=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  repeated string names = 1 [(google.api.field_behavior) = REQUIRED];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-235]: https://aip.dev/235
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0231/aip0231.go
+++ b/rules/aip0231/aip0231.go
@@ -33,6 +33,8 @@ func AddRules(r lint.RuleRegistry) error {
 		httpBody,
 		httpVerb,
 		namesField,
+		requestNamesBehavior,
+		requestNamesReference,
 		requestParentField,
 		resourceField,
 		uriSuffix,

--- a/rules/aip0231/request_names_behavior.go
+++ b/rules/aip0231/request_names_behavior.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0231
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var requestNamesBehavior = &lint.FieldRule{
+	Name: lint.NewRuleName(231, "request-names-behavior"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return isBatchGetRequestMessage(f.GetOwner()) && f.GetName() == "names"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if !utils.GetFieldBehavior(f).Contains("REQUIRED") {
+			return []lint.Problem{{
+				Message:    "Batch Get requests: The `names` field should include `(google.api.field_behavior) = REQUIRED`.",
+				Descriptor: f,
+			}}
+		}
+		return nil
+	},
+}

--- a/rules/aip0231/request_names_behavior_test.go
+++ b/rules/aip0231/request_names_behavior_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0231
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestRequestNamesBehavior(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		MessageName   string
+		FieldName     string
+		FieldBehavior string
+		problems      testutils.Problems
+	}{
+		{"Valid", "BatchGetBooks", "names", " [(google.api.field_behavior) = REQUIRED]", testutils.Problems{}},
+		{"Missing", "BatchGetBooks", "names", "", testutils.Problems{{Message: "(google.api.field_behavior) = REQUIRED"}}},
+		{"IrrelevantMessage", "GetBooks", "names", "", testutils.Problems{}},
+		{"IrrelevantField", "BatchGetBooks", "something_else", "", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/field_behavior.proto";
+				message {{.MessageName}}Request {
+					repeated string {{.FieldName}} = 1{{.FieldBehavior}};
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(requestNamesBehavior.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0231/request_names_reference.go
+++ b/rules/aip0231/request_names_reference.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0231
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var requestNamesReference = &lint.FieldRule{
+	Name: lint.NewRuleName(231, "request-names-reference"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return isBatchGetRequestMessage(f.GetOwner()) && f.GetName() == "names"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if ref := utils.GetResourceReference(f); ref == nil {
+			return []lint.Problem{{
+				Message:    "Batch Get methods: The `names` field should include a `google.api.resource_reference` annotation.",
+				Descriptor: f,
+			}}
+		}
+		return nil
+	},
+}

--- a/rules/aip0231/request_names_reference_test.go
+++ b/rules/aip0231/request_names_reference_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0231
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestRequestNamesReference(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		MessageName string
+		FieldName   string
+		FieldOpts   string
+		problems    testutils.Problems
+	}{
+		{"Valid", "BatchGetBooks", "names", ` [(google.api.resource_reference) = { type: "foo" }]`, testutils.Problems{}},
+		{"Missing", "BatchGetBooks", "names", "", testutils.Problems{{Message: "google.api.resource_reference"}}},
+		{"IrrelevantMessage", "GetBooks", "names", "", testutils.Problems{}},
+		{"IrrelevantField", "BatchGetBooks", "ids", "", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+				message {{.MessageName}}Request {
+					repeated string {{.FieldName}} = 1{{.FieldOpts}};
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(requestNamesReference.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0235/aip0235.go
+++ b/rules/aip0235/aip0235.go
@@ -32,13 +32,21 @@ func AddRules(r lint.RuleRegistry) error {
 		httpUriSuffix,
 		pluralMethodName,
 		requestMessageName,
+		requestNamesBehavior,
+		requestNamesReference,
 	)
 }
 
 var batchDeleteMethodRegexp = regexp.MustCompile("^BatchDelete(?:[A-Z]|$)")
+var batchDeleteReqMessageRegexp = regexp.MustCompile("^BatchDelete[A-Za-z0-9]*Request$")
 var batchDeleteURIRegexp = regexp.MustCompile(`:batchDelete$`)
 
 // Returns true if this is a AIP-235 Batch Delete method, false otherwise.
 func isBatchDeleteMethod(m *desc.MethodDescriptor) bool {
 	return batchDeleteMethodRegexp.MatchString(m.GetName())
+}
+
+// Returns true if this is an AIP-235 Batch Delete request message, false otherwise.
+func isBatchDeleteRequestMessage(m *desc.MessageDescriptor) bool {
+	return batchDeleteReqMessageRegexp.MatchString(m.GetName())
 }

--- a/rules/aip0235/request_names_behavior.go
+++ b/rules/aip0235/request_names_behavior.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var requestNamesBehavior = &lint.FieldRule{
+	Name: lint.NewRuleName(235, "request-names-behavior"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return isBatchDeleteRequestMessage(f.GetOwner()) && f.GetName() == "names"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if !utils.GetFieldBehavior(f).Contains("REQUIRED") {
+			return []lint.Problem{{
+				Message:    "Batch Delete requests: The `names` field should include `(google.api.field_behavior) = REQUIRED`.",
+				Descriptor: f,
+			}}
+		}
+		return nil
+	},
+}

--- a/rules/aip0235/request_names_behavior_test.go
+++ b/rules/aip0235/request_names_behavior_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestRequestNamesBehavior(t *testing.T) {
+	for _, test := range []struct {
+		name          string
+		MessageName   string
+		FieldName     string
+		FieldBehavior string
+		problems      testutils.Problems
+	}{
+		{"Valid", "BatchDeleteBooks", "names", " [(google.api.field_behavior) = REQUIRED]", testutils.Problems{}},
+		{"Missing", "BatchDeleteBooks", "names", "", testutils.Problems{{Message: "(google.api.field_behavior) = REQUIRED"}}},
+		{"IrrelevantMessage", "DeleteBooks", "names", "", testutils.Problems{}},
+		{"IrrelevantField", "BatchDeleteBooks", "something_else", "", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/field_behavior.proto";
+				message {{.MessageName}}Request {
+					repeated string {{.FieldName}} = 1{{.FieldBehavior}};
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(requestNamesBehavior.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0235/request_names_reference.go
+++ b/rules/aip0235/request_names_reference.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var requestNamesReference = &lint.FieldRule{
+	Name: lint.NewRuleName(235, "request-names-reference"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return isBatchDeleteRequestMessage(f.GetOwner()) && f.GetName() == "names"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if ref := utils.GetResourceReference(f); ref == nil {
+			return []lint.Problem{{
+				Message:    "Batch Delete methods: The `names` field should include a `google.api.resource_reference` annotation.",
+				Descriptor: f,
+			}}
+		}
+		return nil
+	},
+}

--- a/rules/aip0235/request_names_reference_test.go
+++ b/rules/aip0235/request_names_reference_test.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0235
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestRequestNamesReference(t *testing.T) {
+	for _, test := range []struct {
+		name        string
+		MessageName string
+		FieldName   string
+		FieldOpts   string
+		problems    testutils.Problems
+	}{
+		{"Valid", "BatchDeleteBooks", "names", ` [(google.api.resource_reference) = { type: "foo" }]`, testutils.Problems{}},
+		{"Missing", "BatchDeleteBooks", "names", "", testutils.Problems{{Message: "google.api.resource_reference"}}},
+		{"IrrelevantMessage", "DeleteBooks", "names", "", testutils.Problems{}},
+		{"IrrelevantField", "BatchDeleteBooks", "ids", "", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+				message {{.MessageName}}Request {
+					repeated string {{.FieldName}} = 1{{.FieldOpts}};
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(requestNamesReference.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
These annotations were added in https://github.com/aip-dev/google.aip.dev/pull/612.

Part of #612.