### PR TITLE
fix(AIP-126): allow first enum value UNKNOWN

### DIFF
--- a/rules/aip0126/unspecified_test.go
+++ b/rules/aip0126/unspecified_test.go
@@ -29,9 +29,9 @@ func TestUnspecified(t *testing.T) {
 	}{
 		{"Valid", "BookFormat", "BOOK_FORMAT_UNSPECIFIED", testutils.Problems{}},
 		{"ValidWithNum", "Ipv6Format", "IPV6_FORMAT_UNSPECIFIED", nil},
+		{"ValidUnknown", "BookFormat", "UNKNOWN", nil},
 		{"InvalidNoPrefix", "BookFormat", "UNSPECIFIED", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
 		{"InvalidWrongSuffix", "BookFormat", "BOOK_FORMAT_UNKNOWN", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
-		{"InvalidJustWrong", "BookFormat", "UNKNOWN", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
 		{"InvalidWithNum", "Ipv6Format", "IPV6FORMAT_UNSPECIFIED", testutils.Problems{{Suggestion: "IPV6_FORMAT_UNSPECIFIED"}}},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #871 by allowing `UNKNOWN` as the first value in an enum.

Note: If this rule emits a problem, it will suggest using the `_UNSPECIFIED` format for the first value and not `UNKNOWN`. Using `UNKNOWN` is an exception for a specific case and that should be discussed with reviewers/referenced from the AIP.