### PR TITLE
build: upgrade to Go 1.17

### DIFF
--- a/.github/quality-checker/rule_documented.go
+++ b/.github/quality-checker/rule_documented.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func checkRuleDocumented(aip int, name string) []error {
 	// Ensure that the expected documentation file exists.
 	wantFile := fmt.Sprintf("docs/rules/%04d/%s.md", aip, name)
-	if _, err := ioutil.ReadFile(wantFile); err != nil {
+	if _, err := os.ReadFile(wantFile); err != nil {
 		return []error{fmt.Errorf("missing rule documentation: %s", wantFile)}
 	}
 	return nil

--- a/.github/quality-checker/rule_name.go
+++ b/.github/quality-checker/rule_name.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 
 	"github.com/stoewer/go-strcase"
@@ -26,7 +26,7 @@ func checkRuleName(aip int, name string) []error {
 	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
 
 	// Read in the file.
-	contentsBytes, err := ioutil.ReadFile(path)
+	contentsBytes, err := os.ReadFile(path)
 	if err != nil {
 		return []error{err}
 	}

--- a/.github/quality-checker/rule_registered.go
+++ b/.github/quality-checker/rule_registered.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -27,7 +27,7 @@ func checkRuleRegistered(aip int, name string) []error {
 	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
 
 	// Read in the file.
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return []error{err}
 	}
@@ -43,7 +43,7 @@ func checkRuleRegistered(aip int, name string) []error {
 
 	// Ensure this rule is registered within its AIP module file.
 	ruleVar := ruleMatch[1]
-	contents, err = ioutil.ReadFile(fmt.Sprintf("rules/aip%04d/aip%04d.go", aip, aip))
+	contents, err = os.ReadFile(fmt.Sprintf("rules/aip%04d/aip%04d.go", aip, aip))
 	if err != nil {
 		return []error{err}
 	}
@@ -52,7 +52,7 @@ func checkRuleRegistered(aip int, name string) []error {
 	}
 
 	// Ensure that the AIP itself is registered in `rules/rules.go`.
-	contents, err = ioutil.ReadFile("rules/rules.go")
+	contents, err = os.ReadFile("rules/rules.go")
 	if err != nil {
 		errata = append(errata, err)
 		return errata

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,13 +7,13 @@ on:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    container: golang:1.14
+    container: golang:1.17
     steps:
       - uses: actions/checkout@v2
       - run: go test -p 1 ./...
   lint:
     runs-on: ubuntu-latest
-    container: golang:1.14
+    container: golang:1.17
     steps:
       - uses: actions/checkout@v2
       - name: Install golangci-lint
@@ -22,7 +22,7 @@ jobs:
         run: golangci-lint run ./...
   quality-checker:
     runs-on: ubuntu-latest
-    container: golang:1.14-alpine
+    container: golang:1.17-alpine
     steps:
       - uses: actions/checkout@v2
       - name: Run the quality checker (which catches obvious mistakes, missing docs, etc.)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   inspect:
     runs-on: ubuntu-latest
-    container: golang:1.14
+    container: golang:1.17
     steps:
       - uses: actions/checkout@v2
         with:
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: "1.14"
+          go-version: "1.17"
       - uses: actions/checkout@v2
       # The API linter does not use these,  but we need them to build the
       # binaries.

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -237,7 +236,7 @@ func loadFileDescriptors(filePaths ...string) (map[string]*desc.FileDescriptor, 
 }
 
 func readFileDescriptorSet(filePath string) (*dpb.FileDescriptorSet, error) {
-	in, err := ioutil.ReadFile(filePath)
+	in, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,11 +198,7 @@ func runLinter(t *testing.T, protoContent, configContent string) string {
 }
 
 func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string, appendArgs []string) (bool, string) {
-	tempDir, err := ioutil.TempDir("", "test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempDir)
+	tempDir := t.TempDir()
 
 	// Prepare command line flags.
 	args := []string{}
@@ -238,7 +233,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 		t.Fatal(lintErr)
 	}
 
-	out, err := ioutil.ReadFile(outPath)
+	out, err := os.ReadFile(outPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,5 +248,5 @@ func writeFile(path, content string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, []byte(content), 0644)
+	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/api-linter
 
-go 1.13
+go 1.17
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.10
@@ -16,4 +16,12 @@ require (
 	google.golang.org/genproto v0.0.0-20211223182754-3ac035c7e7cb
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/mattn/go-runewidth v0.0.9 // indirect
+	golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4 // indirect
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	google.golang.org/grpc v1.40.0 // indirect
 )

--- a/lint/config.go
+++ b/lint/config.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func ReadConfigsFromFile(path string) (Configs, error) {
 
 // ReadConfigsJSON reads Configs from a JSON file.
 func ReadConfigsJSON(f io.Reader) (Configs, error) {
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +77,7 @@ func ReadConfigsJSON(f io.Reader) (Configs, error) {
 
 // ReadConfigsYAML reads Configs from a JSON file.
 func ReadConfigsYAML(f io.Reader) (Configs, error) {
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -16,7 +16,6 @@ package lint
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -423,12 +422,9 @@ func TestReadConfigsFromFile(t *testing.T) {
 }
 
 func createTempFile(t *testing.T, name, content string) string {
-	dir, err := ioutil.TempDir("", "config_tests")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	filePath := filepath.Join(dir, name)
-	if err := ioutil.WriteFile(filePath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 	return filePath


### PR DESCRIPTION
1. Update the go directive in `go.mod` to 1.17
2. Update GitHub workflows to use Go 1.17
3. Replace the existing `io/ioutil` functions with their new definitions in `io` and `os` packages. The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil).

No breaking changes. Everything should still work as expected.