### PR TITLE
feat(AIP-122): resource patterns must start with lowercase letter

### DIFF
--- a/docs/rules/0122/resource-collection-identifiers.md
+++ b/docs/rules/0122/resource-collection-identifiers.md
@@ -18,7 +18,7 @@ in [AIP-122][].
 
 This rule scans messages with a `google.api.resource` annotation, and validates
 the format of `pattern` collection identifiers, specifically that they are in
-lowerCamelCase form and that it does not start with a slash.
+lowerCamelCase form and must start with a lowercase letter.
 
 ## Examples
 

--- a/docs/rules/0122/resource-collection-identifiers.md
+++ b/docs/rules/0122/resource-collection-identifiers.md
@@ -18,7 +18,7 @@ in [AIP-122][].
 
 This rule scans messages with a `google.api.resource` annotation, and validates
 the format of `pattern` collection identifiers, specifically that they are in
-lowerCamelCase form.
+lowerCamelCase form and that it does not start with a slash.
 
 ## Examples
 
@@ -31,6 +31,18 @@ message Book {
     type: "library.googleapis.com/Book"
     // Collection identifiers must be lowerCamelCase.
     pattern: "Publishers/{publisher}/Books/{book}"
+  };
+  string name = 1;
+}
+```
+
+```proto
+// Incorrect.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    // Collection identifiers must begin with a lower-cased letter.
+    pattern: "/publishers/{publisher}/Books/{book}"
   };
   string name = 1;
 }

--- a/rules/aip0122/resource_collection_identifiers.go
+++ b/rules/aip0122/resource_collection_identifiers.go
@@ -15,6 +15,7 @@
 package aip0122
 
 import (
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -23,6 +24,8 @@ import (
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
+
+var firstCharRegexp = regexp.MustCompile(`^[a-z]`)
 
 var resourceCollectionIdentifiers = &lint.MessageRule{
 	Name: lint.NewRuleName(122, "resource-collection-identifiers"),
@@ -33,9 +36,9 @@ var resourceCollectionIdentifiers = &lint.MessageRule{
 		var problems []lint.Problem
 		resource := utils.GetResource(m)
 		for _, p := range resource.GetPattern() {
-			if strings.IndexRune(p, '/') == 0 {
+			if !firstCharRegexp.MatchString(p) {
 				return append(problems, lint.Problem{
-					Message:    "Resource patterns must not start with a slash.",
+					Message:    "Resource patterns must start with a lowercase letter.",
 					Descriptor: m,
 					Location:   locations.MessageResource(m),
 				})

--- a/rules/aip0122/resource_collection_identifiers.go
+++ b/rules/aip0122/resource_collection_identifiers.go
@@ -33,6 +33,14 @@ var resourceCollectionIdentifiers = &lint.MessageRule{
 		var problems []lint.Problem
 		resource := utils.GetResource(m)
 		for _, p := range resource.GetPattern() {
+			if strings.IndexRune(p, '/') == 0 {
+				return append(problems, lint.Problem{
+					Message:    "Resource patterns must not start with a slash.",
+					Descriptor: m,
+					Location:   locations.MessageResource(m),
+				})
+			}
+
 			segs := strings.Split(p, "/")
 			for _, seg := range segs {
 				// Get first rune of each pattern segment.

--- a/rules/aip0122/resource_collection_identifiers_test.go
+++ b/rules/aip0122/resource_collection_identifiers_test.go
@@ -28,6 +28,7 @@ func TestResourceCollectionIdentifiers(t *testing.T) {
 	}{
 		{"Valid", "author/{author}/books/{book}", testutils.Problems{}},
 		{"InvalidUpperCase", "author/{author}/Books/{book}", testutils.Problems{{Message: "lowerCamelCase"}}},
+		{"InvalidStartsWithSlash", "/author/{author}/Books/{book}", testutils.Problems{{Message: "with a slash"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `

--- a/rules/aip0122/resource_collection_identifiers_test.go
+++ b/rules/aip0122/resource_collection_identifiers_test.go
@@ -28,7 +28,8 @@ func TestResourceCollectionIdentifiers(t *testing.T) {
 	}{
 		{"Valid", "author/{author}/books/{book}", testutils.Problems{}},
 		{"InvalidUpperCase", "author/{author}/Books/{book}", testutils.Problems{{Message: "lowerCamelCase"}}},
-		{"InvalidStartsWithSlash", "/author/{author}/Books/{book}", testutils.Problems{{Message: "with a slash"}}},
+		{"InvalidStartsWithSlash", "/author/{author}/Books/{book}", testutils.Problems{{Message: "lowercase letter"}}},
+		{"InvalidStartsWithCapitalLetter", "Author/{author}/Books/{book}", testutils.Problems{{Message: "lowercase letter"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
Resource patterns must start with lowercase letters per [AIP-122](https://google.aip.dev/122).

Fixes #994 