### PR TITLE
fix: Suppress AIP-132 rules for AIP-162 methods and messages

### DIFF
--- a/rules/aip0132/aip0132.go
+++ b/rules/aip0132/aip0132.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/aip0162"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -48,15 +49,15 @@ var listRespMessageRegexp = regexp.MustCompile("^List([A-Za-z0-9]*)Response$")
 
 // Return true if this is an AIP-132 List method, false otherwise.
 func isListMethod(m *desc.MethodDescriptor) bool {
-	return listMethodRegexp.MatchString(m.GetName())
+	return listMethodRegexp.MatchString(m.GetName()) && !aip0162.IsListRevisionsMethod(m)
 }
 
 // Return true if this is an AIP-132 List request message, false otherwise.
 func isListRequestMessage(m *desc.MessageDescriptor) bool {
-	return listReqMessageRegexp.MatchString(m.GetName())
+	return listReqMessageRegexp.MatchString(m.GetName()) && !aip0162.IsListRevisionsRequestMessage(m)
 }
 
 // Return true if this is an AIP-132 List response message, false otherwise.
 func isListResponseMessage(m *desc.MessageDescriptor) bool {
-	return listRespMessageRegexp.MatchString(m.GetName())
+	return listRespMessageRegexp.MatchString(m.GetName()) && !aip0162.IsListRevisionsResponseMessage(m)
 }

--- a/rules/aip0132/request_parent_required_test.go
+++ b/rules/aip0132/request_parent_required_test.go
@@ -16,6 +16,7 @@ func TestRequestParentRequired(t *testing.T) {
 		{"Valid", "ListBooksRequest", "parent", nil},
 		{"InvalidName", "ListBooksRequest", "publisher", testutils.Problems{{Message: "no `parent` field"}}},
 		{"Irrelevant", "EnumerateBooksRequest", "id", nil},
+		{"IrrelevantAIP162", "ListBookRevisionsRequest", "name", nil},
 	}
 
 	for _, test := range tests {

--- a/rules/aip0132/request_unknown_fields_test.go
+++ b/rules/aip0132/request_unknown_fields_test.go
@@ -47,6 +47,7 @@ func TestUnknownFields(t *testing.T) {
 		{"View", "ListBooksRequest", "view", builder.FieldTypeEnum(builder.NewEnum("View")), testutils.Problems{}},
 		{"Invalid", "ListBooksRequest", "application_id", builder.FieldTypeString(), testutils.Problems{{Message: "explicitly described"}}},
 		{"Irrelevant", "EnumerteBooksRequest", "application_id", builder.FieldTypeString(), testutils.Problems{}},
+		{"IrrelevantAIP162", "ListBookRevisionsRequest", "name", builder.FieldTypeString(), testutils.Problems{}},
 	}
 
 	// Run each test individually.

--- a/rules/aip0162/aip0162.go
+++ b/rules/aip0162/aip0162.go
@@ -120,3 +120,22 @@ func isDeleteRevisionMethod(m *desc.MethodDescriptor) bool {
 func isDeleteRevisionRequestMessage(m *desc.MessageDescriptor) bool {
 	return deleteRevisionReqMessageRegexp.MatchString(m.GetName())
 }
+
+var listRevisionsMethodRegexp = regexp.MustCompile(`^List(?:[A-Za-z0-9]+)Revisions$`)
+var listRevisionsReqMessageRegexp = regexp.MustCompile(`^List(?:[A-Za-z0-9]+)RevisionsRequest$`)
+var listRevisionsRespMessageRegexp = regexp.MustCompile(`^List(?:[A-Za-z0-9]+)RevisionsResponse$`)
+
+// Returns true if this is an AIP-162 List Revisions method, false otherwise.
+func IsListRevisionsMethod(m *desc.MethodDescriptor) bool {
+	return listRevisionsMethodRegexp.MatchString(m.GetName())
+}
+
+// Returns true if this is an AIP-162 List Revisions request message, false otherwise.
+func IsListRevisionsRequestMessage(m *desc.MessageDescriptor) bool {
+	return listRevisionsReqMessageRegexp.MatchString(m.GetName())
+}
+
+// Returns true if this is an AIP-162 List Revisions response message, false otherwise.
+func IsListRevisionsResponseMessage(m *desc.MessageDescriptor) bool {
+	return listRevisionsRespMessageRegexp.MatchString(m.GetName())
+}


### PR DESCRIPTION
Fixes #771.
Part of #721.