### PR TITLE
fix: ignore oneof fields optional consistency

### DIFF
--- a/rules/aip0203/optional_consistency.go
+++ b/rules/aip0203/optional_consistency.go
@@ -21,13 +21,13 @@ import (
 )
 
 // If a message has a field which is described as optional, ensure that every
-// optional field on the message has this indicator.
+// optional field on the message has this indicator. Oneof fields do not count.
 var optionalBehaviorConsistency = &lint.MessageRule{
 	Name:   lint.NewRuleName(203, "optional-consistency"),
 	OnlyIf: messageHasOptionalFieldBehavior,
 	LintMessage: func(m *desc.MessageDescriptor) (problems []lint.Problem) {
 		for _, f := range m.GetFields() {
-			if utils.GetFieldBehavior(f).Len() == 0 {
+			if utils.GetFieldBehavior(f).Len() == 0 && f.GetOneOf() == nil {
 				problems = append(problems, lint.Problem{
 					Message:    "Within a single message, either all optional fields should be indicated, or none of them should be.",
 					Descriptor: f,

--- a/rules/aip0203/optional_consistency_test.go
+++ b/rules/aip0203/optional_consistency_test.go
@@ -70,6 +70,22 @@ string author = 4;`,
 				Message: "Within a single message, either all optional fields should be indicated, or none of them should be.",
 			}},
 		},
+		{
+			name: "Valid-IgnoreOneofFields",
+			field: `
+string name = 1 [
+	(google.api.field_behavior) = IMMUTABLE,
+	(google.api.field_behavior) = OUTPUT_ONLY];
+
+string title = 2 [(google.api.field_behavior) = REQUIRED];
+
+string summary = 3 [(google.api.field_behavior) = OPTIONAL];
+
+oneof other {
+	string author = 4;	
+}`,
+			problems: nil,
+		},
 	}
 
 	for _, test := range testCases {


### PR DESCRIPTION
Excludes `oneof` fields when considering `OPTIONAL` field behavior consistency. This is reasonable because `oneof` fields are inherently optional.

Fixes #708