### PR TITLE
fix(ci): use go 1.18 in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   inspect:
     runs-on: ubuntu-latest
-    container: golang:1.14
+    container: golang:1.18
     steps:
       - uses: actions/checkout@v3
         with:
@@ -57,7 +57,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v3
         with:
-          go-version: "1.14"
+          go-version: "1.18"
       - uses: actions/checkout@v3
       # The API linter does not use these,  but we need them to build the
       # binaries.


### PR DESCRIPTION
The `release` job for `darwin/arm64` failed because the `gcc` toolchain for `darwin/arm64` is not available on ubuntu by default. Apparently Go 1.16 added support for this compilation target, so I'm updating to Go 1.18 so as to 1. capture this change and 2. get the release job a little more up to date with modern Go version. I built the X-compiled binary locally with no issue.

We should look at upping the version used across CI and in our `go.mod`.