### PR TITLE
ci: build Darwin/arm64 artifacts in release

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,6 +50,8 @@ jobs:
             arch: arm
           - os: darwin
             arch: amd64
+          - os: darwin
+            arch: arm64
           - os: windows
             arch: amd64
     steps:


### PR DESCRIPTION
As mentioned in #991, building locally using `gox -osarch darwin/arm64 -output api-linter ./...` works just fine (which isn't surprising as there's already Linux ARM support).