### PR TITLE
fix(AIP-192): include location in absolute-link finding

### DIFF
--- a/rules/aip0192/absolute_links.go
+++ b/rules/aip0192/absolute_links.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -42,6 +43,7 @@ var absoluteLinks = &lint.DescriptorRule{
 				return []lint.Problem{{
 					Message:    "Links in comments should be absolute and begin with https://",
 					Descriptor: d,
+					Location:   locations.DescriptorName(d),
 				}}
 			}
 		}


### PR DESCRIPTION
The `absolute-link` rule did not include a location on the resulting finding. We can give a rough estimate on the location of the specific descriptor/element which has the offending comment.

This fixes an internally filed issue http://b/263138317.