### PR TITLE
chore(release-tool): allow commits to have a scope

### DIFF
--- a/.github/release-tool/changelog.go
+++ b/.github/release-tool/changelog.go
@@ -35,6 +35,9 @@ func newCommit(line string) *commit {
 			breaking = true
 			cat = strings.TrimSuffix(cat, "!")
 		}
+		if scope := strings.Index(cat, "("); scope != -1 {
+			cat = cat[:scope]
+		}
 		msg = strings.TrimSpace(lineSplit[1])
 	} else {
 		cat = "unknown"


### PR DESCRIPTION
Updates release-tool to parse out commit scopes when determining the category. This allows a commit message like `fix(AIP-161): foo bar bz` to be viewed as a `fix`. Tested locally.

Note: this repo may want to be moved to release-please