### PR TITLE
fix: Allow V1Main (version selector) in the C# namespace.

### DIFF
--- a/rules/aip0191/csharp_namespace.go
+++ b/rules/aip0191/csharp_namespace.go
@@ -68,4 +68,4 @@ var csharpNamespace = &lint.FileRule{
 }
 
 var csharpValidChars = regexp.MustCompile("^[A-Za-z0-9.]+$")
-var csharpVersionRegexp = regexp.MustCompile("[0-9]+(p[0-9]+)?(alpha|beta)")
+var csharpVersionRegexp = regexp.MustCompile("[0-9]+(p[0-9]+)?(alpha|beta|main)")

--- a/rules/aip0191/csharp_namespace_test.go
+++ b/rules/aip0191/csharp_namespace_test.go
@@ -29,6 +29,7 @@ func TestCsharpNamespace(t *testing.T) {
 	}{
 		{"Valid", "Google.Example.V1", nil},
 		{"ValidBeta", "Google.Example.V1Beta1", nil},
+		{"ValidMain", "Google.Example.V1Main", nil},
 		{"ValidPointBeta", "Google.Example.V1P1Beta1", nil},
 		{"InvalidBadChars", "Google:Example:V1", testutils.Problems{{Message: "Invalid characters"}}},
 		{"Invalid", "google.example.v1", testutils.Problems{{


### PR DESCRIPTION
Fixes #734.