### PR TITLE
chore: remove renovate grouping

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,6 @@
 {
   extends: ["config:base"],
   commitMessagePrefix: "chore: ",
-  groupName: "all",
   packageRules: [
     {
       // The genproto package is updated every time that any API published by


### PR DESCRIPTION
Changes from RenovateBot that update this repos dependencies will no longer be grouped in a single Pull Request (like it is [today](https://github.com/googleapis/api-linter/pull/926)). Instead, they will come in as individual Pull Requests.