### PR TITLE
feat: require Problem to have Descriptor

### DIFF
--- a/lint/lint.go
+++ b/lint/lint.go
@@ -70,6 +70,10 @@ func (l *Linter) lintFileDescriptor(fd *desc.FileDescriptor) (Response, error) {
 		if l.configs.IsRuleEnabled(string(name), fd.GetName()) {
 			if problems, err := l.runAndRecoverFromPanics(rule, fd); err == nil {
 				for _, p := range problems {
+					if p.Descriptor == nil {
+						errMessages = append(errMessages, fmt.Sprintf("rule %q missing required Descriptor in returned Problem", rule.GetName()))
+						continue
+					}
 					if ruleIsEnabled(rule, p.Descriptor, p.Location, aliasMap) {
 						p.RuleID = rule.GetName()
 						resp.Problems = append(resp.Problems, p)

--- a/lint/problem.go
+++ b/lint/problem.go
@@ -39,9 +39,10 @@ type Problem struct {
 	// precise.
 	Suggestion string
 
-	// Descriptor provides the descriptor related to the problem.
+	// Descriptor provides the descriptor related to the problem. This must be
+	// set on every Problem.
 	//
-	// If present and `Location` is not specified, then the starting location of
+	// If `Location` is not specified, then the starting location of
 	// the descriptor is used as the location of the problem.
 	Descriptor desc.Descriptor
 
@@ -75,7 +76,7 @@ func (p Problem) MarshalYAML() (interface{}, error) {
 
 // Marshal defines how to represent a serialized Problem.
 func (p Problem) marshal() interface{} {
-	// Either descriptor or location may be set.
+	// The descriptor is always set, and location may be set.
 	// If they are both set, prefer the location.
 	loc := p.Location
 	if loc == nil && p.Descriptor != nil {


### PR DESCRIPTION
The `lint` framework depends on each `Problem` reporting the `Descriptor` that created the `Problem` for information such as source code location and leading comments (e.g. for local rule exceptions). Parts of the framework work on the assumption that `Descriptor` will always be present on the `Problem`. This is a fair assumption to make and we should enforce it, returning an error if a `Problem` is reported _without_ a `Descriptor`. There is no reason _not_ to include the `Descriptor`.