### PR TITLE
API Linter: In the rule docs, reference AIP links in a uniform way.

### DIFF
--- a/docs/rules/0123/resource-reference-type.md
+++ b/docs/rules/0123/resource-reference-type.md
@@ -65,4 +65,4 @@ message Book {
 
 Do not violate this rule; it will break several tools.
 
-[aip-123]: http://aip.dev/123
+[aip-123]: https://aip.dev/123

--- a/docs/rules/0126/unspecified.md
+++ b/docs/rules/0126/unspecified.md
@@ -11,7 +11,7 @@ redirect_from:
 # Enum unspecified value
 
 This rule enforces that all enums have a default unspecified value, as mandated
-in [AIP-126](http://aip.dev/126).
+in [AIP-126][].
 
 Because our APIs create automatically-generated client libraries, we need to
 consider languages that have varying behavior around default values. To avoid
@@ -69,4 +69,5 @@ enum Format {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-126]: https://aip.dev/126
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0126/upper-snake-values.md
+++ b/docs/rules/0126/upper-snake-values.md
@@ -11,7 +11,7 @@ redirect_from:
 # Upper snake case values
 
 This rule enforces that all enum values be in upper snake case, as mandated in
-[AIP-126](http://aip.dev/126).
+[AIP-126][].
 
 ## Details
 
@@ -55,3 +55,5 @@ enum Format {
 
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
+
+[aip-126]: https://aip.dev/126

--- a/docs/rules/0132/request-parent-field.md
+++ b/docs/rules/0132/request-parent-field.md
@@ -11,7 +11,7 @@ redirect_from:
 # List methods: Parent field
 
 This rule enforces that all `List` standard methods have a `string parent`
-field in the request message, as mandated in [AIP-132](http://aip.dev/132).
+field in the request message, as mandated in [AIP-132][].
 
 ## Details
 
@@ -61,4 +61,5 @@ message ListBooksRequest {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-132]: https://aip.dev/132
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0132/request-parent-required.md
+++ b/docs/rules/0132/request-parent-required.md
@@ -11,7 +11,7 @@ redirect_from:
 # List methods: Parent field
 
 This rule enforces that all `List` standard methods have a `string parent`
-field in the request message, as mandated in [AIP-132](http://aip.dev/132).
+field in the request message, as mandated in [AIP-132][].
 
 ## Details
 
@@ -61,4 +61,5 @@ message ListBooksRequest {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-132]: https://aip.dev/132
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0132/request-show-deleted-required.md
+++ b/docs/rules/0132/request-show-deleted-required.md
@@ -13,7 +13,7 @@ redirect_from:
 
 This rule enforces that all `List` standard methods have a `bool show_deleted`
 field in the request message if the resource supports soft delete, as mandated
-in [AIP-132](http://aip.dev/132).
+in [AIP-132][].
 
 ## Details
 
@@ -77,4 +77,5 @@ message ListBooksRequest {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-132]: https://aip.dev/132
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0133/request-parent-field.md
+++ b/docs/rules/0133/request-parent-field.md
@@ -11,7 +11,7 @@ redirect_from:
 # Create methods: Parent field
 
 This rule enforces that all `Create` standard methods have a `string parent`
-field in the request message, as mandated in [AIP-133](http://aip.dev/133).
+field in the request message, as mandated in [AIP-133][].
 
 ## Details
 
@@ -61,4 +61,5 @@ message CreateBookRequest {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-133]: https://aip.dev/133
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0133/request-parent-required.md
+++ b/docs/rules/0133/request-parent-required.md
@@ -11,7 +11,7 @@ redirect_from:
 # Create methods: Parent field
 
 This rule enforces that all `Create` standard methods have a `string parent`
-field in the request message, as mandated in [AIP-133](http://aip.dev/133).
+field in the request message, as mandated in [AIP-133][].
 
 ## Details
 
@@ -61,4 +61,5 @@ message CreateBookRequest {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
+[aip-133]: https://aip.dev/133
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0140/prepositions.md
+++ b/docs/rules/0140/prepositions.md
@@ -61,5 +61,5 @@ message Book {
 If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
-[aip-136]: https://aip.dev/136
+[aip-140]: https://aip.dev/140
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0140/reserved-words.md
+++ b/docs/rules/0140/reserved-words.md
@@ -64,7 +64,7 @@ If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
 <!-- prettier-ignore-start -->
-[aip-136]: https://aip.dev/136
+[aip-140]: https://aip.dev/140
 [aip.dev/not-precedent]: https://aip.dev/not-precedent
 [the code]: https://github.com/googleapis/api-linter/blob/main/rules/aip0140/reserved_words.go
 <!-- prettier-ignore-end -->


### PR DESCRIPTION
Specifically, this:

  * Changes remaining direct links (e.g. `[AIP-NNN](https://aip.dev/NNN)`)
    to the reference-style links (e.g.  `[AIP-NNN][]`)
  * Updates a few existing `http` AIP links to `https`
  * Fixes a couple of incorrect references in the `0140` docs