### PR TITLE
feat(AIP-123): lint resource_definition annotations

### DIFF
--- a/docs/rules/0123/resource-definition-pattern.md
+++ b/docs/rules/0123/resource-definition-pattern.md
@@ -1,0 +1,88 @@
+---
+rule:
+  aip: 123
+  name: [core, '0123', resource-definition-pattern]
+  summary: Resource annotations should define a pattern.
+permalink: /123/resource-definition-pattern
+redirect_from:
+  - /0123/resource-definition-pattern
+---
+
+# Resource patterns
+
+This rule enforces that files that define a resource with the
+`google.api.resource_definition` annotation have a `pattern` defined, as
+described in [AIP-123][].
+
+## Details
+
+This rule scans all `google.api.resource_definition` annotations in all files,
+and complains if `pattern` is not provided at least once. It also complains if
+the segments outside of variable names contain underscores.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+import "google/api/resources.proto";
+
+// Incorrect.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  // pattern should be here
+};
+```
+
+```proto
+import "google/api/resources.proto";
+
+// Incorrect.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/ElectronicBook"
+  // Should be: publishers/{publisher}/electronicBooks/{electronic_book}
+  pattern: "publishers/{publisher}/electronic_books/{electronic_book}"
+};
+```
+
+**Correct** code for this rule:
+
+```proto
+import "google/api/resources.proto";
+
+// Correct.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  pattern: "publishers/{publisher}/books/{book}"
+};
+```
+
+```proto
+import "google/api/resource.proto";
+
+// Correct.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/ElectronicBook"
+  pattern: "publishers/{publisher}/electronicBooks/{electronic_book}"
+};
+```
+
+## Disabling
+
+If you need to violate this rule, use a comment on the annotation.
+
+```proto
+import "google/api/resource.proto";
+
+// (-- api-linter: core::0123::resource-definition-pattern=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+};
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-123]: http://aip.dev/123
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0123/resource-definition-type-name.md
+++ b/docs/rules/0123/resource-definition-type-name.md
@@ -1,0 +1,68 @@
+---
+rule:
+  aip: 123
+  name: [core, '0123', resource-definition-type-name]
+  summary: Resource type names must be of the form {Service Name}/{Type}.
+permalink: /123/resource-definition-type-name
+redirect_from:
+  - /0123/resource-definition-type-name
+---
+
+# Resource type name
+
+This rule enforces that files that define a resource with the
+`google.api.resource_definition` annotation have a properly formatted `type`, as
+described in [AIP-123][].
+
+## Details
+
+This rule scans files with `google.api.resource_definition` annotations, and
+validates the format of the `type` field conforms to `{Service Name}/{Type}`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+import "google/api/resource.proto";
+
+// Incorrect.
+option (google.api.resource_definition) = {
+  // Should not have more than one separating '/'.
+  type: "library.googleapis.com/Genre/Mystery/Book"
+  pattern: "publishers/{publisher}/books/{book}"
+};
+```
+
+**Correct** code for this rule:
+
+```proto
+import "google/api/resource.proto";
+
+// Correct.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  pattern: "publishers/{publisher}/books/{book}"
+};
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the annotation.
+
+```proto
+import "google/api/resource.proto";
+
+// (-- api-linter: core::0123::resource-definition-type-name=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Genre/Mystery/Book"
+  pattern: "publishers/{publisher}/books/{book}"
+};
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-123]: http://aip.dev/123
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0123/resource-definition-variables.md
+++ b/docs/rules/0123/resource-definition-variables.md
@@ -1,0 +1,88 @@
+---
+rule:
+  aip: 123
+  name: [core, '0123', resource-definition-variables]
+  summary: Resource patterns should use consistent variable naming.
+permalink: /123/resource-definition-variables
+redirect_from:
+  - /0123/resource-definition-variables
+---
+
+# Resource pattern variables
+
+This rule enforces that resource patterns use consistent variable naming
+conventions, as described in [AIP-123][].
+
+## Details
+
+This rule scans all files with `google.api.resource_definition` annotations, and
+complains if variables in a `pattern` use camel case, or end in `_id`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+import "google/api/resource.proto";
+
+// Incorrect.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  // Should be: publishers/{publisher}/books/{book}
+  pattern: "publishers/{publisher_id}/books/{book_id}"
+};
+```
+
+```proto
+import "google/api/resource.proto";
+
+// Incorrect.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/ElectronicBook"
+  // Should be: publishers/{publisher}/electronicBooks/{electronic_book}
+  pattern: "publishers/{publisher}/electronicBooks/{electronicBook}"
+};
+```
+
+**Correct** code for this rule:
+
+```proto
+import "google/api/resource.proto";
+
+// Correct.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  pattern: "publishers/{publisher}/books/{book}"
+};
+```
+
+```proto
+import "google/api/resource.proto";
+
+// Correct.
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/ElectronicBook"
+  pattern: "publishers/{publisher}/electronicBooks/{electronic_book}"
+};
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the annotation.
+
+```proto
+import "google/api/resource.proto";
+
+// (-- api-linter: core::0123::resource-definition-variables=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+option (google.api.resource_definition) = {
+  type: "library.googleapis.com/Book"
+  pattern: "publishers/{publisher_id}/books/{book_id}"
+};
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-123]: http://aip.dev/123
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0123/aip0123.go
+++ b/rules/aip0123/aip0123.go
@@ -38,6 +38,9 @@ func AddRules(r lint.RuleRegistry) error {
 		resourceReferenceType,
 		resourceTypeName,
 		resourceVariables,
+		resourceDefinitionVariables,
+		resourceDefinitionPatterns,
+		resourceDefinitionTypeName,
 	)
 }
 
@@ -48,6 +51,10 @@ func isResourceMessage(m *desc.MessageDescriptor) bool {
 
 func hasResourceAnnotation(m *desc.MessageDescriptor) bool {
 	return utils.GetResource(m) != nil
+}
+
+func hasResourceDefinitionAnnotation(f *desc.FileDescriptor) bool {
+	return len(utils.GetResourceDefinitions(f)) > 0
 }
 
 // getVariables returns a slice of variables declared in the pattern.

--- a/rules/aip0123/resource_definition_pattern.go
+++ b/rules/aip0123/resource_definition_pattern.go
@@ -30,8 +30,8 @@ var resourceDefinitionPatterns = &lint.FileRule{
 
 		for ndx, resource := range resources {
 			loc := locations.FileResourceDefinition(f, ndx)
-			p := lintResourcePattern(resource, f, loc)
-			problems = append(problems, p...)
+			probs := lintResourcePattern(resource, f, loc)
+			problems = append(problems, probs...)
 		}
 		return problems
 	},

--- a/rules/aip0123/resource_definition_pattern.go
+++ b/rules/aip0123/resource_definition_pattern.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var resourceDefinitionPatterns = &lint.FileRule{
+	Name:   lint.NewRuleName(123, "resource-definition-pattern"),
+	OnlyIf: hasResourceDefinitionAnnotation,
+	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
+		var problems []lint.Problem
+		resources := utils.GetResourceDefinitions(f)
+
+		for ndx, resource := range resources {
+			loc := locations.FileResourceDefinition(f, ndx)
+			p := lintResourcePattern(resource, f, loc)
+			problems = append(problems, p...)
+		}
+		return problems
+	},
+}

--- a/rules/aip0123/resource_definition_pattern_test.go
+++ b/rules/aip0123/resource_definition_pattern_test.go
@@ -42,7 +42,8 @@ func TestResourceDefinitionPattern(t *testing.T) {
 					{{.Pattern}}
 				};
 			`, test)
-			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionPatterns.Lint(f)); diff != "" {
+			got := resourceDefinitionPatterns.Lint(f)
+			if diff := test.problems.SetDescriptor(f).Diff(got); diff != "" {
 				t.Errorf(diff)
 			}
 		})

--- a/rules/aip0123/resource_definition_pattern_test.go
+++ b/rules/aip0123/resource_definition_pattern_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceDefinitionPattern(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		Pattern  string
+		problems testutils.Problems
+	}{
+		{"Valid", `pattern: "publishers/{publisher}/books/{book}"`, testutils.Problems{}},
+		{"ValidCamel", `pattern: "publishers/{publisher}/electronicBooks/{electronic_book}"`, testutils.Problems{}},
+		{"Missing", "", testutils.Problems{{Message: "declare resource name pattern"}}},
+		{"SnakeCase", `pattern: "book_publishers/{book_publisher}/books/{book}"`, testutils.Problems{{
+			Message: "bookPublishers/{book_publisher}/books/{book}",
+		}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				option (google.api.resource_definition) = {
+					type: "library.googleapis.com/Book"
+					{{.Pattern}}
+				};
+			`, test)
+			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionPatterns.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0123/resource_definition_type_name.go
+++ b/rules/aip0123/resource_definition_type_name.go
@@ -1,0 +1,44 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var resourceDefinitionTypeName = &lint.FileRule{
+	Name:   lint.NewRuleName(123, "resource-definition-type-name"),
+	OnlyIf: hasResourceDefinitionAnnotation,
+	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
+		var problems []lint.Problem
+		resources := utils.GetResourceDefinitions(f)
+		for ndx, resource := range resources {
+			if strings.Count(resource.GetType(), "/") != 1 {
+				problems = append(problems, lint.Problem{
+					Message:    "Resource type names must be of the form {Service Name}/{Type}.",
+					Descriptor: f,
+					Location:   locations.FileResourceDefinition(f, ndx),
+				})
+			}
+		}
+
+		return problems
+	},
+}

--- a/rules/aip0123/resource_definition_type_name_test.go
+++ b/rules/aip0123/resource_definition_type_name_test.go
@@ -1,0 +1,46 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceDefinitionTypeName(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		TypeName string
+		problems testutils.Problems
+	}{
+		{"Valid", "library.googleapis.com/Book", testutils.Problems{}},
+		{"InvalidTooMany", "library.googleapis.com/shelf/Book", testutils.Problems{{Message: "{Service Name}/{Type}"}}},
+		{"InvalidNotEnough", "library.googleapis.com~Book", testutils.Problems{{Message: "{Service Name}/{Type}"}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+			import "google/api/resource.proto";
+			option (google.api.resource_definition) = {
+				type: "{{ .TypeName }}"
+				pattern: "publishers/{publisher}/books/{book}"
+			};
+		`, test)
+			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionTypeName.Lint(f)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0123/resource_definition_type_name_test.go
+++ b/rules/aip0123/resource_definition_type_name_test.go
@@ -38,7 +38,8 @@ func TestResourceDefinitionTypeName(t *testing.T) {
 				pattern: "publishers/{publisher}/books/{book}"
 			};
 		`, test)
-			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionTypeName.Lint(f)); diff != "" {
+			got := resourceDefinitionTypeName.Lint(f)
+			if diff := test.problems.SetDescriptor(f).Diff(got); diff != "" {
 				t.Error(diff)
 			}
 		})

--- a/rules/aip0123/resource_definition_variables.go
+++ b/rules/aip0123/resource_definition_variables.go
@@ -1,0 +1,38 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var resourceDefinitionVariables = &lint.FileRule{
+	Name:   lint.NewRuleName(123, "resource-definition-variables"),
+	OnlyIf: hasResourceDefinitionAnnotation,
+	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
+		var problems []lint.Problem
+		resources := utils.GetResourceDefinitions(f)
+
+		for ndx, resource := range resources {
+			loc := locations.FileResourceDefinition(f, ndx)
+			p := lintResourceVariables(resource, f, loc)
+			problems = append(problems, p...)
+		}
+		return problems
+	},
+}

--- a/rules/aip0123/resource_definition_variables_test.go
+++ b/rules/aip0123/resource_definition_variables_test.go
@@ -1,0 +1,50 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceDefinitionVariables(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		Pattern  string
+		problems testutils.Problems
+	}{
+		{"Valid", "publishers/{publisher}/electronicBooks/{electronic_book}", testutils.Problems{}},
+		{"CamelCase", "publishers/{publisher}/electronicBooks/{electronicBook}", testutils.Problems{{
+			Message: "publishers/{publisher}/electronicBooks/{electronic_book}",
+		}}},
+		{"ID", "publishers/{publisher}/electronicBooks/{electronic_book_id}", testutils.Problems{{
+			Message: "publishers/{publisher}/electronicBooks/{electronic_book}",
+		}}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+				option (google.api.resource_definition) = {
+					type: "library.googleapis.com/Book"
+					pattern: "{{.Pattern}}"
+				};
+			`, test)
+			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionVariables.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0123/resource_definition_variables_test.go
+++ b/rules/aip0123/resource_definition_variables_test.go
@@ -42,7 +42,8 @@ func TestResourceDefinitionVariables(t *testing.T) {
 					pattern: "{{.Pattern}}"
 				};
 			`, test)
-			if diff := test.problems.SetDescriptor(f).Diff(resourceDefinitionVariables.Lint(f)); diff != "" {
+			got := resourceDefinitionVariables.Lint(f)
+			if diff := test.problems.SetDescriptor(f).Diff(got); diff != "" {
 				t.Errorf(diff)
 			}
 		})


### PR DESCRIPTION
Since `google.api.resource_definition` annotations are the "headless" form of a `google.api.resource` (headless in that there is no message defined in the API to back them i.e. this is a resource from another API), their fields should be linted in mostly the same way. This copies three different rules already implemented for `google.api.resource` and adjusts them for `google.api.resource_definition`. Some of the code is almost exactly the same, so I abstracted those bits into local functions to share between the message and file level versions of these annotations.

Fixes #949 and does the same thing for some other rules in this AIP that apply to `google.api.resource_definition`.