### PR TITLE
Allow releases to be triggered manually

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@ name: release
 on:
   schedule:
     - cron: 0 20 * * 3 # Wednesdays at 20:00 UTC
+  workflow_dispatch: {} # Allow manual triggering
 jobs:
   inspect:
     runs-on: ubuntu-latest


### PR DESCRIPTION
It is sometimes useful to be able to create a release without having to wait for the scheduled run of this action.