### PR TITLE
feat: add proto-package check to AIP-191

### DIFF
--- a/docs/rules/0191/proto-package.md
+++ b/docs/rules/0191/proto-package.md
@@ -1,0 +1,49 @@
+---
+rule:
+  aip: 191
+  name: [core, '0191', proto-package]
+  summary: Proto package must match the directory structure.
+permalink: /191/proto-package
+redirect_from:
+  - /0191/proto-package
+---
+
+# Protobuf Package
+
+This rule attempts to enforce that the proto package and the directory structure
+match, as mandated in [AIP-191][].
+
+## Details
+
+Accordig to the [Protobuf Style Guide][], the package name must correspond to
+the directory structure.
+
+This rule currently complains if the package and the directory structure do not
+correspond.
+
+## Examples
+
+**Incorrect** directory structures and proto packages for this rule:
+
+- `example/v1` `example.library.v1`
+- `example/library/v1` `example.librarian.v1`
+
+**Correct** directory structures and proto packages for this rule:
+
+- `example/library/v1` `example.library.v1`
+- `example/library/v1/types` `example.library.v1.types`
+
+## Disabling
+
+If you need to violate this rule, use a comment at the top of the file.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0191::proto-package=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+syntax = "proto3";
+```
+
+[aip-191]: https://aip.dev/191
+[aip.dev/not-precedent]: https://aip.dev/not-precedent
+[Protobuf Style Guide]: https://developers.google.com/protocol-buffers/docs/style#packages

--- a/rules/aip0191/aip0191.go
+++ b/rules/aip0191/aip0191.go
@@ -34,6 +34,7 @@ func AddRules(r lint.RuleRegistry) error {
 		javaOuterClassname,
 		javaPackage,
 		phpNamespace,
+		protoPkg,
 		rubyPackage,
 		syntax,
 	)

--- a/rules/aip0191/proto_package.go
+++ b/rules/aip0191/proto_package.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0191
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Protobuf package must match the directory structure.
+var protoPkg = &lint.FileRule{
+	Name: lint.NewRuleName(191, "proto-package"),
+	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
+		dir := filepath.Dir(f.GetName())
+		pkg := strings.ReplaceAll(f.GetPackage(), ".", "/")
+
+		if dir != "." && !strings.HasSuffix(dir, pkg) {
+			return []lint.Problem{{
+				Message:    "Proto package and directory structure mismatch: The proto package must match the proto directory structure.",
+				Descriptor: f,
+				Location:   locations.FilePackage(f),
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0191/proto_package_test.go
+++ b/rules/aip0191/proto_package_test.go
@@ -1,0 +1,48 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0191
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+	"github.com/jhump/protoreflect/desc/builder"
+)
+
+func TestProtoPkg(t *testing.T) {
+	tests := []struct {
+		testName string
+		filename string
+		pkg      string
+		problems testutils.Problems
+	}{
+		{"Valid", "google/example/library/v1/library.proto", "google.example.library.v1", testutils.Problems{}},
+		{"ValidSuffix", "other/parent/google/example/library/v1/library.proto", "google.example.library.v1", testutils.Problems{}},
+		{"InvalidPackage", "google/example/library/v1/library.proto", "google.library.v1", testutils.Problems{{Message: "directory structure"}}},
+		{"InvalidDirectory", "google/v1/library.proto", "google.example.library.v1", testutils.Problems{{Message: "directory structure"}}},
+		{"IgnoreRootDirectory", "library.proto", "google.example.library.v1", testutils.Problems{}},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			f, err := builder.NewFile(test.filename).SetPackageName(test.pkg).Build()
+			if err != nil {
+				t.Fatalf("Failed to build file.")
+			}
+			if diff := test.problems.SetDescriptor(f).Diff(protoPkg.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Checks that the proto package corresponds tot he directory structure of the proto file. If the proto file name is at the root, it is ignored. 