### PR TITLE
feat: Add `allow_missing` rule to AIP-134.

### DIFF
--- a/docs/rules/0134/request-allow-missing-field.md
+++ b/docs/rules/0134/request-allow-missing-field.md
@@ -1,0 +1,72 @@
+---
+rule:
+  aip: 134
+  name: [core, '0134', request-allow-missing-field]
+  summary: |
+    Update RPCs on declarative-friendly resources should include allow_missing.
+permalink: /134/request-allow-missing-field
+redirect_from:
+  - /0134/request-allow-missing-field
+---
+
+# Update methods: Allow missing
+
+This rule enforces that all `Update` standard methods for declarative-friendly
+resources ([AIP-128][]) have a `bool allow_missing` field, as mandated in
+[AIP-134][].
+
+## Details
+
+This rule looks at any message matching `Update*Request` and complains if the
+`bool allow_missing` field is not found.
+
+**Important:** This rule is only active if the corresponding resource is
+designated as declarative-friendly.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message UpdateBookRequest {
+  Book book = 1;
+  google.protobuf.FieldMask update_mask = 2;
+  // Needs `bool allow_missing`
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message UpdateBookRequest {
+  Book book = 1;
+  google.protobuf.FieldMask update_mask = 2;
+  bool allow_missing = 3;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0134::request-allow-missing-field=disabled
+//     aip.dev/not-precedent: We really need this field because reasons. --)
+message UpdateBookRequest {
+  Book book = 1;
+  google.protobuf.FieldMask update_mask = 2;
+}
+```
+
+**Note:** Violations of declarative-friendly rules should be rare, as tools are
+likely to expect strong consistency.
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-134]: https://aip.dev/134
+[aip-155]: https://aip.dev/155
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0134/request-unknown-fields.md
+++ b/docs/rules/0134/request-unknown-fields.md
@@ -19,6 +19,7 @@ This rule looks at any message matching `Update*Request` and complains if it
 comes across any fields other than:
 
 - `{Resource} {resource}` ([AIP-134][])
+- `bool allow_missing` ([AIP-134][])
 - `google.protobuf.FieldMask update_mask` ([AIP-134][])
 - `string request_id` ([AIP-155][])
 

--- a/rules/aip0134/aip0134.go
+++ b/rules/aip0134/aip0134.go
@@ -29,6 +29,7 @@ import (
 func AddRules(r lint.RuleRegistry) error {
 	return r.Register(
 		134,
+		allowMissing,
 		httpBody,
 		httpMethod,
 		httpNameField,

--- a/rules/aip0134/request_allow_missing_field.go
+++ b/rules/aip0134/request_allow_missing_field.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0134
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var allowMissing = &lint.MessageRule{
+	Name: lint.NewRuleName(134, "allow-missing"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		return isUpdateRequestMessage(m) && utils.IsDeclarativeFriendlyMessage(m)
+	},
+	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		for _, field := range m.GetFields() {
+			if field.GetName() == "allow_missing" && utils.GetTypeName(field) == "bool" {
+				return nil
+			}
+		}
+		return []lint.Problem{{
+			Descriptor: m,
+			Message:    "Update requests on declarative-friendly resources should include `bool allow_missing`.",
+		}}
+	},
+}

--- a/rules/aip0134/request_allow_missing_field.go
+++ b/rules/aip0134/request_allow_missing_field.go
@@ -21,7 +21,7 @@ import (
 )
 
 var allowMissing = &lint.MessageRule{
-	Name: lint.NewRuleName(134, "allow-missing"),
+	Name: lint.NewRuleName(134, "request-allow-missing-field"),
 	OnlyIf: func(m *desc.MessageDescriptor) bool {
 		return isUpdateRequestMessage(m) && utils.IsDeclarativeFriendlyMessage(m)
 	},

--- a/rules/aip0134/request_allow_missing_field_test.go
+++ b/rules/aip0134/request_allow_missing_field_test.go
@@ -21,6 +21,7 @@ import (
 )
 
 func TestAllowMissing(t *testing.T) {
+	problems := testutils.Problems{{Message: "include `bool allow_missing`"}}
 	for _, test := range []struct {
 		name         string
 		Style        string
@@ -29,7 +30,8 @@ func TestAllowMissing(t *testing.T) {
 	}{
 		{"IgnoredNotDF", "", "", nil},
 		{"ValidIncluded", "style: DECLARATIVE_FRIENDLY", "bool allow_missing = 2;", nil},
-		{"Invalid", "style: DECLARATIVE_FRIENDLY", "", testutils.Problems{{Message: "include `bool allow_missing`"}}},
+		{"Invalid", "style: DECLARATIVE_FRIENDLY", "", problems},
+		{"InvalidWrongType", "style: DECLARATIVE_FRIENDLY", "string allow_missing = 2;", problems},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0134/request_allow_missing_field_test.go
+++ b/rules/aip0134/request_allow_missing_field_test.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0134
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestAllowMissing(t *testing.T) {
+	for _, test := range []struct {
+		name         string
+		Style        string
+		AllowMissing string
+		problems     testutils.Problems
+	}{
+		{"IgnoredNotDF", "", "", nil},
+		{"ValidIncluded", "style: DECLARATIVE_FRIENDLY", "bool allow_missing = 2;", nil},
+		{"Invalid", "style: DECLARATIVE_FRIENDLY", "", testutils.Problems{{Message: "include `bool allow_missing`"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				service Library {
+					rpc UpdateBook(UpdateBookRequest) returns (Book);
+				}
+
+				message UpdateBookRequest {
+					Book book = 1;
+					{{.AllowMissing}}
+				}
+
+				message Book {
+					option (google.api.resource) = {
+						type: "library.googleapis.com/Book"
+						{{.Style}}
+					};
+				}
+			`, test)
+			m := f.GetMessageTypes()[0]
+			if diff := test.problems.SetDescriptor(m).Diff(allowMissing.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0134/request_unknown_fields.go
+++ b/rules/aip0134/request_unknown_fields.go
@@ -31,6 +31,7 @@ var unknownFields = &lint.MessageRule{
 		// Rule check: Establish that there are no unexpected fields.
 		allowedFields := stringset.New(
 			fieldNameFromResource(resource), // AIP-134
+			"allow_missing",                 // AIP-134
 			"request_id",                    // AIP-155
 			"update_mask",                   // AIP-134
 			"validate_only",                 // AIP-163


### PR DESCRIPTION
Note: This rule applies to declarative-friendly resources only.