### PR TITLE
fix: Correct handling of top-level resources in parent-field lints

### DIFF
--- a/rules/aip0132/request_parent_required.go
+++ b/rules/aip0132/request_parent_required.go
@@ -24,7 +24,7 @@ var requestParentRequired = &lint.MessageRule{
 			// from the response, then get the resource annotation from that,
 			// and then inspect the pattern there (oy!).
 			plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "List")
-			if resp := m.GetFile().FindMessage(fmt.Sprintf("List%sResponse", plural)); resp != nil {
+			if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("List%sResponse", plural)); resp != nil {
 				if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 					if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 						for _, pattern := range resource.GetPattern() {

--- a/rules/aip0231/request_parent_field.go
+++ b/rules/aip0231/request_parent_field.go
@@ -31,7 +31,7 @@ var requestParentField = &lint.MessageRule{
 	Name: lint.NewRuleName(231, "request-parent-field"),
 	OnlyIf: func(m *desc.MessageDescriptor) bool {
 		// Sanity check: If the resource has a pattern, and that pattern
-		// contains no variables, then a parent field is not expected.
+		// contains only one variable, then a parent field is not expected.
 		//
 		// In order to parse out the pattern, we get the resource message
 		// from the response, then get the resource annotation from that,
@@ -41,7 +41,7 @@ var requestParentField = &lint.MessageRule{
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {
-						if strings.Count(pattern, "{") == 0 {
+						if strings.Count(pattern, "{") == 1 {
 							return false
 						}
 					}
@@ -64,7 +64,7 @@ var requestParentField = &lint.MessageRule{
 		// Rule check: Establish that the parent field is a string.
 		if parentField.GetType() != builder.FieldTypeString().GetType() {
 			return []lint.Problem{{
-				Message:    "`parent` field on Batch Get request message must be a string",
+				Message:    "`parent` field on create request message must be a string",
 				Suggestion: "string",
 				Descriptor: parentField,
 				Location:   locations.FieldType(parentField),

--- a/rules/aip0231/request_parent_field.go
+++ b/rules/aip0231/request_parent_field.go
@@ -37,7 +37,7 @@ var requestParentField = &lint.MessageRule{
 		// from the response, then get the resource annotation from that,
 		// and then inspect the pattern there (oy!).
 		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchGet")
-		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchGet%sResponse", plural)); resp != nil {
+		if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("BatchGet%sResponse", plural)); resp != nil {
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {

--- a/rules/aip0231/request_parent_field_test.go
+++ b/rules/aip0231/request_parent_field_test.go
@@ -24,19 +24,27 @@ import (
 func TestParentField(t *testing.T) {
 	for _, test := range []struct {
 		name     string
+		Package  string
 		RPC      string
 		Field    string
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchGetBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
-		{"Missing", "BatchGetBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchGetBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
-		{"IrrelevantNoParent", "BatchGetBooks", "", "books/{b}", nil},
+		{"Valid", "", "BatchGetBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "", "BatchGetBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "", "BatchGetBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "", "BatchGetBooks", "", "books/{b}", nil},
+
+		{"PackageValid", "package foo;", "BatchGetBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"PackageMissing", "package foo;", "BatchGetBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"PackageInvalidType", "package foo;", "BatchGetBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"PackageIrrelevantRPCName", "package foo;", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"PackageIrrelevantNoParent", "package foo;", "BatchGetBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				{{.Package}}
 				import "google/api/resource.proto";
 
 				service Library {
@@ -60,7 +68,7 @@ func TestParentField(t *testing.T) {
 				}
 			`, test)
 			var d desc.Descriptor = f.GetMessageTypes()[0]
-			if test.name == "InvalidType" {
+			if test.name == "InvalidType" || test.name == "PackageInvalidType" {
 				d = f.GetMessageTypes()[0].GetFields()[0]
 			}
 			if diff := test.problems.SetDescriptor(d).Diff(requestParentField.Lint(f)); diff != "" {

--- a/rules/aip0231/request_parent_field_test.go
+++ b/rules/aip0231/request_parent_field_test.go
@@ -29,11 +29,11 @@ func TestParentField(t *testing.T) {
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchGetBooks", "string parent = 1;", "publishers/{p}/books", nil},
-		{"Missing", "BatchGetBooks", "", "publishers/{p}/books", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchGetBooks", "int32 parent = 1;", "publishers/{p}/books", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books", nil},
-		{"IrrelevantNoParent", "BatchGetBooks", "", "books", nil},
+		{"Valid", "BatchGetBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "BatchGetBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "BatchGetBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "BatchGetBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0233/request_parent_field.go
+++ b/rules/aip0233/request_parent_field.go
@@ -37,7 +37,7 @@ var requestParentField = &lint.MessageRule{
 		// from the response, then get the resource annotation from that,
 		// and then inspect the pattern there (oy!).
 		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchCreate")
-		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchCreate%sResponse", plural)); resp != nil {
+		if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("BatchCreate%sResponse", plural)); resp != nil {
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {

--- a/rules/aip0233/request_parent_field.go
+++ b/rules/aip0233/request_parent_field.go
@@ -41,7 +41,7 @@ var requestParentField = &lint.MessageRule{
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {
-						if strings.Count(pattern, "{") == 0 {
+						if strings.Count(pattern, "{") == 1 {
 							return false
 						}
 					}
@@ -64,7 +64,7 @@ var requestParentField = &lint.MessageRule{
 		// Rule check: Establish that the parent field is a string.
 		if parentField.GetType() != builder.FieldTypeString().GetType() {
 			return []lint.Problem{{
-				Message:    "`parent` field on Batch Create request message must be a string.",
+				Message:    "`parent` field on create request message must be a string.",
 				Descriptor: parentField,
 				Location:   locations.FieldType(parentField),
 				Suggestion: "string",

--- a/rules/aip0233/request_parent_field_test.go
+++ b/rules/aip0233/request_parent_field_test.go
@@ -24,19 +24,27 @@ import (
 func TestParentField(t *testing.T) {
 	for _, test := range []struct {
 		name     string
+		Package  string
 		RPC      string
 		Field    string
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchCreateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
-		{"Missing", "BatchCreateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchCreateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
-		{"IrrelevantNoParent", "BatchCreateBooks", "", "books/{b}", nil},
+		{"Valid", "", "BatchCreateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "", "BatchCreateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "", "BatchCreateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "", "BatchCreateBooks", "", "books/{b}", nil},
+
+		{"PackageValid", "package foo;", "BatchCreateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"PackageMissing", "package foo;", "BatchCreateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"PackageInvalidType", "package foo;", "BatchCreateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"PackageIrrelevantRPCName", "package foo;", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"PackageIrrelevantNoParent", "package foo;", "BatchCreateBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				{{.Package}}
 				import "google/api/resource.proto";
 
 				service Library {
@@ -60,7 +68,7 @@ func TestParentField(t *testing.T) {
 				}
 			`, test)
 			var d desc.Descriptor = f.GetMessageTypes()[0]
-			if test.name == "InvalidType" {
+			if test.name == "InvalidType" || test.name == "PackageInvalidType" {
 				d = f.GetMessageTypes()[0].GetFields()[0]
 			}
 			if diff := test.problems.SetDescriptor(d).Diff(requestParentField.Lint(f)); diff != "" {

--- a/rules/aip0233/request_parent_field_test.go
+++ b/rules/aip0233/request_parent_field_test.go
@@ -29,11 +29,11 @@ func TestParentField(t *testing.T) {
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchCreateBooks", "string parent = 1;", "publishers/{p}/books", nil},
-		{"Missing", "BatchCreateBooks", "", "publishers/{p}/books", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchCreateBooks", "int32 parent = 1;", "publishers/{p}/books", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books", nil},
-		{"IrrelevantNoParent", "BatchCreateBooks", "", "books", nil},
+		{"Valid", "BatchCreateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "BatchCreateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "BatchCreateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "BatchCreateBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0234/request_parent_field.go
+++ b/rules/aip0234/request_parent_field.go
@@ -37,7 +37,7 @@ var requestParentField = &lint.MessageRule{
 		// from the response, then get the resource annotation from that,
 		// and then inspect the pattern there (oy!).
 		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchUpdate")
-		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchUpdate%sResponse", plural)); resp != nil {
+		if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("BatchUpdate%sResponse", plural)); resp != nil {
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {

--- a/rules/aip0234/request_parent_field.go
+++ b/rules/aip0234/request_parent_field.go
@@ -31,7 +31,7 @@ var requestParentField = &lint.MessageRule{
 	Name: lint.NewRuleName(234, "request-parent-field"),
 	OnlyIf: func(m *desc.MessageDescriptor) bool {
 		// Sanity check: If the resource has a pattern, and that pattern
-		// contains no variables, then a parent field is not expected.
+		// contains only one variable, then a parent field is not expected.
 		//
 		// In order to parse out the pattern, we get the resource message
 		// from the response, then get the resource annotation from that,
@@ -41,7 +41,7 @@ var requestParentField = &lint.MessageRule{
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {
-						if strings.Count(pattern, "{") == 0 {
+						if strings.Count(pattern, "{") == 1 {
 							return false
 						}
 					}
@@ -64,7 +64,7 @@ var requestParentField = &lint.MessageRule{
 		// Rule check: Establish that the parent field is a string.
 		if parentField.GetType() != builder.FieldTypeString().GetType() {
 			return []lint.Problem{{
-				Message:    "`parent` field on Batch Update request message must be a string.",
+				Message:    "`parent` field on Update request message must be a string.",
 				Descriptor: parentField,
 				Location:   locations.FieldType(parentField),
 				Suggestion: "string",

--- a/rules/aip0234/request_parent_field_test.go
+++ b/rules/aip0234/request_parent_field_test.go
@@ -29,11 +29,11 @@ func TestParentField(t *testing.T) {
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchUpdateBooks", "string parent = 1;", "publishers/{p}/books", nil},
-		{"Missing", "BatchUpdateBooks", "", "publishers/{p}/books", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchUpdateBooks", "int32 parent = 1;", "publishers/{p}/books", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books", nil},
-		{"IrrelevantNoParent", "BatchUpdateBooks", "", "books", nil},
+		{"Valid", "BatchUpdateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "BatchUpdateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "BatchUpdateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "BatchUpdateBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0234/request_parent_field_test.go
+++ b/rules/aip0234/request_parent_field_test.go
@@ -24,19 +24,27 @@ import (
 func TestParentField(t *testing.T) {
 	for _, test := range []struct {
 		name     string
+		Package  string
 		RPC      string
 		Field    string
 		Pattern  string
 		problems testutils.Problems
 	}{
-		{"Valid", "BatchUpdateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
-		{"Missing", "BatchUpdateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
-		{"InvalidType", "BatchUpdateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
-		{"IrrelevantRPCName", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
-		{"IrrelevantNoParent", "BatchUpdateBooks", "", "books/{b}", nil},
+		{"Valid", "", "BatchUpdateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"Missing", "", "BatchUpdateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"InvalidType", "", "BatchUpdateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"IrrelevantRPCName", "", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"IrrelevantNoParent", "", "BatchUpdateBooks", "", "books/{b}", nil},
+
+		{"PackageValid", "package foo;", "BatchUpdateBooks", "string parent = 1;", "publishers/{p}/books/{b}", nil},
+		{"PackageMissing", "package foo;", "BatchUpdateBooks", "", "publishers/{p}/books/{b}", testutils.Problems{{Message: "no `parent`"}}},
+		{"PackageInvalidType", "package foo;", "BatchUpdateBooks", "int32 parent = 1;", "publishers/{p}/books/{b}", testutils.Problems{{Suggestion: "string"}}},
+		{"PackageIrrelevantRPCName", "package foo;", "EnumerateBooks", "", "publishers/{p}/books/{b}", nil},
+		{"PackageIrrelevantNoParent", "package foo;", "BatchUpdateBooks", "", "books/{b}", nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				{{.Package}}
 				import "google/api/resource.proto";
 
 				service Library {
@@ -60,7 +68,7 @@ func TestParentField(t *testing.T) {
 				}
 			`, test)
 			var d desc.Descriptor = f.GetMessageTypes()[0]
-			if test.name == "InvalidType" {
+			if test.name == "InvalidType" || test.name == "PackageInvalidType" {
 				d = f.GetMessageTypes()[0].GetFields()[0]
 			}
 			if diff := test.problems.SetDescriptor(d).Diff(requestParentField.Lint(f)); diff != "" {

--- a/rules/aip0235/request_parent_field.go
+++ b/rules/aip0235/request_parent_field.go
@@ -37,7 +37,7 @@ var requestParentField = &lint.MessageRule{
 		// from the response, then get the resource annotation from that,
 		// and then inspect the pattern there (oy!).
 		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "BatchDelete")
-		if resp := m.GetFile().FindMessage(fmt.Sprintf("BatchDelete%sResponse", plural)); resp != nil {
+		if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("BatchDelete%sResponse", plural)); resp != nil {
 			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
 				if resource := utils.GetResource(paged.GetMessageType()); resource != nil {
 					for _, pattern := range resource.GetPattern() {


### PR DESCRIPTION
First, we revert commit 04d68971f51c68363ce75c5bf441a5c3d72b59dc: In #631 I mistakenly thought this was looking at the HTTP pattern, not the resource pattern.

Next, we fix #620.