### PR TITLE
Exempt `crypto_key_name` from AIP-122 resource name check.

### DIFF
--- a/docs/rules/0122/name-suffix.md
+++ b/docs/rules/0122/name-suffix.md
@@ -18,8 +18,8 @@ This rule enforces that fields do not use the suffix `_name`, as mandated in
 This rule scans all fields complains if it sees the suffix `_name` on a field.
 
 **Note:** The standard field `display_name` is exempt, as are `given_name` and
-`family_name` (used to represent the human-readable name of a person), and
-`full_resource_name`.
+`family_name` (used to represent the human-readable name of a person),
+`full_resource_name`, and `crypto_key_name`.
 
 ## Examples
 

--- a/rules/aip0122/name_suffix.go
+++ b/rules/aip0122/name_suffix.go
@@ -31,6 +31,7 @@ var nameSuffix = &lint.FieldRule{
 			"family_name",
 			"given_name",
 			"full_resource_name",
+			"crypto_key_name",
 			"name",
 		).Contains(f.GetName())
 	},


### PR DESCRIPTION
This is in accordance with the guidance at https://google.aip.dev/122.