### PR TITLE
chore: Update staticcheck-action action to v1.3.0

### DIFF
--- a/.github/quality-checker/rule_documented.go
+++ b/.github/quality-checker/rule_documented.go
@@ -16,13 +16,13 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 )
 
 func checkRuleDocumented(aip int, name string) []error {
 	// Ensure that the expected documentation file exists.
 	wantFile := fmt.Sprintf("docs/rules/%04d/%s.md", aip, name)
-	if _, err := ioutil.ReadFile(wantFile); err != nil {
+	if _, err := os.ReadFile(wantFile); err != nil {
 		return []error{fmt.Errorf("missing rule documentation: %s", wantFile)}
 	}
 	return nil

--- a/.github/quality-checker/rule_name.go
+++ b/.github/quality-checker/rule_name.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 
 	"github.com/stoewer/go-strcase"
@@ -26,7 +26,7 @@ func checkRuleName(aip int, name string) []error {
 	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
 
 	// Read in the file.
-	contentsBytes, err := ioutil.ReadFile(path)
+	contentsBytes, err := os.ReadFile(path)
 	if err != nil {
 		return []error{err}
 	}

--- a/.github/quality-checker/rule_registered.go
+++ b/.github/quality-checker/rule_registered.go
@@ -16,7 +16,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"strings"
 
@@ -27,7 +27,7 @@ func checkRuleRegistered(aip int, name string) []error {
 	path := fmt.Sprintf("rules/aip%04d/%s.go", aip, strcase.SnakeCase(name))
 
 	// Read in the file.
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	if err != nil {
 		return []error{err}
 	}
@@ -43,7 +43,7 @@ func checkRuleRegistered(aip int, name string) []error {
 
 	// Ensure this rule is registered within its AIP module file.
 	ruleVar := ruleMatch[1]
-	contents, err = ioutil.ReadFile(fmt.Sprintf("rules/aip%04d/aip%04d.go", aip, aip))
+	contents, err = os.ReadFile(fmt.Sprintf("rules/aip%04d/aip%04d.go", aip, aip))
 	if err != nil {
 		return []error{err}
 	}
@@ -52,7 +52,7 @@ func checkRuleRegistered(aip int, name string) []error {
 	}
 
 	// Ensure that the AIP itself is registered in `rules/rules.go`.
-	contents, err = ioutil.ReadFile("rules/rules.go")
+	contents, err = os.ReadFile("rules/rules.go")
 	if err != nil {
 		errata = append(errata, err)
 		return errata

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
         with:
           go-version: 1.18
       - name: staticcheck
-        uses: dominikh/staticcheck-action@v1.2.0
+        uses: dominikh/staticcheck-action@v1.3.0
         with:
           version: "2022.1.1"
   quality-checker:

--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -243,7 +242,7 @@ func loadFileDescriptors(filePaths ...string) (map[string]*desc.FileDescriptor, 
 }
 
 func readFileDescriptorSet(filePath string) (*dpb.FileDescriptorSet, error) {
-	in, err := ioutil.ReadFile(filePath)
+	in, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -17,7 +17,6 @@ package main
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -199,7 +198,7 @@ func runLinter(t *testing.T, protoContent, configContent string) string {
 }
 
 func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string, appendArgs []string) (bool, string) {
-	tempDir, err := ioutil.TempDir("", "test")
+	tempDir, err := os.MkdirTemp("", "test")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -238,7 +237,7 @@ func runLinterWithFailureStatus(t *testing.T, protoContent, configContent string
 		t.Fatal(lintErr)
 	}
 
-	out, err := ioutil.ReadFile(outPath)
+	out, err := os.ReadFile(outPath)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -253,5 +252,5 @@ func writeFile(path, content string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(path, []byte(content), 0o644)
+	return os.WriteFile(path, []byte(content), 0o644)
 }

--- a/lint/config.go
+++ b/lint/config.go
@@ -18,7 +18,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func ReadConfigsFromFile(path string) (Configs, error) {
 
 // ReadConfigsJSON reads Configs from a JSON file.
 func ReadConfigsJSON(f io.Reader) (Configs, error) {
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +77,7 @@ func ReadConfigsJSON(f io.Reader) (Configs, error) {
 
 // ReadConfigsYAML reads Configs from a YAML(.yml or .yaml) file.
 func ReadConfigsYAML(f io.Reader) (Configs, error) {
-	b, err := ioutil.ReadAll(f)
+	b, err := io.ReadAll(f)
 	if err != nil {
 		return nil, err
 	}

--- a/lint/config_test.go
+++ b/lint/config_test.go
@@ -16,7 +16,6 @@ package lint
 
 import (
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -446,12 +445,12 @@ func TestReadConfigsFromFile(t *testing.T) {
 }
 
 func createTempFile(t *testing.T, name, content string) string {
-	dir, err := ioutil.TempDir("", "config_tests")
+	dir, err := os.MkdirTemp("", "config_tests")
 	if err != nil {
 		t.Fatal(err)
 	}
 	filePath := filepath.Join(dir, name)
-	if err := ioutil.WriteFile(filePath, []byte(content), 0o644); err != nil {
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
 		t.Fatal(err)
 	}
 	return filePath


### PR DESCRIPTION
This is a duplicate of #1085, which could not
be merged automatically.

removing references to ioutil as the package has been deprecated and now just shims to functions in io / os.