### PR TITLE
chore: switch to statticcheck, fix linting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,8 +20,10 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: 1.18
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+      - name: staticcheck
+        uses: dominikh/staticcheck-action@v1.2.0
+        with:
+          version: "2022.1.1"
   quality-checker:
     runs-on: ubuntu-latest
     steps:

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -46,9 +46,9 @@ type cli struct {
 	ListRulesFlag           bool
 }
 
-// ErrExitForLintFailure is an error to indicate that an error
-// was found during linting.
-var ErrExitForLintFailure = errors.New("found problems during linting")
+// ExitForLintFailure indicates that a problem was found during linting.
+//lint:ignore ST1012 modifying this variable name is a breaking change.
+var ExitForLintFailure = errors.New("found problems during linting")
 
 func newCli(args []string) *cli {
 	// Define flag variables.
@@ -211,7 +211,7 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 	// Return error on lint failure which subsequently
 	// exits with a non-zero status code
 	if c.ExitStatusOnLintFailure && anyProblems(results) {
-		return ErrExitForLintFailure
+		return ExitForLintFailure
 	}
 
 	return nil

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -46,7 +46,9 @@ type cli struct {
 	ListRulesFlag           bool
 }
 
-var ExitForLintFailure = errors.New("found problems during linting")
+// ErrExitForLintFailure is an error to indicate that an error
+// was found during linting.
+var ErrExitForLintFailure = errors.New("found problems during linting")
 
 func newCli(args []string) *cli {
 	// Define flag variables.
@@ -209,7 +211,7 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 	// Return error on lint failure which subsequently
 	// exits with a non-zero status code
 	if c.ExitStatusOnLintFailure && anyProblems(results) {
-		return ExitForLintFailure
+		return ErrExitForLintFailure
 	}
 
 	return nil

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -234,7 +234,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 	args = append(args, appendArgs...)
 
 	lintErr := runCLI(args)
-	if lintErr != nil && !errors.Is(lintErr, ErrExitForLintFailure) {
+	if lintErr != nil && !errors.Is(lintErr, ExitForLintFailure) {
 		t.Fatal(lintErr)
 	}
 
@@ -242,7 +242,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 	if err != nil {
 		t.Fatal(err)
 	}
-	return errors.Is(lintErr, ErrExitForLintFailure), string(out)
+	return errors.Is(lintErr, ExitForLintFailure), string(out)
 }
 
 func writeFile(path, content string) error {

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -234,7 +234,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 	args = append(args, appendArgs...)
 
 	lintErr := runCLI(args)
-	if lintErr != nil && !errors.Is(lintErr, ExitForLintFailure) {
+	if lintErr != nil && !errors.Is(lintErr, ErrExitForLintFailure) {
 		t.Fatal(lintErr)
 	}
 
@@ -242,7 +242,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 	if err != nil {
 		t.Fatal(err)
 	}
-	return errors.Is(lintErr, ExitForLintFailure), string(out)
+	return errors.Is(lintErr, ErrExitForLintFailure), string(out)
 }
 
 func writeFile(path, content string) error {

--- a/lint/problem.go
+++ b/lint/problem.go
@@ -60,7 +60,7 @@ type Problem struct {
 	// The category for this problem, based on user configuration.
 	category string
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -50,7 +50,7 @@ type FileRule struct {
 	// is applicable.
 	OnlyIf func(*desc.FileDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -82,7 +82,7 @@ type MessageRule struct {
 	// is applicable.
 	OnlyIf func(*desc.MessageDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -119,7 +119,7 @@ type FieldRule struct {
 	// is applicable.
 	OnlyIf func(*desc.FieldDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -158,7 +158,7 @@ type ServiceRule struct {
 	// is applicable.
 	OnlyIf func(*desc.ServiceDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -192,7 +192,7 @@ type MethodRule struct {
 	// is applicable.
 	OnlyIf func(*desc.MethodDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -228,7 +228,7 @@ type EnumRule struct {
 	// is applicable.
 	OnlyIf func(*desc.EnumDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -264,7 +264,7 @@ type EnumValueRule struct {
 	// is applicable.
 	OnlyIf func(*desc.EnumValueDescriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 
@@ -306,7 +306,7 @@ type DescriptorRule struct {
 	// is applicable.
 	OnlyIf func(desc.Descriptor) bool
 
-	// nolint:structcheck,unused
+	//lint:ignore U1000 ignored via golint previously
 	noPositional struct{}
 }
 

--- a/lint/rule_urls.go
+++ b/lint/rule_urls.go
@@ -18,23 +18,23 @@ import "strings"
 //	}
 var ruleURLMappings = []func(string) string{
 	coreRuleURL,
-	clientLibrariesRuleUrl,
-	cloudRuleUrl,
+	clientLibrariesRuleURL,
+	cloudRuleURL,
 }
 
 func coreRuleURL(ruleName string) string {
-	return groupUrl(ruleName, "core")
+	return groupURL(ruleName, "core")
 }
 
-func clientLibrariesRuleUrl(ruleName string) string {
-	return groupUrl(ruleName, "client-libraries")
+func clientLibrariesRuleURL(ruleName string) string {
+	return groupURL(ruleName, "client-libraries")
 }
 
-func cloudRuleUrl(ruleName string) string {
-	return groupUrl(ruleName, "cloud")
+func cloudRuleURL(ruleName string) string {
+	return groupURL(ruleName, "cloud")
 }
 
-func groupUrl(ruleName, groupName string) string {
+func groupURL(ruleName, groupName string) string {
 	base := "https://linter.aip.dev/"
 	nameParts := strings.Split(ruleName, "::") // e.g., client-libraries::0122::camel-case-uris -> ["client-libraries", "0122", "camel-case-uris"]
 	if len(nameParts) == 0 || nameParts[0] != groupName {

--- a/lint/rule_urls_test.go
+++ b/lint/rule_urls_test.go
@@ -35,7 +35,7 @@ func TestClientLibrariesRuleURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := clientLibrariesRuleUrl(test.rule); got != test.url {
+			if got := clientLibrariesRuleURL(test.rule); got != test.url {
 				t.Errorf("clientLibrariesRuleUrl(%s) got %s, but want %s", test.name, got, test.url)
 			}
 		})
@@ -54,7 +54,7 @@ func TestCloudRuleURL(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			if got := cloudRuleUrl(test.rule); got != test.url {
+			if got := cloudRuleURL(test.rule); got != test.url {
 				t.Errorf("cloudRuleUrl(%s) got %s, but want %s", test.name, got, test.url)
 			}
 		})

--- a/rules/aip0152/aip0152.go
+++ b/rules/aip0152/aip0152.go
@@ -29,7 +29,7 @@ func AddRules(r lint.RuleRegistry) error {
 		152,
 		httpBody,
 		httpMethod,
-		httpUriSuffix,
+		httpURISuffix,
 		requestMessageName,
 		requestNameBehavior,
 		requestNameField,

--- a/rules/aip0152/http_uri_suffix.go
+++ b/rules/aip0152/http_uri_suffix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Run methods should have a proper HTTP pattern.
-var httpUriSuffix = &lint.MethodRule{
+var httpURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(152, "http-uri-suffix"),
 	OnlyIf: isRunMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0152/http_uri_suffix_test.go
+++ b/rules/aip0152/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -40,7 +40,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}
@@ -48,7 +48,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				message {{.MethodName}}Request{}
 				message {{.MethodName}}Response{}
 				`, test)
-			problems := httpUriSuffix.Lint(file)
+			problems := httpURISuffix.Lint(file)
 			if diff := test.problems.SetDescriptor(file.GetServices()[0].GetMethods()[0]).Diff(problems); diff != "" {
 				t.Errorf(diff)
 			}

--- a/rules/aip0162/aip0162.go
+++ b/rules/aip0162/aip0162.go
@@ -146,17 +146,20 @@ var (
 	listRevisionsURINameRegexp     = regexp.MustCompile(`:listRevisions$`)
 )
 
-// Returns true if this is an AIP-162 List Revisions method, false otherwise.
+// IsListRevisionsMethod returns true if this is an AIP-162 List Revisions method,
+// false otherwise.
 func IsListRevisionsMethod(m *desc.MethodDescriptor) bool {
 	return listRevisionsMethodRegexp.MatchString(m.GetName())
 }
 
-// Returns true if this is an AIP-162 List Revisions request message, false otherwise.
+// IsListRevisionsRequestMessage returns true if this is an AIP-162 List
+// Revisions request message, false otherwise.
 func IsListRevisionsRequestMessage(m *desc.MessageDescriptor) bool {
 	return listRevisionsReqMessageRegexp.MatchString(m.GetName())
 }
 
-// Returns true if this is an AIP-162 List Revisions response message, false otherwise.
+// IsListRevisionsResponseMessage returns true if this is an AIP-162 List
+// Revisions response message, false otherwise.
 func IsListRevisionsResponseMessage(m *desc.MessageDescriptor) bool {
 	return listRevisionsRespMessageRegexp.MatchString(m.GetName())
 }

--- a/rules/aip0164/http_uri_suffix_test.go
+++ b/rules/aip0164/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -40,7 +40,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns (Book) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}

--- a/rules/aip0165/http_uri_suffix_test.go
+++ b/rules/aip0165/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -40,7 +40,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}

--- a/rules/aip0233/aip0233.go
+++ b/rules/aip0233/aip0233.go
@@ -31,7 +31,7 @@ func AddRules(r lint.RuleRegistry) error {
 		requestMessageName,
 		responseMessageName,
 		httpBody,
-		httpUriSuffix,
+		httpURISuffix,
 		httpVerb,
 		requestParentField,
 		requestParentReference,

--- a/rules/aip0233/http_method_test.go
+++ b/rules/aip0233/http_method_test.go
@@ -24,7 +24,7 @@ func TestHttpVerb(t *testing.T) {
 	// Set up testing permutations.
 	tests := []struct {
 		testName   string
-		HttpVerb   string
+		HTTPVerb   string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -42,7 +42,7 @@ func TestHttpVerb(t *testing.T) {
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							{{.HttpVerb}}: "/v1/{parent=publishers/*}/books:batchCreate"
+							{{.HTTPVerb}}: "/v1/{parent=publishers/*}/books:batchCreate"
 							body: "*"
 						};
 					}

--- a/rules/aip0233/http_uri_suffix.go
+++ b/rules/aip0233/http_uri_suffix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Batch Create methods should have a proper HTTP pattern.
-var httpUriSuffix = &lint.MethodRule{
+var httpURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(233, "http-uri-suffix"),
 	OnlyIf: isBatchCreateMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0233/http_uri_suffix_test.go
+++ b/rules/aip0233/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -37,11 +37,11 @@ func TestHttpUriSuffix(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}
@@ -51,7 +51,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				`, test)
 
 			// Run the method, ensure we get what we expect.
-			problems := httpUriSuffix.Lint(file)
+			problems := httpURISuffix.Lint(file)
 			if diff := test.problems.SetDescriptor(file.GetServices()[0].GetMethods()[0]).Diff(problems); diff != "" {
 				t.Errorf(diff)
 			}

--- a/rules/aip0233/plural_method_name_test.go
+++ b/rules/aip0233/plural_method_name_test.go
@@ -25,25 +25,25 @@ func TestMethodPluralResourceName(t *testing.T) {
 	tests := []struct {
 		testName   string
 		MethodName string
-		UriSuffix  string
+		URISuffix  string
 		problems   testutils.Problems
 	}{
 		{
 			testName:   "Valid-BatchCreateBooks",
 			MethodName: "BatchCreateBooks",
-			UriSuffix:  "books:batchCreate",
+			URISuffix:  "books:batchCreate",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Valid-BatchCreateMen",
 			MethodName: "BatchCreateMen",
-			UriSuffix:  "men:batchCreate",
+			URISuffix:  "men:batchCreate",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Invalid-SingularBus",
 			MethodName: "BatchCreateBus",
-			UriSuffix:  "bus:batchCreate",
+			URISuffix:  "bus:batchCreate",
 			problems: testutils.Problems{{
 				Suggestion: "BatchCreateBuses",
 			}},
@@ -51,7 +51,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-SingularCorpPerson",
 			MethodName: "BatchCreateCorpPerson",
-			UriSuffix:  "corpPerson:batchCreate",
+			URISuffix:  "corpPerson:batchCreate",
 			problems: testutils.Problems{{
 				Suggestion: "BatchCreateCorpPeople",
 			}},
@@ -59,7 +59,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-Irrelevant",
 			MethodName: "AcquireBook",
-			UriSuffix:  "book",
+			URISuffix:  "book",
 			problems:   testutils.Problems{},
 		},
 	}
@@ -69,18 +69,18 @@ func TestMethodPluralResourceName(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "/v1/{parent=publishers/*}/{{.UriSuffix}}"
+							post: "/v1/{parent=publishers/*}/{{.URISuffix}}"
 							body: "*"
 						};
 					}
 				}
-				
+
 				message {{.MethodName}}Request {}
-				
+
 				message {{.MethodName}}Response{}
 				`, test)
 

--- a/rules/aip0234/aip0234.go
+++ b/rules/aip0234/aip0234.go
@@ -29,7 +29,7 @@ func AddRules(r lint.RuleRegistry) error {
 		234,
 		httpBody,
 		httpMethod,
-		httpUriSuffix,
+		httpURISuffix,
 		pluralMethodName,
 		requestMessageName,
 		requestParentField,

--- a/rules/aip0234/http_method_test.go
+++ b/rules/aip0234/http_method_test.go
@@ -24,7 +24,7 @@ func TestHttpMethod(t *testing.T) {
 	// Set up testing permutations.
 	tests := []struct {
 		testName   string
-		HttpVerb   string
+		HTTPVerb   string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -38,11 +38,11 @@ func TestHttpMethod(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							{{.HttpVerb}}: "/v1/{parent=publishers/*}/books:batchUpdate"
+							{{.HTTPVerb}}: "/v1/{parent=publishers/*}/books:batchUpdate"
 							body: "*"
 						};
 					}

--- a/rules/aip0234/http_uri_suffix.go
+++ b/rules/aip0234/http_uri_suffix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Batch Update methods should have a proper HTTP pattern.
-var httpUriSuffix = &lint.MethodRule{
+var httpURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(234, "http-uri-suffix"),
 	OnlyIf: isBatchUpdateMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0234/http_uri_suffix_test.go
+++ b/rules/aip0234/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -37,11 +37,11 @@ func TestHttpUriSuffix(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}
@@ -51,7 +51,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				`, test)
 
 			// Run the method, ensure we get what we expect.
-			problems := httpUriSuffix.Lint(file)
+			problems := httpURISuffix.Lint(file)
 			if diff := test.problems.SetDescriptor(file.GetServices()[0].GetMethods()[0]).Diff(problems); diff != "" {
 				t.Errorf(diff)
 			}

--- a/rules/aip0234/plural_method_name_test.go
+++ b/rules/aip0234/plural_method_name_test.go
@@ -25,25 +25,25 @@ func TestMethodPluralResourceName(t *testing.T) {
 	tests := []struct {
 		testName   string
 		MethodName string
-		UriSuffix  string
+		URISuffix  string
 		problems   testutils.Problems
 	}{
 		{
 			testName:   "Valid-BatchUpdateBooks",
 			MethodName: "BatchUpdateBooks",
-			UriSuffix:  "books:batchUpdate",
+			URISuffix:  "books:batchUpdate",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Valid-BatchUpdateMen",
 			MethodName: "BatchUpdateMen",
-			UriSuffix:  "men:batchUpdate",
+			URISuffix:  "men:batchUpdate",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Invalid-SingularBus",
 			MethodName: "BatchUpdateBus",
-			UriSuffix:  "bus:batchUpdate",
+			URISuffix:  "bus:batchUpdate",
 			problems: testutils.Problems{{
 				Suggestion: "BatchUpdateBuses",
 			}},
@@ -51,7 +51,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-SingularCorpPerson",
 			MethodName: "BatchUpdateCorpPerson",
-			UriSuffix:  "corpPerson:batchUpdate",
+			URISuffix:  "corpPerson:batchUpdate",
 			problems: testutils.Problems{{
 				Suggestion: "BatchUpdateCorpPeople",
 			}},
@@ -59,7 +59,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-Irrelevant",
 			MethodName: "AcquireBook",
-			UriSuffix:  "book",
+			URISuffix:  "book",
 			problems:   testutils.Problems{},
 		},
 	}
@@ -69,18 +69,18 @@ func TestMethodPluralResourceName(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "/v1/{parent=publishers/*}/{{.UriSuffix}}"
+							post: "/v1/{parent=publishers/*}/{{.URISuffix}}"
 							body: "*"
 						};
 					}
 				}
-				
+
 				message {{.MethodName}}Request {}
-				
+
 				message {{.MethodName}}Response{}
 				`, test)
 

--- a/rules/aip0235/aip0235.go
+++ b/rules/aip0235/aip0235.go
@@ -29,7 +29,7 @@ func AddRules(r lint.RuleRegistry) error {
 		235,
 		httpBody,
 		httpMethod,
-		httpUriSuffix,
+		httpURISuffix,
 		pluralMethodName,
 		requestMessageName,
 		requestNamesBehavior,

--- a/rules/aip0235/http_uri_suffix.go
+++ b/rules/aip0235/http_uri_suffix.go
@@ -22,7 +22,7 @@ import (
 )
 
 // Batch Delete methods should have a proper HTTP pattern.
-var httpUriSuffix = &lint.MethodRule{
+var httpURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(235, "http-uri-suffix"),
 	OnlyIf: isBatchDeleteMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {

--- a/rules/aip0235/http_uri_suffix_test.go
+++ b/rules/aip0235/http_uri_suffix_test.go
@@ -23,7 +23,7 @@ import (
 func TestHttpUriSuffix(t *testing.T) {
 	tests := []struct {
 		testName   string
-		HttpUri    string
+		HTTPURI    string
 		MethodName string
 		problems   testutils.Problems
 	}{
@@ -37,11 +37,11 @@ func TestHttpUriSuffix(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "{{.HttpUri}}"
+							post: "{{.HTTPURI}}"
 							body: "*"
 						};
 					}
@@ -51,7 +51,7 @@ func TestHttpUriSuffix(t *testing.T) {
 				`, test)
 
 			// Run the method, ensure we get what we expect.
-			problems := httpUriSuffix.Lint(file)
+			problems := httpURISuffix.Lint(file)
 			if diff := test.problems.SetDescriptor(file.GetServices()[0].GetMethods()[0]).Diff(problems); diff != "" {
 				t.Errorf(diff)
 			}

--- a/rules/aip0235/plural_method_name_test.go
+++ b/rules/aip0235/plural_method_name_test.go
@@ -25,25 +25,25 @@ func TestMethodPluralResourceName(t *testing.T) {
 	tests := []struct {
 		testName   string
 		MethodName string
-		UriSuffix  string
+		URISuffix  string
 		problems   testutils.Problems
 	}{
 		{
 			testName:   "Valid-BatchDeleteBooks",
 			MethodName: "BatchDeleteBooks",
-			UriSuffix:  "books:batchDelete",
+			URISuffix:  "books:batchDelete",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Valid-BatchDeleteMen",
 			MethodName: "BatchDeleteMen",
-			UriSuffix:  "men:batchDelete",
+			URISuffix:  "men:batchDelete",
 			problems:   testutils.Problems{},
 		},
 		{
 			testName:   "Invalid-SingularBus",
 			MethodName: "BatchDeleteBus",
-			UriSuffix:  "bus:batchDelete",
+			URISuffix:  "bus:batchDelete",
 			problems: testutils.Problems{{
 				Suggestion: "BatchDeleteBuses",
 			}},
@@ -51,7 +51,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-SingularCorpPerson",
 			MethodName: "BatchDeleteCorpPerson",
-			UriSuffix:  "corpPerson:batchDelete",
+			URISuffix:  "corpPerson:batchDelete",
 			problems: testutils.Problems{{
 				Suggestion: "BatchDeleteCorpPeople",
 			}},
@@ -59,7 +59,7 @@ func TestMethodPluralResourceName(t *testing.T) {
 		{
 			testName:   "Invalid-Irrelevant",
 			MethodName: "AcquireBook",
-			UriSuffix:  "book",
+			URISuffix:  "book",
 			problems:   testutils.Problems{},
 		},
 	}
@@ -69,18 +69,18 @@ func TestMethodPluralResourceName(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
 				import "google/api/annotations.proto";
-				
+
 				service BookService {
 					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {
 						option (google.api.http) = {
-							post: "/v1/{parent=publishers/*}/{{.UriSuffix}}"
+							post: "/v1/{parent=publishers/*}/{{.URISuffix}}"
 							body: "*"
 						};
 					}
 				}
-				
+
 				message {{.MethodName}}Request {}
-				
+
 				message {{.MethodName}}Response{}
 				`, test)
 

--- a/rules/internal/utils/http.go
+++ b/rules/internal/utils/http.go
@@ -129,7 +129,9 @@ func (h *HTTPRule) GetPlainURI() string {
 }
 
 var (
-	plainVar         = regexp.MustCompile(`\{([^}=]+)\}`)
-	varSegment       = regexp.MustCompile(`\{([^}=]+)=([^}]+)\}`)
+	plainVar   = regexp.MustCompile(`\{([^}=]+)\}`)
+	varSegment = regexp.MustCompile(`\{([^}=]+)=([^}]+)\}`)
+	// VersionedSegment is a regex to extract the API version from
+	// an HTTP path.
 	VersionedSegment = regexp.MustCompile(`\{\$api_version\}`)
 )


### PR DESCRIPTION
 using staticcheck as golint has been deprecated.
    
golint errors ignore comments were also not being
honored, so switching to staticcheck enables the whole
repository pass some form of linter.

 Go lint had multiple findings when run on the full codebase.
    
 Fixing those to help ensure future contributors have less friction
 and confusion wondering if the errors were caused by them.

