### PR TITLE
fix: disable all rules instead of core rules only

### DIFF
--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -170,7 +170,7 @@ func TestExitStatusForLintFailure(t *testing.T) {
 
 	// checks lint failure = false when no problems found
 	t.Run(failCase.testName+"ReturnsNoFailure", func(t *testing.T) {
-		disableAll := `[ { "disabled_rules": [ "core" ] } ]`
+		disableAll := `[ { "disabled_rules": [ "all" ] } ]`
 		lintFailureStatus, result := runLinterWithFailureStatus(t, failCase.proto, disableAll, []string{"--set-exit-status"})
 		if lintFailureStatus {
 			t.Log(result)


### PR DESCRIPTION
This makes the integration test independent of particular rule sets.

For example, it allows creation of rules in other spaces that may generate
violations for the sample API definition.