### PR TITLE
feat: Add URI validation rule for AIP-127

### DIFF
--- a/docs/rules/0127/uri-validation.md
+++ b/docs/rules/0127/uri-validation.md
@@ -1,0 +1,66 @@
+---
+rule:
+  aip: 127
+  name: [core, '0127', uri-validation]
+  summary: HTTP URIs must have the proper format.
+permalink: /127/uri-validation
+redirect_from:
+  - /0127/uri-validation
+---
+
+# HTTP URI format
+
+This rule enforces that the URI in an HTTP annotation has the proper format.
+
+## Details
+
+This rule scans all methods that a `google.api.http` annotation is present on
+and complains if the URI format is invalid.
+
+## Examples
+
+### Missing forward slash prefix
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+rpc GetBook(GetBookRequest) returns (Book) {
+  option (google.api.http) = {
+    // Missing a forward slash at the beginning.
+    get: "v1/{name=publishers/*/books/*}"
+  };
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+rpc GetBook(GetBookRequest) returns (Book) {
+  option (google.api.http) = {
+    get: "/v1/{name=publishers/*/books/*}"
+  };
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0127::uri-validation=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+rpc GetBook(GetBookRequest) returns (Book) {
+    option (google.api.http) = {
+    get: "v1/{name=publishers/*/books/*}"
+  };
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-127]: https://aip.dev/127
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0127/uri_validation.go
+++ b/rules/aip0127/uri_validation.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rules/aip0127/uri_validation.go
+++ b/rules/aip0127/uri_validation.go
@@ -12,19 +12,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0127 contains rules defined in https://aip.dev/127.
 package aip0127
 
 import (
+	"strings"
+
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
 )
 
-// AddRules adds all of the AIP-127 rules to the provided registry.
-func AddRules(r lint.RuleRegistry) error {
-	return r.Register(
-		127,
-		hasAnnotation,
-		resourceNameExtraction,
-		uriValidation,
-	)
+var uriValidation = &lint.MethodRule{
+	Name: lint.NewRuleName(127, "uri-validation"),
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		for _, rule := range utils.GetHTTPRules(m) {
+			if !strings.HasPrefix(rule.URI, "/") {
+				return []lint.Problem{{
+					Message:    `URI must begin with a "/".`,
+					Descriptor: m,
+					Location:   locations.MethodHTTPRule(m),
+				}}
+			}
+		}
+		return nil
+	},
 }

--- a/rules/aip0127/uri_validation_test.go
+++ b/rules/aip0127/uri_validation_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rules/aip0127/uri_validation_test.go
+++ b/rules/aip0127/uri_validation_test.go
@@ -1,0 +1,53 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0127
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestURIValidation(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		uri      string
+		problems testutils.Problems
+	}{
+		{"Valid", "/v1/{name=publishers/*/books/*}", testutils.Problems{}},
+		{"Invalid", "v1/{name=publishers/*/books/*}", testutils.Problems{{Message: "URI must begin"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3String(t, strings.ReplaceAll(`
+				import "google/api/annotations.proto";
+				service Library {
+					rpc GetBook(GetBookRequest) returns (Book) {
+						option (google.api.http) = {
+							get: "{{.URI}}"
+						};
+					}
+				}
+				message GetBookRequest {}
+				message Book {}
+			`, "{{.URI}}", test.uri))
+			method := f.GetServices()[0].GetMethods()[0]
+			problems := uriValidation.Lint(f)
+			if diff := test.problems.SetDescriptor(method).Diff(problems); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a simple check that the google.api.http URI starts with a "/".