### PR TITLE
fix: Prevent AIP-132 request-show-deleted-required rule from crashing on non-message fields

### DIFF
--- a/rules/aip0132/request_show_deleted_required.go
+++ b/rules/aip0132/request_show_deleted_required.go
@@ -22,7 +22,7 @@ var requestShowDeletedRequired = &lint.MessageRule{
 		// from the corresponding response message.
 		plural := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Request"), "List")
 		if resp := utils.FindMessage(m.GetFile(), fmt.Sprintf("List%sResponse", plural)); resp != nil {
-			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil {
+			if paged := resp.FindFieldByName(strcase.SnakeCase(plural)); paged != nil && paged.GetMessageType() != nil {
 				singular := paged.GetMessageType().GetName()
 				return utils.FindMethod(m.GetFile(), "Undelete"+singular) != nil
 			}

--- a/rules/aip0132/request_show_deleted_required_test.go
+++ b/rules/aip0132/request_show_deleted_required_test.go
@@ -42,3 +42,17 @@ func TestRequestShowDeletedRequired(t *testing.T) {
 		})
 	}
 }
+
+// Regression test for https://github.com/googleapis/api-linter/issues/854.
+func TestRequestShowDeletedRequired_NonMessageType(t *testing.T) {
+	f := testutils.ParseProto3Tmpl(t, `
+		message ListBooksRequest {}
+		message ListBooksResponse {
+			repeated string books = 1;
+		}
+	`, nil)
+	problems := requestShowDeletedRequired.Lint(f)
+	if diff := (testutils.Problems{}).SetDescriptor(f.GetMessageTypes()[0]).Diff(problems); diff != "" {
+		t.Error(diff)
+	}
+}


### PR DESCRIPTION
Fixes #854