### PR TITLE
fix: not all findings have column info

### DIFF
--- a/cmd/api-linter/github_actions.go
+++ b/cmd/api-linter/github_actions.go
@@ -33,10 +33,22 @@ func formatGitHubActionOutput(responses []lint.Response) []byte {
 
 			fmt.Fprintf(&buf, "::error file=%s", response.FilePath)
 			if problem.Location != nil {
-				fmt.Fprintf(&buf, " line=%d", problem.Location.Span[0])
-				fmt.Fprintf(&buf, " col=%d", problem.Location.Span[1])
-				fmt.Fprintf(&buf, " endLine=%d", problem.Location.Span[2])
-				fmt.Fprintf(&buf, " endColumn=%d", problem.Location.Span[3])
+				// Some findings are *line level* and only have start positions but no
+				// starting column. Construct a switch fallthrough to emit as many of
+				// the location indicators are included.
+				switch len(problem.Location.Span) {
+				case 4:
+					fmt.Fprintf(&buf, " endColumn=%d", problem.Location.Span[3])
+					fallthrough
+				case 3:
+					fmt.Fprintf(&buf, " endLine=%d", problem.Location.Span[2])
+					fallthrough
+				case 2:
+					fmt.Fprintf(&buf, " col=%d", problem.Location.Span[1])
+					fallthrough
+				case 1:
+					fmt.Fprintf(&buf, " line=%d", problem.Location.Span[0])
+				}
 			}
 
 			// GitHub uses :: as control characters (which are also used to delimit


### PR DESCRIPTION
Turns out that real lint errors can come in many forms. This now only
prints out the information that is present instead of out of bounds
`panic`ing.