### PR TITLE
feat(AIP-136): disable http-name-variable and http-parent-variable

### DIFF
--- a/docs/rules/0136/http-name-variable.md
+++ b/docs/rules/0136/http-name-variable.md
@@ -9,6 +9,9 @@ redirect_from:
   - /0136/http-name-variable
 ---
 
+**Important:** This rule has been temporarily disabled as it does not match any
+AIP guidance. See discussion [here][https://github.com/aip-dev/google.aip.dev/issues/955].
+
 # Custom methods: HTTP name variable
 
 This rule enforces that custom methods only use the `name` variable if the RPC

--- a/docs/rules/0136/http-parent-variable.md
+++ b/docs/rules/0136/http-parent-variable.md
@@ -10,6 +10,9 @@ redirect_from:
   - /0136/http-parent-variable
 ---
 
+**Important:** This rule has been temporarily disabled as it does not match any
+AIP guidance. See discussion [here][https://github.com/aip-dev/google.aip.dev/issues/955].
+
 # Custom methods: HTTP parent variable
 
 This rule enforces that custom methods only use the `parent` variable if the

--- a/rules/aip0136/aip0136.go
+++ b/rules/aip0136/aip0136.go
@@ -30,12 +30,14 @@ func AddRules(r lint.RuleRegistry) error {
 		136,
 		httpBody,
 		httpMethod,
-		httpNameVariable,
-		httpParentVariable,
 		noPrepositions,
 		standardMethodsOnly,
 		uriSuffix,
 		verbNoun,
+		// These rules are disabled as they have no matching AIP guidance.
+		// See https://github.com/aip-dev/google.aip.dev/issues/955 for details.
+		// httpNameVariable,
+		// httpParentVariable,
 	)
 }
 


### PR DESCRIPTION
Disable the AIP-136 rules `http-name-variable` and `http-parent-variable` after discussion on https://github.com/aip-dev/google.aip.dev/issues/955 identified that these rules were insufficient and not tied to specific guidance.

Fixes #1023 by disabling it.

Note: The rule documentation has a notice that will be highlighted/formatted to stand out.