### PR TITLE
feat: name field must never be proto3_optional

### DIFF
--- a/docs/rules/0123/name-never-optional.md
+++ b/docs/rules/0123/name-never-optional.md
@@ -1,0 +1,73 @@
+---
+rule:
+  aip: 123
+  name: [core, '0123', name-never-optional]
+  summary: Resource name fields must never be labeled with proto3_optional.
+permalink: /123/name-never-optional
+redirect_from:
+  - /0123/name-never-optional
+---
+
+# Resource name field never optional
+
+This rule enforces that the name field of resource messages is not labeled with
+proto3_optional.
+
+## Details
+
+This rule scans for messages with a `google.api.resource` annotation and ensures
+that the configured name field (either `name` or whichever field specified via
+`name_field`) is not labeled as `optional`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  // The name field should not be labeled as optional.
+  optional string name = 1;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  string name = 1;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the message.
+
+```proto
+// (-- api-linter: core::0123::name-never-optional=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  optional string name = 1;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/docs/rules/0123/name-never-optional.md
+++ b/docs/rules/0123/name-never-optional.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Resource name field never optional
 
-This rule enforces that the name field of resource messages is not labeled with
+This rule enforces that the name field of a resource message is not labeled with
 proto3_optional.
 
 ## Details

--- a/rules/aip0123/aip0123.go
+++ b/rules/aip0123/aip0123.go
@@ -41,6 +41,7 @@ func AddRules(r lint.RuleRegistry) error {
 		resourceDefinitionVariables,
 		resourceDefinitionPatterns,
 		resourceDefinitionTypeName,
+		nameNeverOptional,
 	)
 }
 

--- a/rules/aip0123/name_never_optional.go
+++ b/rules/aip0123/name_never_optional.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var nameNeverOptional = &lint.MessageRule{
+	Name: lint.NewRuleName(123, "name-never-optional"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		f := "name"
+		if nf := utils.GetResource(m).GetNameField(); nf != "" {
+			f = nf
+		}
+		return utils.IsResource(m) && m.FindFieldByName(f) != nil
+	},
+	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		f := "name"
+		if nf := utils.GetResource(m).GetNameField(); nf != "" {
+			f = nf
+		}
+		field := m.FindFieldByName(f)
+
+		if field.IsProto3Optional() {
+			return []lint.Problem{{
+				Message:    "Resource name fields must never be labeled with proto3_optional",
+				Descriptor: field,
+				Location:   locations.FieldLabel(field),
+				Suggestion: "",
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0123/name_never_optional_test.go
+++ b/rules/aip0123/name_never_optional_test.go
@@ -1,0 +1,55 @@
+// Copyright 2019 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestNameNeverOptional(t *testing.T) {
+	for _, test := range []struct {
+		name      string
+		FieldName string
+		NameField string
+		Label     string
+		problems  testutils.Problems
+	}{
+		{"Valid", "name", "", "", testutils.Problems{}},
+		{"ValidAlternativeName", "resource", "resource", "", testutils.Problems{}},
+		{"InvalidProto3Optional", "name", "", "optional", testutils.Problems{{Message: "never be labeled"}}},
+		{"SkipNameFieldDNE", "name", "does_not_exist", "", testutils.Problems{}},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+				message Book {
+					option (google.api.resource) = {
+						type: "library.googleapis.com/Book"
+						pattern: "publishers/{publisher}/books/{book}"
+						name_field: "{{.NameField}}"
+					};
+
+					{{.Label}} string {{.FieldName}} = 1;
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(nameNeverOptional.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
AIP-123 does not explicitly state that the name field must not be proto3_optional, but fundamentally it should never be. The use of proto3_optional is outlined in AIP-149, which states that it must only be used when the unset/default empty value holds meaning. In this case, an empty string `""` is not a valid resource name and must never be differentiated as a valid value.

Fixes #1010 