### PR TITLE
feat: Add rule to suggest removing AIP-162 List Revisions request order_by fields

### DIFF
--- a/docs/rules/0162/list-revisions-request-no-order-by-field.md
+++ b/docs/rules/0162/list-revisions-request-no-order-by-field.md
@@ -1,0 +1,85 @@
+---
+rule:
+  aip: 162
+  name: [core, '0162', list-revisions-request-no-order-by-field]
+  summary: List Revisions requests should not have an `order_by` field.
+permalink: /162/list-revisions-request-no-order-by-field
+redirect_from:
+  - /0162/list-revisions-request-no-order-by-field
+---
+
+# List Revisions requests: No `order_by` field
+
+This rule enforces that List Revisions requests do not have a `string order_by`
+field, as mandated in [AIP-162][].
+
+## Details
+
+This rule looks at any message matching `List*RevisionsRequest` and complains if
+an `order_by` field is present, as revisions in the response must be ordered in
+reverse chronological order.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message ListBookRevisionsRequest {
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+
+  int32 page_size = 2;
+
+  string page_token = 3;
+
+  // Field should be removed.
+  string order_by = 4;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message ListBookRevisionsRequest {
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+
+  int32 page_size = 2;
+
+  string page_token = 3;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+message ListBookRevisionsRequest {
+  string name = 1 [
+    (google.api.field_behavior) = REQUIRED,
+    (google.api.resource_reference).type = "library.googleapis.com/Book"
+  ];
+
+  int32 page_size = 2;
+
+  string page_token = 3;
+
+  // (-- api-linter: core::0162::list-revisions-request-no-order-by-field=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
+  string order_by = 4;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-162]: https://aip.dev/162
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0162/aip0162.go
+++ b/rules/aip0162/aip0162.go
@@ -47,6 +47,7 @@ func AddRules(r lint.RuleRegistry) error {
 		listRevisionsHTTPURISuffix,
 		listRevisionsRequestMessageName,
 		listRevisionsRequestNameField,
+		listRevisionsRequestNoOrderByField,
 		listRevisionsResponseMessageName,
 		rollbackHTTPBody,
 		rollbackHTTPMethod,

--- a/rules/aip0162/list_revisions_request_no_order_by_field.go
+++ b/rules/aip0162/list_revisions_request_no_order_by_field.go
@@ -1,0 +1,34 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0162
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// List Revisions requests should not have an order_by field.
+var listRevisionsRequestNoOrderByField = &lint.FieldRule{
+	Name: lint.NewRuleName(162, "list-revisions-request-no-order-by-field"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return IsListRevisionsRequestMessage(f.GetOwner()) && f.GetName() == "order_by"
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		return []lint.Problem{{
+			Message:    "List Revisions requests should not contain an `order_by` field, as revisions must be ordered in reverse chronological order.",
+			Descriptor: f,
+		}}
+	},
+}

--- a/rules/aip0162/list_revisions_request_no_order_by_field_test.go
+++ b/rules/aip0162/list_revisions_request_no_order_by_field_test.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0162
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestListRevisionsRequestNoOrderByField(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		Message  string
+		Field    string
+		problems testutils.Problems
+	}{
+		{"Valid", "ListBookRevisionsRequest", "string name = 1;", nil},
+		{"Invalid", "ListBookRevisionsRequest", "string order_by = 1;", testutils.Problems{{Message: "not contain an `order_by`"}}},
+		{"IrrelevantMessage", "ListBooksRequest", "string order_by = 1;", nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				message {{.Message}} {
+					{{.Field}}
+				}
+			`, test)
+			d := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(d).Diff(listRevisionsRequestNoOrderByField.Lint(f)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
From https://google.aip.dev/162#listing-revisions:

> Revisions **must** be ordered in reverse chronological order. An `order_by` field **should not** be provided.

Part of #721.