### PR TITLE
docs: Fix typo in core::0141::forbidden-types

### DIFF
--- a/docs/rules/0141/forbidden-types.md
+++ b/docs/rules/0141/forbidden-types.md
@@ -53,10 +53,10 @@ If you need to violate this rule, use a leading comment above the field.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto
-// (-- api-linter: core::0141::forbidden-types=disabled
-//     aip.dev/not-precedent: We need to do this because reasons. --)
 message Book {
   string name = 1;
+  // (-- api-linter: core::0141::forbidden-types=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
   uint32 page_count = 2;
 }
 ```

--- a/docs/rules/0141/forbidden-types.md
+++ b/docs/rules/0141/forbidden-types.md
@@ -49,7 +49,7 @@ message Book {
 
 ## Disabling
 
-If you need to violate this rule, use a leading comment above the message.
+If you need to violate this rule, use a leading comment above the field.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto

--- a/docs/rules/0141/forbidden-types.md
+++ b/docs/rules/0141/forbidden-types.md
@@ -49,7 +49,7 @@ message Book {
 
 ## Disabling
 
-If you need to violate this rule, use a leading comment above the method.
+If you need to violate this rule, use a leading comment above the message.
 Remember to also include an [aip.dev/not-precedent][] comment explaining why.
 
 ```proto


### PR DESCRIPTION
Though it's not clear to me whether the suppression comment should be added over the field or message.