### PR TITLE
fix: replace version template var to ignore

### DIFF
--- a/rules/aip0122/camel_case_uris_test.go
+++ b/rules/aip0122/camel_case_uris_test.go
@@ -33,6 +33,7 @@ func TestHttpUriField(t *testing.T) {
 		{"ValidSnakeVariable", "/v1/{book_name=publishers/*/books/*}:frob", testutils.Problems{}},
 		{"ValidSnakeSoloVariable", "/v1/{book_name}:frob", testutils.Problems{}},
 		{"InvalidCamelSoloVariable", "/v1/{bookName}:frob", testutils.Problems{{Message: "Variable names"}}},
+		{"ValidVersionTemplateVariable", "/{$api_version}/{book_name}:frob", testutils.Problems{}},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {

--- a/rules/internal/utils/http_test.go
+++ b/rules/internal/utils/http_test.go
@@ -116,6 +116,7 @@ func TestGetPlainURI(t *testing.T) {
 		{"KeyOnly", "/v1/publishers/{pub_id}/books/{book_id}", "/v1/publishers/*/books/*"},
 		{"KeyValue", "/v1/{name=publishers/*/books/*}", "/v1/publishers/*/books/*"},
 		{"MultiKeyValue", "/v1/{publisher=publishers/*}/{book=books/*}", "/v1/publishers/*/books/*"},
+		{"TemplateVariableSegment", "/{$api_version}/publishers/{pub_id}/books/{book_id}", "/v/publishers/*/books/*"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {


### PR DESCRIPTION
The version template variable `{$api_version}` wasn't being replaced in the Plain URI representation of a URI, so it must be explicitly replaced. This uses a `v` as a placeholder.

Fixes #897 and reworks the solution for #881.