### PR TITLE
feat: Add rule for UNORDERED_LIST field behavior

### DIFF
--- a/docs/rules/0203/unordered-list-repeated.md
+++ b/docs/rules/0203/unordered-list-repeated.md
@@ -1,0 +1,64 @@
+---
+rule:
+  aip: 203
+  name: [core, '0203', unordered-list-repeated]
+  summary: Only repeated fields may be annotated with `UNORDERED_LIST`.
+permalink: /203/optional
+redirect_from:
+  - /0203/optional
+---
+
+# Optional fields
+
+This rule enforces that only repeated fields, not singular ones, are annotated
+with `(google.api.field_behavior) = UNORDERED_LIST`, as mandated by [AIP-203][].
+
+## Details
+
+This rule looks at any field with a `(google.api.field_behavior) =
+UNORDERED_LIST` annotation and complains if it is not a repeated field.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+message Book {
+  // UNORDERED_LIST only applies to repeated fields.
+  string name = 1 [(google.api.field_behavior) = UNORDERED_LIST];
+
+  repeated string genres = 2 [(google.api.field_behavior) = UNORDERED_LIST];
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  string name = 1;
+
+  repeated string genres = 2 [(google.api.field_behavior) = UNORDERED_LIST];
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message Book {
+  // (-- api-linter: core::0203::unordered-list-repeated=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  string name = 1 [(google.api.field_behavior) = UNORDERED_LIST];
+
+  repeated string genres = 2 [(google.api.field_behavior) = UNORDERED_LIST];
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-203]: https://aip.dev/203
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/spf13/pflag v1.0.5
 	github.com/stoewer/go-strcase v1.2.0
-	google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4
+	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d
 	google.golang.org/protobuf v1.25.1-0.20200805231151-a709e31e5d12
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4 h1:J4dpx/41slnq1aogzUSTuBuvD7VXz7ZLkVpr32YgSlg=
 google.golang.org/genproto v0.0.0-20201209185603-f92720507ed4/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d h1:HV9Z9qMhQEsdlvxNFELgQ11RkMzO3CMkjEySjCtuLes=
+google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=

--- a/rules/aip0203/aip0203.go
+++ b/rules/aip0203/aip0203.go
@@ -36,6 +36,7 @@ func AddRules(r lint.RuleRegistry) error {
 		outputOnly,
 		required,
 		requiredAndOptional,
+		unorderedListRepeated,
 	)
 }
 

--- a/rules/aip0203/unordered_list_repeated.go
+++ b/rules/aip0203/unordered_list_repeated.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0203
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var unorderedListRepeated = &lint.FieldRule{
+	Name: lint.NewRuleName(203, "unordered-list-repeated"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return utils.GetFieldBehavior(f).Contains("UNORDERED_LIST")
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		if f.IsRepeated() {
+			return nil
+		}
+		return []lint.Problem{{
+			Message:    "The UNORDERED_LIST `google.api.field_behavior` annotation must not be applied to non-repeated fields.",
+			Descriptor: f,
+		}}
+	},
+}

--- a/rules/aip0203/unordered_list_repeated_test.go
+++ b/rules/aip0203/unordered_list_repeated_test.go
@@ -1,0 +1,65 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0203
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestUnorderedList(t *testing.T) {
+	testCases := []struct {
+		name     string
+		Field    string
+		problems testutils.Problems
+	}{
+		{
+			name:     "ValidSingularNoAnnotation",
+			Field:    `string title = 1;`,
+			problems: nil,
+		},
+		{
+			name:     "ValidRepeatedNoAnnotation",
+			Field:    `repeated string authors = 1;`,
+			problems: nil,
+		},
+		{
+			name:     "ValidRepeatedAnnotation",
+			Field:    `repeated string authors = 1 [(google.api.field_behavior) = UNORDERED_LIST];`,
+			problems: nil,
+		},
+		{
+			name:     "InvalidSingularAnnotation",
+			Field:    `string title = 1 [(google.api.field_behavior) = UNORDERED_LIST];`,
+			problems: testutils.Problems{{Message: "must not be applied to non-repeated fields"}},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/field_behavior.proto";
+				message Book {
+					{{.Field}}
+				}`, test)
+			f := file.GetMessageTypes()[0].GetFields()[0]
+			problems := unorderedListRepeated.Lint(file)
+			if diff := test.problems.SetDescriptor(f).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
We update `go.mod` to pick up the corresponding changes to the field-behavior proto.