### PR TITLE
chore(install): update to use go install

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -33,10 +33,10 @@ Each linter rule has its own [rule documentation][], and rules can be
 
 ## Installation
 
-To install `api-linter`, use `go get`:
+To install `api-linter`, use `go install`:
 
 ```sh
-go get -u github.com/googleapis/api-linter/cmd/api-linter
+go install github.com/googleapis/api-linter/cmd/api-linter@latest
 ```
 
 It will install `api-linter` into your local Go binary directory


### PR DESCRIPTION
this change updates the installation docs to use the more recent `go install`.

from the go 1.17 doc referenced below:
> go get prints a deprecation warning when installing commands outside the main module (without the -d flag). go install cmd@version should be used instead to install a command at a specific version, using a suffix like @latest or @v1.2.3. In Go 1.18, the -d flag will always be enabled, and go get will only be used to change dependencies in go.mod.

ref: https://tip.golang.org/doc/go1.16#go-command
ref: https://tip.golang.org/doc/go1.17#go-command