### PR TITLE
fix: Render URIs in github actions links

### DIFF
--- a/cmd/api-linter/github_actions.go
+++ b/cmd/api-linter/github_actions.go
@@ -57,6 +57,10 @@ func formatGitHubActionOutput(responses []lint.Response) []byte {
 			runeThatLooksLikeTwoColonsButIsActuallyTwoArmenianFullStops := "։։"
 			title := strings.ReplaceAll(string(problem.RuleID), "::", runeThatLooksLikeTwoColonsButIsActuallyTwoArmenianFullStops)
 			message := strings.ReplaceAll(problem.Message, "\n", "\\n")
+			uri := problem.GetRuleURI()
+			if uri != "" {
+				message += "\\n\\n" + uri
+			}
 			fmt.Fprintf(&buf, " title=%s::%s\n", title, message)
 		}
 	}

--- a/cmd/api-linter/github_actions_test.go
+++ b/cmd/api-linter/github_actions_test.go
@@ -98,8 +98,8 @@ func TestFormatGitHubActionOutput(t *testing.T) {
 					},
 				},
 			},
-			want: `::error file=example.proto endColumn=4 endLine=3 col=2 line=1 title=core։։naming_formats։։field_names::
-::error file=example.proto endColumn=8 endLine=7 col=6 line=5 title=core։։naming_formats։։field_names::multi\nline\ncomment
+			want: `::error file=example.proto endColumn=4 endLine=3 col=2 line=1 title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example.proto endColumn=8 endLine=7 col=6 line=5 title=core։։naming_formats։։field_names::multi\nline\ncomment\n\nhttps://linter.aip.dev/naming_formats/field_names
 `,
 		},
 		{
@@ -133,13 +133,13 @@ func TestFormatGitHubActionOutput(t *testing.T) {
 					},
 				},
 			},
-			want: `::error file=example.proto title=core։։naming_formats։։field_names::
-::error file=example.proto title=core։։naming_formats։։field_names::
-::error file=example2.proto title=core։։0131։։request_message։։name::
-::error file=example2.proto title=core։։0132։։response_message։։name::
-::error file=example3.proto title=core։։naming_formats։։field_names::
-::error file=example4.proto title=core։։naming_formats։։field_names::
-::error file=example4.proto title=core։։0132։։response_message։։name::
+			want: `::error file=example.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example2.proto title=core։։0131։։request_message։։name::\n\nhttps://linter.aip.dev/131/request_message/name
+::error file=example2.proto title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
+::error file=example3.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example4.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example4.proto title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
 `,
 		},
 	}

--- a/lint/problem.go
+++ b/lint/problem.go
@@ -95,9 +95,14 @@ func (p Problem) marshal() interface{} {
 		p.Suggestion,
 		fileLocationFromPBLocation(loc),
 		p.RuleID,
-		getRuleURL(string(p.RuleID), ruleURLMappings),
+		p.GetRuleURI(),
 		p.category,
 	}
+}
+
+// GetRuleURI returns a URI to learn more about the problem.
+func (p Problem) GetRuleURI() string {
+	return getRuleURL(string(p.RuleID), ruleURLMappings)
 }
 
 // position describes a one-based position in a source code file.


### PR DESCRIPTION
Include linter rule URI in findings for GitHub Action format.