### PR TITLE
refactor: Make separate IsDeclarativeFriendly methods for message and method.

### DIFF
--- a/rules/internal/utils/declarative_friendly.go
+++ b/rules/internal/utils/declarative_friendly.go
@@ -166,10 +166,7 @@ func findMethod(f *desc.FileDescriptor, name string) *desc.MethodDescriptor {
 // getServices finds all services in a file and all imports within the
 // same package.
 func getServices(f *desc.FileDescriptor) []*desc.ServiceDescriptor {
-	answer := []*desc.ServiceDescriptor{}
-	for _, s := range f.GetServices() {
-		answer = append(answer, s)
-	}
+	answer := f.GetServices()
 	for _, dep := range f.GetDependencies() {
 		if f.GetPackage() == dep.GetPackage() {
 			answer = append(answer, getServices(dep)...)


### PR DESCRIPTION
Otherwise they can not be sent to `OnlyIf`.
Additionally, support request messages (e.g. `CreateBookRequest`).