### PR TITLE
fix: Do not require delete_time or uid fields for singleton resources

### DIFF
--- a/rules/aip0156/forbidden_methods.go
+++ b/rules/aip0156/forbidden_methods.go
@@ -31,7 +31,7 @@ var forbiddenMethods = &lint.MethodRule{
 		//
 		// For example:
 		//   publishers/*/books/* -- not a singleton, many books
-		//   publishers/*/settings -- a singleton; one settings object per book
+		//   publishers/*/settings -- a singleton; one settings object per publisher
 		for _, http := range utils.GetHTTPRules(m) {
 			if name, ok := http.GetVariables()["name"]; ok {
 				if !strings.HasSuffix(name, "*") {


### PR DESCRIPTION
Fixes #791.

We can add a new rule to *prevent* singleton resources from having `delete_time` and `uid` fields in a followup PR.