### PR TITLE
fix: Permit two-word top-level collections in the URI suffix.

### DIFF
--- a/rules/aip0136/http_uri_suffix.go
+++ b/rules/aip0136/http_uri_suffix.go
@@ -89,7 +89,7 @@ var uriSuffix = &lint.MethodRule{
 			plainURI := httpRule.GetPlainURI()
 			segs := strings.Split(strings.Split(plainURI, ":")[0], "/")
 			segment := segs[len(segs)-1]
-			if len(want) == 0 && strings.HasSuffix(strings.ToLower(n), segment) {
+			if len(want) == 0 && strings.HasSuffix(strings.ToLower(n), strings.ToLower(segment)) {
 				want = segment + ":" + strings.Split(strcase.SnakeCase(n), "_")[0]
 			}
 

--- a/rules/aip0136/http_uri_suffix_test.go
+++ b/rules/aip0136/http_uri_suffix_test.go
@@ -27,6 +27,7 @@ func TestURISuffix(t *testing.T) {
 		URI        string
 		problems   testutils.Problems
 	}{
+		{"ValidTwoWordNoParent", "SearchAudioBooks", "/v1/audioBooks:search", nil},
 		{"ValidVerb", "ArchiveBook", "/v1/{name=publishers/*/books}:archive", testutils.Problems{}},
 		{"ValidVerbNested", "ArchiveBook", "/v1/{book.name=publishers/*/books}:archive", testutils.Problems{}},
 		{"ValidVerbParent", "ImportBooks", "/v1/{parent=publishers/*}/books:import", testutils.Problems{}},


### PR DESCRIPTION
Another tweak to the perpetually-difficult `http-uri-suffix` rule from AIP-136.

Fixes #622.