### PR TITLE
fix: Use OS-specific file separator in core::0191::proto-package rule

### DIFF
--- a/rules/aip0191/proto_package.go
+++ b/rules/aip0191/proto_package.go
@@ -28,7 +28,7 @@ var protoPkg = &lint.FileRule{
 	Name: lint.NewRuleName(191, "proto-package"),
 	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
 		dir := filepath.Dir(f.GetName())
-		pkg := strings.ReplaceAll(f.GetPackage(), ".", "/")
+		pkg := strings.ReplaceAll(f.GetPackage(), ".", string(filepath.Separator))
 
 		if dir != "." && !strings.HasSuffix(dir, pkg) {
 			return []lint.Problem{{

--- a/rules/aip0191/proto_package_test.go
+++ b/rules/aip0191/proto_package_test.go
@@ -38,10 +38,10 @@ func TestProtoPkg(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			f, err := builder.NewFile(test.filename).SetPackageName(test.pkg).Build()
 			if err != nil {
-				t.Fatalf("Failed to build file.")
+				t.Fatalf("Failed to build file: %s", err)
 			}
 			if diff := test.problems.SetDescriptor(f).Diff(protoPkg.Lint(f)); diff != "" {
-				t.Errorf(diff)
+				t.Error(diff)
 			}
 		})
 	}


### PR DESCRIPTION
Fixes #864.