### PR TITLE
fix: delimit github lint components correctly

### DIFF
--- a/cmd/api-linter/github_actions.go
+++ b/cmd/api-linter/github_actions.go
@@ -38,16 +38,16 @@ func formatGitHubActionOutput(responses []lint.Response) []byte {
 				// the location indicators are included.
 				switch len(problem.Location.Span) {
 				case 4:
-					fmt.Fprintf(&buf, " endColumn=%d", problem.Location.Span[3])
+					fmt.Fprintf(&buf, ",endColumn=%d", problem.Location.Span[3])
 					fallthrough
 				case 3:
-					fmt.Fprintf(&buf, " endLine=%d", problem.Location.Span[2])
+					fmt.Fprintf(&buf, ",endLine=%d", problem.Location.Span[2])
 					fallthrough
 				case 2:
-					fmt.Fprintf(&buf, " col=%d", problem.Location.Span[1])
+					fmt.Fprintf(&buf, ",col=%d", problem.Location.Span[1])
 					fallthrough
 				case 1:
-					fmt.Fprintf(&buf, " line=%d", problem.Location.Span[0])
+					fmt.Fprintf(&buf, ",line=%d", problem.Location.Span[0])
 				}
 			}
 
@@ -61,7 +61,7 @@ func formatGitHubActionOutput(responses []lint.Response) []byte {
 			if uri != "" {
 				message += "\\n\\n" + uri
 			}
-			fmt.Fprintf(&buf, " title=%s::%s\n", title, message)
+			fmt.Fprintf(&buf, ",title=%s::%s\n", title, message)
 		}
 	}
 

--- a/cmd/api-linter/github_actions_test.go
+++ b/cmd/api-linter/github_actions_test.go
@@ -64,16 +64,16 @@ func TestFormatGitHubActionOutput(t *testing.T) {
 							RuleID:  "line",
 							Message: "Line only",
 							Location: &descriptorpb.SourceCodeInfo_Location{
-								Span: []int32{5, 6, 7, 8},
+								Span: []int32{5},
 							},
 						},
 					},
 				},
 			},
-			want: `::error file=example.proto endColumn=8 endLine=7 col=6 line=5 title=line։։col։։endLine։։endColumn::line, column, endline, and endColumn
-::error file=example.proto endLine=7 col=6 line=5 title=line։։col։։endLine::Line, column, and endline
-::error file=example.proto col=6 line=5 title=line։։col::Line and column
-::error file=example.proto endColumn=8 endLine=7 col=6 line=5 title=line::Line only
+			want: `::error file=example.proto,endColumn=8,endLine=7,col=6,line=5,title=line։։col։։endLine։։endColumn::line, column, endline, and endColumn
+::error file=example.proto,endLine=7,col=6,line=5,title=line։։col։։endLine::Line, column, and endline
+::error file=example.proto,col=6,line=5,title=line։։col::Line and column
+::error file=example.proto,line=5,title=line::Line only
 `,
 		},
 		{
@@ -98,8 +98,8 @@ func TestFormatGitHubActionOutput(t *testing.T) {
 					},
 				},
 			},
-			want: `::error file=example.proto endColumn=4 endLine=3 col=2 line=1 title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
-::error file=example.proto endColumn=8 endLine=7 col=6 line=5 title=core։։naming_formats։։field_names::multi\nline\ncomment\n\nhttps://linter.aip.dev/naming_formats/field_names
+			want: `::error file=example.proto,endColumn=4,endLine=3,col=2,line=1,title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example.proto,endColumn=8,endLine=7,col=6,line=5,title=core։։naming_formats։։field_names::multi\nline\ncomment\n\nhttps://linter.aip.dev/naming_formats/field_names
 `,
 		},
 		{
@@ -133,13 +133,13 @@ func TestFormatGitHubActionOutput(t *testing.T) {
 					},
 				},
 			},
-			want: `::error file=example.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
-::error file=example.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
-::error file=example2.proto title=core։։0131։։request_message։։name::\n\nhttps://linter.aip.dev/131/request_message/name
-::error file=example2.proto title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
-::error file=example3.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
-::error file=example4.proto title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
-::error file=example4.proto title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
+			want: `::error file=example.proto,title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example.proto,title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example2.proto,title=core։։0131։։request_message։։name::\n\nhttps://linter.aip.dev/131/request_message/name
+::error file=example2.proto,title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
+::error file=example3.proto,title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example4.proto,title=core։։naming_formats։։field_names::\n\nhttps://linter.aip.dev/naming_formats/field_names
+::error file=example4.proto,title=core։։0132։։response_message։։name::\n\nhttps://linter.aip.dev/132/response_message/name
 `,
 		},
 	}


### PR DESCRIPTION
The documentations[0] very clearly states that you should use a comma to
delimit the various sections of a lint comment (line,col,title,etc.).
However I completely missed the mark on that one. This uses the correct
delimiter which should hopefully make the annotations show up properly.

[0] https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-error-message