### PR TITLE
fix(AIP-132): lint OnlyIf the response message is a resource

### DIFF
--- a/rules/aip0132/resource_reference_type_test.go
+++ b/rules/aip0132/resource_reference_type_test.go
@@ -20,18 +20,27 @@ import (
 	"github.com/googleapis/api-linter/rules/internal/testutils"
 )
 
+const bookResource = `
+option (google.api.resource) = {
+	type: "library.googleapis.com/Book"
+	pattern: "shelves/{shelf}/books/{book}"
+};
+`
+
 func TestResourceReferenceType(t *testing.T) {
 	// Set up testing permutations.
 	tests := []struct {
-		testName string
-		TypeName string
-		RefType  string
-		problems testutils.Problems
+		testName           string
+		TypeName           string
+		RefType            string
+		ResourceAnnotation string
+		problems           testutils.Problems
 	}{
-		{"ValidChildType", "library.googleapis.com/Book", "child_type", nil},
-		{"ValidType", "library.googleapis.com/Shelf", "type", nil},
-		{"InvalidType", "library.googleapis.com/Book", "type", testutils.Problems{{Message: "not a `type`"}}},
-		{"InvalidChildType", "library.googleapis.com/Shelf", "child_type", testutils.Problems{{Message: "`child_type`"}}},
+		{"ValidChildType", "library.googleapis.com/Book", "child_type", bookResource, nil},
+		{"ValidType", "library.googleapis.com/Shelf", "type", bookResource, nil},
+		{"InvalidType", "library.googleapis.com/Book", "type", bookResource, testutils.Problems{{Message: "not a `type`"}}},
+		{"InvalidChildType", "library.googleapis.com/Shelf", "child_type", bookResource, testutils.Problems{{Message: "`child_type`"}}},
+		{"SkipNonResource", "library.googleapis.com/Book", "child_type", "", nil},
 	}
 
 	// Run each test.
@@ -50,10 +59,7 @@ func TestResourceReferenceType(t *testing.T) {
 					repeated Book books = 1;
 				}
 				message Book {
-					option (google.api.resource) = {
-						type: "library.googleapis.com/Book"
-						pattern: "shelves/{shelf}/books/{book}"
-					};
+					{{ .ResourceAnnotation }}
 					string name = 1;
 				}
 			`, test)

--- a/rules/aip0132/resource_reference_type_test.go
+++ b/rules/aip0132/resource_reference_type_test.go
@@ -20,14 +20,14 @@ import (
 	"github.com/googleapis/api-linter/rules/internal/testutils"
 )
 
-const bookResource = `
+func TestResourceReferenceType(t *testing.T) {
+	bookResource := `
 option (google.api.resource) = {
 	type: "library.googleapis.com/Book"
 	pattern: "shelves/{shelf}/books/{book}"
 };
 `
 
-func TestResourceReferenceType(t *testing.T) {
 	// Set up testing permutations.
 	tests := []struct {
 		testName           string


### PR DESCRIPTION
[yaqs/6147033380028416](http://yaqs/6147033380028416) is an example of an API that attempted to annotate a List `parent` field with a resource_reference to a message that isn't a resource. 

The resource_reference type should only be linted if the response message is a resource.