### PR TITLE
fix: Make plainVar RegExp explicit and consistent.

### DIFF
--- a/rules/internal/utils/http.go
+++ b/rules/internal/utils/http.go
@@ -115,6 +115,6 @@ func (h *HTTPRule) GetPlainURI() string {
 		"*")
 }
 
-var plainVar = regexp.MustCompile(`\{([^}=]+)}`)
+var plainVar = regexp.MustCompile(`\{([^}=]+)\}`)
 var varSegment = regexp.MustCompile(`\{([^}=]+)=([^}]+)\}`)
 var templateSegment = regexp.MustCompile(`\{\$api_version\}`)


### PR DESCRIPTION
Escape `}`. Works without but other RegExp's here do it and I don't know that I like that it does work without it because what about `{2}` or `{0,2}`. Anyway, let's make it consistent and explicit.