### PR TITLE
fix: Account for empty messages in AIP-158 response-plural-first-field rule

### DIFF
--- a/rules/aip0158/response_plural_first_field.go
+++ b/rules/aip0158/response_plural_first_field.go
@@ -22,8 +22,10 @@ import (
 )
 
 var responsePluralFirstField = &lint.MessageRule{
-	Name:   lint.NewRuleName(158, "response-plural-first-field"),
-	OnlyIf: isPaginatedResponseMessage,
+	Name: lint.NewRuleName(158, "response-plural-first-field"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		return isPaginatedResponseMessage(m) && len(m.GetFields()) > 0
+	},
 	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
 		// Throw a linter warning if, the first field in the message is not named
 		// according to plural(message_name.to_snake().split('_')[1:-1]).

--- a/rules/aip0158/response_plural_first_field_test.go
+++ b/rules/aip0158/response_plural_first_field_test.go
@@ -54,4 +54,14 @@ func TestResponsePluralFirstField(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("ValidNoFields", func(t *testing.T) {
+		f := testutils.ParseProto3Tmpl(t, `
+			message ListStudentProfilesResponse {}
+		`, nil)
+		problems := responsePluralFirstField.Lint(f)
+		if diff := (testutils.Problems{}).Diff(problems); diff != "" {
+			t.Error(diff)
+		}
+	})
 }


### PR DESCRIPTION
Fixes #769.