### PR TITLE
feat: add new --list-rules flag to output rules database list

### DIFF
--- a/cmd/api-linter/rules.go
+++ b/cmd/api-linter/rules.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"sort"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/olekukonko/tablewriter"
+)
+
+type (
+	listedRule struct {
+		Name lint.RuleName
+	}
+	listedRules       []listedRule
+	listedRulesByName []listedRule
+)
+
+func (a listedRulesByName) Len() int           { return len(a) }
+func (a listedRulesByName) Less(i, j int) bool { return a[i].Name < a[j].Name }
+func (a listedRulesByName) Swap(i, j int)      { a[i], a[j] = a[j], a[i] }
+
+func (r listedRules) printSummaryTable() ([]byte, error) {
+
+	var buf bytes.Buffer
+	table := tablewriter.NewWriter(&buf)
+	table.SetHeader([]string{"Rule Name"})
+	table.SetCaption(true, fmt.Sprintf("Total Rules: %d", len(r)))
+	for _, rule := range r {
+		table.Append([]string{
+			string(rule.Name),
+		})
+	}
+	table.Render()
+
+	return buf.Bytes(), nil
+}
+
+func outputRules(formatType string) error {
+
+	rules := listedRules{}
+	for id := range globalRules {
+		rules = append(rules, listedRule{
+			Name: id,
+		})
+	}
+
+	sort.Sort(listedRulesByName(rules))
+
+	// Determine the format for printing the results.
+	// YAML format is the default.
+	marshal := getOutputFormatFunc(formatType)
+
+	// Print the results.
+	b, err := marshal(rules)
+	if err != nil {
+		return err
+	}
+	w := os.Stdout
+	if _, err = w.Write(b); err != nil {
+		return err
+	}
+
+	return nil
+
+}


### PR DESCRIPTION
This is to address #768.  I'm more than happy to change the implementation but my goal here is to be able to extract information about how many rules the linter validates against so we can track our progress along enabling all the rules.  Example usage is below:

```bash
./api-linter --list-rules
./api-linter --list-rules --output-format yaml
./api-linter --list-rules --output-format yml
./api-linter --list-rules --output-format json | jq '.'
./api-linter --list-rules --output-format summary
```

Right now the most interesting metric I'm interested in is thi:

```bash
./api-linter --list-rules --output-format json | jq '. | length'
282
```

In perhaps a subsequent PR I would like to start including the URL to the rule as well but that information is an internal implementation detail right now that's not as easily accessible.

