### PR TITLE
Exclude Delete{Resource}Revision methods from AIP-135 checks.

### DIFF
--- a/rules/aip0135/aip0135.go
+++ b/rules/aip0135/aip0135.go
@@ -45,10 +45,11 @@ func AddRules(r lint.RuleRegistry) error {
 
 var deleteMethodRegexp = regexp.MustCompile("^Delete(?:[A-Z]|$)")
 var deleteReqMessageRegexp = regexp.MustCompile("^Delete[A-Za-z0-9]*Request$")
+var deleteRevisionMethodRegexp = regexp.MustCompile("^Delete[A-Za-z0-9]*Revision$")
 
 // Returns true if this is a AIP-135 Delete method, false otherwise.
 func isDeleteMethod(m *desc.MethodDescriptor) bool {
-	return deleteMethodRegexp.MatchString(m.GetName())
+	return deleteMethodRegexp.MatchString(m.GetName()) && !deleteRevisionMethodRegexp.MatchString(m.GetName())
 }
 
 // Returns true if this is an AIP-135 Delete request message, false otherwise.


### PR DESCRIPTION
These are governed by AIP-162 and have different (conflicting) requirements for their return values.

Fixes #888 