### PR TITLE
Change destination of ci badge click to show ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Google API Linter
 
-![ci](https://github.com/googleapis/api-linter/workflows/ci/badge.svg)
+[![ci](https://github.com/googleapis/api-linter/actions/workflows/ci.yaml/badge.svg)](https://github.com/googleapis/api-linter/actions/workflows/ci.yaml)
 ![latest release](https://img.shields.io/github/v/release/googleapis/api-linter)
 ![go version](https://img.shields.io/github/go-mod/go-version/googleapis/api-linter)
 


### PR DESCRIPTION
This change makes it so that upon clicking the ci badge in the root README and therefore on the homepage of the repo, the user is redirected to the ci workflows page rather than a view of the badge itself as svg.