### PR TITLE
feat(AIP-191): compare service casing to packaging

### DIFF
--- a/rules/aip0191/aip0191.go
+++ b/rules/aip0191/aip0191.go
@@ -17,6 +17,7 @@ package aip0191
 
 import (
 	"regexp"
+	"strings"
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/jhump/protoreflect/desc"
@@ -42,6 +43,20 @@ func AddRules(r lint.RuleRegistry) error {
 
 func hasPackage(f *desc.FileDescriptor) bool {
 	return f.GetPackage() != ""
+}
+
+func packagingServiceNameEquals(serv, pkg, sep string) bool {
+	segments := strings.Split(pkg, sep)
+	for _, segment := range segments {
+		// If a packaging annotation segment and a service name are equal in a
+		// case-insensitive comparison, they must also be equal using a
+		// case-sensitive comparison.
+		if strings.EqualFold(segment, serv) && segment != serv {
+			return false
+		}
+	}
+
+	return true
 }
 
 var versionRegexp = regexp.MustCompile(`^v[0-9]+(p[0-9]+)?((alpha|beta)[0-9]*)?$`)

--- a/rules/aip0191/csharp_namespace_test.go
+++ b/rules/aip0191/csharp_namespace_test.go
@@ -31,6 +31,7 @@ func TestCsharpNamespace(t *testing.T) {
 		{"ValidBeta", "Google.Example.V1Beta1", nil},
 		{"ValidMain", "Google.Example.V1Main", nil},
 		{"ValidPointBeta", "Google.Example.V1P1Beta1", nil},
+		{"ValidServiceCasing", "Google.FooBar.V1", testutils.Problems{}},
 		{"InvalidBadChars", "Google:Example:V1", testutils.Problems{{Message: "Invalid characters"}}},
 		{"Invalid", "google.example.v1", testutils.Problems{{
 			Suggestion: fmt.Sprintf("option csharp_namespace = %q;", "Google.Example.V1"),
@@ -44,12 +45,15 @@ func TestCsharpNamespace(t *testing.T) {
 		{"InvalidPointBeta", "Google.Example.V1p1beta1", testutils.Problems{{
 			Suggestion: fmt.Sprintf("option csharp_namespace = %q;", "Google.Example.V1P1Beta1"),
 		}}},
+		{"InvalidServiceCasing", "Google.Foobar.V1", testutils.Problems{{Message: "Casing"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
 				package google.example.v1;
 
 				option csharp_namespace = "{{.CsharpNamespace}}";
+
+				service FooBar {}
 			`, test)
 			if diff := test.problems.SetDescriptor(f).Diff(csharpNamespace.Lint(f)); diff != "" {
 				t.Errorf(diff)

--- a/rules/aip0191/php_namespace.go
+++ b/rules/aip0191/php_namespace.go
@@ -27,37 +27,40 @@ import (
 
 var phpNamespace = &lint.FileRule{
 	Name: lint.NewRuleName(191, "php-namespace"),
+	OnlyIf: func(f *desc.FileDescriptor) bool {
+		fops := f.GetFileOptions()
+		return fops != nil && fops.GetPhpNamespace() != ""
+	},
 	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		if ns := f.GetFileOptions().GetPhpNamespace(); ns != "" {
-			// Check for invalid characters.
-			if !phpValidChars.MatchString(ns) {
-				return []lint.Problem{{
-					Message:    `Invalid characters: PHP namespaces only allow [A-Za-z0-9\].`,
-					Descriptor: f,
-					Location:   locations.FilePhpNamespace(f),
-				}}
-			}
+		ns := f.GetFileOptions().GetPhpNamespace()
+		// Check for invalid characters.
+		if !phpValidChars.MatchString(ns) {
+			return []lint.Problem{{
+				Message:    `Invalid characters: PHP namespaces only allow [A-Za-z0-9\].`,
+				Descriptor: f,
+				Location:   locations.FilePhpNamespace(f),
+			}}
+		}
 
-			// Check that upper camel case is used.
-			upperCamel := []string{}
-			for _, segment := range strings.Split(ns, `\`) {
-				upperCamel = append(upperCamel, strcase.UpperCamelCase(segment))
-			}
-			if want := strings.Join(upperCamel, `\`); ns != want {
-				return []lint.Problem{{
-					Message: "PHP namespaces use UpperCamelCase.",
-					Suggestion: fmt.Sprintf(
-						"option php_namespace = %s;",
-						// Even though the string value is a single backslash, we want
-						// to suggest two backslashes, because that is what should be
-						// typed into the editor. We use %s to avoid additional escaping
-						// of backslashes by Sprintf.
-						strings.ReplaceAll(want, `\`, `\\`),
-					),
-					Descriptor: f,
-					Location:   locations.FilePhpNamespace(f),
-				}}
-			}
+		// Check that upper camel case is used.
+		upperCamel := []string{}
+		for _, segment := range strings.Split(ns, `\`) {
+			upperCamel = append(upperCamel, strcase.UpperCamelCase(segment))
+		}
+		if want := strings.Join(upperCamel, `\`); ns != want {
+			return []lint.Problem{{
+				Message: "PHP namespaces use UpperCamelCase.",
+				Suggestion: fmt.Sprintf(
+					"option php_namespace = %s;",
+					// Even though the string value is a single backslash, we want
+					// to suggest two backslashes, because that is what should be
+					// typed into the editor. We use %s to avoid additional escaping
+					// of backslashes by Sprintf.
+					strings.ReplaceAll(want, `\`, `\\`),
+				),
+				Descriptor: f,
+				Location:   locations.FilePhpNamespace(f),
+			}}
 		}
 		return nil
 	},

--- a/rules/aip0191/php_namespace_test.go
+++ b/rules/aip0191/php_namespace_test.go
@@ -29,6 +29,7 @@ func TestPhpNamespace(t *testing.T) {
 	}{
 		{"Valid", `Google\\Example\\V1`, testutils.Problems{}},
 		{"ValidBeta", `Google\\Example\\V1beta1`, testutils.Problems{}},
+		{"ValidServiceCasing", `Google\\FooBar\\V1`, testutils.Problems{}},
 		{"InvalidBadChars", "Google:Example:V1", testutils.Problems{{Message: "Invalid characters"}}},
 		{"Invalid", `google\\example\\v1`, testutils.Problems{{
 			Suggestion: fmt.Sprintf("option php_namespace = %s;", `Google\\Example\\V1`),
@@ -39,12 +40,15 @@ func TestPhpNamespace(t *testing.T) {
 		{"InvalidBeta", `Google\\Example\\V1Beta1`, testutils.Problems{{
 			Suggestion: fmt.Sprintf("option php_namespace = %s;", `Google\\Example\\V1beta1`),
 		}}},
+		{"InvalidServiceCasing", `Google\\Foobar\\V1`, testutils.Problems{{Message: "Casing"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
 				package google.example.v1;
 
 				option php_namespace = "{{.PhpNamespace}}";
+
+				service FooBar {}
 			`, test)
 			if diff := test.problems.SetDescriptor(f).Diff(phpNamespace.Lint(f)); diff != "" {
 				t.Errorf(diff)

--- a/rules/aip0191/ruby_package.go
+++ b/rules/aip0191/ruby_package.go
@@ -27,30 +27,34 @@ import (
 
 var rubyPackage = &lint.FileRule{
 	Name: lint.NewRuleName(191, "ruby-package"),
+	OnlyIf: func(f *desc.FileDescriptor) bool {
+		fops := f.GetFileOptions()
+		return fops != nil && fops.GetRubyPackage() != ""
+	},
 	LintFile: func(f *desc.FileDescriptor) []lint.Problem {
-		if ns := f.GetFileOptions().GetRubyPackage(); ns != "" {
-			// Check for invalid characters.
-			if !rubyValidChars.MatchString(ns) {
-				return []lint.Problem{{
-					Message:    "Invalid characters: Ruby packages only allow [A-Za-z0-9:].",
-					Descriptor: f,
-					Location:   locations.FileRubyPackage(f),
-				}}
-			}
+		ns := f.GetFileOptions().GetRubyPackage()
 
-			// Check that upper camel case is used.
-			upperCamel := []string{}
-			for _, segment := range strings.Split(ns, "::") {
-				upperCamel = append(upperCamel, strcase.UpperCamelCase(segment))
-			}
-			if want := strings.Join(upperCamel, "::"); ns != want {
-				return []lint.Problem{{
-					Message:    "Ruby packages use UpperCamelCase.",
-					Suggestion: fmt.Sprintf("option ruby_package = %q;", want),
-					Descriptor: f,
-					Location:   locations.FileRubyPackage(f),
-				}}
-			}
+		// Check for invalid characters.
+		if !rubyValidChars.MatchString(ns) {
+			return []lint.Problem{{
+				Message:    "Invalid characters: Ruby packages only allow [A-Za-z0-9:].",
+				Descriptor: f,
+				Location:   locations.FileRubyPackage(f),
+			}}
+		}
+
+		// Check that upper camel case is used.
+		upperCamel := []string{}
+		for _, segment := range strings.Split(ns, "::") {
+			upperCamel = append(upperCamel, strcase.UpperCamelCase(segment))
+		}
+		if want := strings.Join(upperCamel, "::"); ns != want {
+			return []lint.Problem{{
+				Message:    "Ruby packages use UpperCamelCase.",
+				Suggestion: fmt.Sprintf("option ruby_package = %q;", want),
+				Descriptor: f,
+				Location:   locations.FileRubyPackage(f),
+			}}
 		}
 		return nil
 	},

--- a/rules/aip0191/ruby_package_test.go
+++ b/rules/aip0191/ruby_package_test.go
@@ -29,7 +29,7 @@ func TestRubyPackage(t *testing.T) {
 	}{
 		{"Valid", "Google::Example::V1", testutils.Problems{}},
 		{"ValidBeta", "Google::Example::V1beta1", testutils.Problems{}},
-		{"ValidTwoWords", "Google::LibraryExample::V1", testutils.Problems{}},
+		{"ValidServiceCasing", "Google::FooBar::V1", testutils.Problems{}},
 		{"InvalidBadChars", "Google.Example.V1", testutils.Problems{{Message: "Invalid characters"}}},
 		{"Invalid", "google::example::v1", testutils.Problems{{
 			Suggestion: fmt.Sprintf("option ruby_package = %q;", "Google::Example::V1"),
@@ -40,12 +40,15 @@ func TestRubyPackage(t *testing.T) {
 		{"InvalidBeta", "Google::Example::V1Beta1", testutils.Problems{{
 			Suggestion: fmt.Sprintf("option ruby_package = %q;", "Google::Example::V1beta1"),
 		}}},
+		{"InvalidServiceCasing", "Google::Foobar::V1", testutils.Problems{{Message: "Casing"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
 				package google.example.v1;
 
 				option ruby_package = "{{.RubyPackage}}";
+
+				service FooBar {}
 			`, test)
 			if diff := test.problems.SetDescriptor(f).Diff(rubyPackage.Lint(f)); diff != "" {
 				t.Errorf(diff)


### PR DESCRIPTION
A first step towards protecting services and packing annotations from having mismatched names e.g. `service Foobar` and `option c_sharp_namespace = "Google.FooBar.V1"` where `Foobar` and `FooBar` do not match in casing.

@jskeet 