### PR TITLE
fix: Make the required and optional rules less noisy.

### DIFF
--- a/rules/aip0203/immutable.go
+++ b/rules/aip0203/immutable.go
@@ -23,11 +23,9 @@ import (
 )
 
 var immutable = &lint.FieldRule{
-	Name:   lint.NewRuleName(203, "immutable"),
-	OnlyIf: withoutImmutableFieldBehavior,
-	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		return checkLeadingComments(f, immutableRegexp, "IMMUTABLE")
-	},
+	Name:      lint.NewRuleName(203, "immutable"),
+	OnlyIf:    withoutImmutableFieldBehavior,
+	LintField: checkLeadingComments(immutableRegexp, "IMMUTABLE"),
 }
 
 var immutableRegexp = regexp.MustCompile("(?i).*immutable.*")

--- a/rules/aip0203/input_only.go
+++ b/rules/aip0203/input_only.go
@@ -23,11 +23,9 @@ import (
 )
 
 var inputOnly = &lint.FieldRule{
-	Name:   lint.NewRuleName(203, "input-only"),
-	OnlyIf: withoutInputOnlyFieldBehavior,
-	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		return checkLeadingComments(f, inputOnlyRegexp, "INPUT_ONLY")
-	},
+	Name:      lint.NewRuleName(203, "input-only"),
+	OnlyIf:    withoutInputOnlyFieldBehavior,
+	LintField: checkLeadingComments(inputOnlyRegexp, "INPUT_ONLY"),
 }
 
 var inputOnlyRegexp = regexp.MustCompile("(?i).*input.?only.*")

--- a/rules/aip0203/optional.go
+++ b/rules/aip0203/optional.go
@@ -23,11 +23,9 @@ import (
 )
 
 var optional = &lint.FieldRule{
-	Name:   lint.NewRuleName(203, "optional"),
-	OnlyIf: withoutFieldBehavior,
-	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		return checkLeadingComments(f, optionalRegexp, "OPTIONAL")
-	},
+	Name:      lint.NewRuleName(203, "optional"),
+	OnlyIf:    withoutFieldBehavior,
+	LintField: checkLeadingComments(optionalRegexp, "OPTIONAL", requiredRegexp),
 }
 
 var optionalRegexp = regexp.MustCompile("(?i).*optional.*")

--- a/rules/aip0203/optional_test.go
+++ b/rules/aip0203/optional_test.go
@@ -51,6 +51,12 @@ func TestOptional(t *testing.T) {
 			}},
 		},
 		{
+			name:     "valid-required-and-optional",
+			comment:  "optional required",
+			field:    titleField,
+			problems: nil,
+		},
+		{
 			name:    "Invalid-Optional",
 			comment: "Optional",
 			field:   titleField,

--- a/rules/aip0203/output_only.go
+++ b/rules/aip0203/output_only.go
@@ -23,11 +23,9 @@ import (
 )
 
 var outputOnly = &lint.FieldRule{
-	Name:   lint.NewRuleName(203, "output-only"),
-	OnlyIf: withoutOutputOnlyFieldBehavior,
-	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		return checkLeadingComments(f, outputOnlyRegexp, "OUTPUT_ONLY")
-	},
+	Name:      lint.NewRuleName(203, "output-only"),
+	OnlyIf:    withoutOutputOnlyFieldBehavior,
+	LintField: checkLeadingComments(outputOnlyRegexp, "OUTPUT_ONLY"),
 }
 
 var outputOnlyRegexp = regexp.MustCompile("(?i).*output.?only.*")

--- a/rules/aip0203/required.go
+++ b/rules/aip0203/required.go
@@ -18,15 +18,12 @@ import (
 	"regexp"
 
 	"github.com/googleapis/api-linter/lint"
-	"github.com/jhump/protoreflect/desc"
 )
 
 var required = &lint.FieldRule{
-	Name:   lint.NewRuleName(203, "required"),
-	OnlyIf: withoutFieldBehavior,
-	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		return checkLeadingComments(f, requiredRegexp, "REQUIRED")
-	},
+	Name:      lint.NewRuleName(203, "required"),
+	OnlyIf:    withoutFieldBehavior,
+	LintField: checkLeadingComments(requiredRegexp, "REQUIRED", optionalRegexp),
 }
 
 var requiredRegexp = regexp.MustCompile("(?i).*required.*")


### PR DESCRIPTION
This commit makes those lint rules stop complaining if *both* the terms "required" and "optional" are present; this is a common occurrence when fields are conditionally required, which is a good reason to use the terms in comments without an annotation.

Fixes #759.