### PR TITLE
Fixes 0203/unordered-list-repeated links

### DIFF
--- a/docs/rules/0203/unordered-list-repeated.md
+++ b/docs/rules/0203/unordered-list-repeated.md
@@ -3,12 +3,12 @@ rule:
   aip: 203
   name: [core, '0203', unordered-list-repeated]
   summary: Only repeated fields may be annotated with `UNORDERED_LIST`.
-permalink: /203/optional
+permalink: /203/unordered-list-repeated
 redirect_from:
-  - /0203/optional
+  - /0203/unordered-list-repeated
 ---
 
-# Optional fields
+# Repeated fields: Unordered
 
 This rule enforces that only repeated fields, not singular ones, are annotated
 with `(google.api.field_behavior) = UNORDERED_LIST`, as mandated by [AIP-203][].


### PR DESCRIPTION
Currently, 0203/unordered-list-repeated.md has the same permalink as 0203/optional.md

As a result, https://linter.aip.dev/203/optional displays information about UNORDERED_LIST instead of about OPTIONAL, and https://linter.aip.dev/203/unordered-list-repeated is a 404.