### PR TITLE
chore: include chore commits in visible list

### DIFF
--- a/.github/release-tool/changelog.go
+++ b/.github/release-tool/changelog.go
@@ -76,6 +76,8 @@ func newChangelog(gitlog string) *changelog {
 			docs = append(docs, cmt)
 		case "refactor":
 			vis = append(vis, cmt)
+		case "chore":
+			vis = append(vis, cmt)
 		default:
 			invis = append(invis, cmt)
 		}


### PR DESCRIPTION
This means that `chore` commits will precipitate a patch release.