### PR TITLE
feat: add the ability to ignore comment disables

### DIFF
--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -77,7 +77,7 @@ func TestRules_EnabledByDefault(t *testing.T) {
 			proto := test.proto
 			result := runLinter(t, proto, "")
 			if !strings.Contains(result, test.rule) {
-				t.Errorf("Rule %q should be enabled by default", test.rule)
+				t.Errorf("rule %q should be enabled by default", test.rule)
 			}
 		})
 	}
@@ -90,22 +90,47 @@ func TestRules_DisabledByFileComments(t *testing.T) {
 			proto := disableInFile + "\n" + test.proto
 			result := runLinter(t, proto, "")
 			if strings.Contains(result, test.rule) {
-				t.Errorf("Rule %q should be disabled by file comments", test.rule)
+				t.Errorf("rule %q should be disabled by file comments", test.rule)
 			}
 		})
 	}
 }
 
 func TestRules_DisabledByInlineComments(t *testing.T) {
+	testConfigurations := []struct {
+		suffix       string
+		appendArgs   []string
+		wantDisabled bool
+	}{
+		{
+			suffix:       "WithIgnoreCommentDisablesTrue",
+			appendArgs:   []string{"--ignore-comment-disables=true"},
+			wantDisabled: false,
+		},
+		{
+			suffix:       "WithIgnoreCommentDisablesFalse",
+			appendArgs:   []string{"--ignore-comment-disables=false"},
+			wantDisabled: true,
+		},
+		{
+			suffix:       "WithNoFlags",
+			appendArgs:   []string{},
+			wantDisabled: true,
+		},
+	}
+
 	for _, test := range testCases {
-		t.Run(test.testName, func(t *testing.T) {
-			disableInline := fmt.Sprintf("(-- api-linter: %s=disabled --)", test.rule)
-			proto := strings.Replace(test.proto, "disable-me-here", disableInline, -1)
-			result := runLinter(t, proto, "")
-			if strings.Contains(result, test.rule) {
-				t.Errorf("Rule %q should be disabled by in-line comments", test.rule)
-			}
-		})
+		for _, testConfig := range testConfigurations {
+			t.Run(test.testName+testConfig.suffix, func(t *testing.T) {
+				disableInline := fmt.Sprintf("(-- api-linter: %s=disabled --)", test.rule)
+				proto := strings.Replace(test.proto, "disable-me-here", disableInline, -1)
+				_, result := runLinterWithFailureStatus(t, proto, "", testConfig.appendArgs)
+				isDisabled := !strings.Contains(result, test.rule)
+				if isDisabled != testConfig.wantDisabled {
+					t.Errorf("want %q disabled by in-line comments to be %v with flags %v, got %v", test.rule, testConfig.wantDisabled, testConfig.appendArgs, isDisabled)
+				}
+			})
+		}
 	}
 }
 
@@ -123,7 +148,7 @@ func TestRules_DisabledByConfig(t *testing.T) {
 			c := strings.Replace(config, "replace-me-here", test.rule, -1)
 			result := runLinter(t, test.proto, c)
 			if strings.Contains(result, test.rule) {
-				t.Errorf("Rule %q should be disabled by the user config: %q", test.rule, c)
+				t.Errorf("rule %q should be disabled by the user config: %q", test.rule, c)
 			}
 		})
 	}

--- a/lint/lint.go
+++ b/lint/lint.go
@@ -27,9 +27,10 @@ import (
 
 // Linter checks API files and returns a list of detected problems.
 type Linter struct {
-	rules   RuleRegistry
-	configs Configs
-	debug   bool
+	rules                 RuleRegistry
+	configs               Configs
+	debug                 bool
+	ignoreCommentDisables bool
 }
 
 // LinterOption prvoides the ability to configure the Linter.
@@ -39,6 +40,13 @@ type LinterOption func(l *Linter)
 func Debug(debug bool) LinterOption {
 	return func(l *Linter) {
 		l.debug = debug
+	}
+}
+
+// IgnoreCommentDisables sets the flag for ignoring comments which disable rules.
+func IgnoreCommentDisables(ignoreCommentDisables bool) LinterOption {
+	return func(l *Linter) {
+		l.ignoreCommentDisables = ignoreCommentDisables
 	}
 }
 
@@ -91,7 +99,7 @@ func (l *Linter) lintFileDescriptor(fd *desc.FileDescriptor) (Response, error) {
 						errMessages = append(errMessages, fmt.Sprintf("rule %q missing required Descriptor in returned Problem", rule.GetName()))
 						continue
 					}
-					if ruleIsEnabled(rule, p.Descriptor, p.Location, aliasMap) {
+					if ruleIsEnabled(rule, p.Descriptor, p.Location, aliasMap, l.ignoreCommentDisables) {
 						p.RuleID = rule.GetName()
 						resp.Problems = append(resp.Problems, p)
 					}

--- a/lint/lint_test.go
+++ b/lint/lint_test.go
@@ -178,3 +178,29 @@ func TestLinter_debug(t *testing.T) {
 		})
 	}
 }
+
+func TestLinter_IgnoreCommentDisables(t *testing.T) {
+	tests := []struct {
+		name                  string
+		ignoreCommentDisables bool
+	}{
+		{
+			name:                  "ignoreCommentDisables",
+			ignoreCommentDisables: true,
+		},
+		{
+			name:                  "do not ignoreCommentDisables",
+			ignoreCommentDisables: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			l := New(NewRuleRegistry(), nil, IgnoreCommentDisables(test.ignoreCommentDisables))
+
+			if a, e := l.ignoreCommentDisables, test.ignoreCommentDisables; a != e {
+				t.Errorf("got ignoreCommentDisables %v wanted ignoreCommentDisables %v", a, e)
+			}
+		})
+	}
+}

--- a/lint/rule_enabled_test.go
+++ b/lint/rule_enabled_test.go
@@ -71,8 +71,13 @@ func TestRuleIsEnabled(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error building test message")
 			}
-			if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0], nil, aliases), test.enabled; got != want {
+			if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0], nil, aliases, false), test.enabled; got != want {
 				t.Errorf("Expected the test rule to return %v from ruleIsEnabled, got %v", want, got)
+			}
+			if !test.enabled {
+				if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0], nil, aliases, true), true; got != want {
+					t.Errorf("Expected the test rule with ignoreCommentDisables true to return %v from ruleIsEnabled, got %v", want, got)
+				}
 			}
 		})
 	}
@@ -98,10 +103,10 @@ func TestRuleIsEnabledFirstMessage(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building test file: %q", err)
 	}
-	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0], nil, nil), false; got != want {
+	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0], nil, nil, false), false; got != want {
 		t.Errorf("Expected the first message to return %v from ruleIsEnabled, got %v", want, got)
 	}
-	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[1], nil, nil), true; got != want {
+	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[1], nil, nil, false), true; got != want {
 		t.Errorf("Expected the second message to return %v from ruleIsEnabled, got %v", want, got)
 	}
 }
@@ -126,10 +131,10 @@ func TestRuleIsEnabledParent(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error building test file: %q", err)
 	}
-	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0].GetFields()[0], nil, nil), false; got != want {
+	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0].GetFields()[0], nil, nil, false), false; got != want {
 		t.Errorf("Expected the foo field to return %v from ruleIsEnabled; got %v", want, got)
 	}
-	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[1].GetFields()[0], nil, nil), true; got != want {
+	if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[1].GetFields()[0], nil, nil, false), true; got != want {
 		t.Errorf("Expected the foo field to return %v from ruleIsEnabled; got %v", want, got)
 	}
 }
@@ -166,7 +171,7 @@ func TestRuleIsEnabledDeprecated(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Error building test file: %q", err)
 			}
-			if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0].GetFields()[0], nil, nil), test.enabled; got != want {
+			if got, want := ruleIsEnabled(rule, f.GetMessageTypes()[0].GetFields()[0], nil, nil, false), test.enabled; got != want {
 				t.Errorf("Expected the foo field to return %v from ruleIsEnabled; got %v", want, got)
 			}
 		})


### PR DESCRIPTION
For strict enforcement of AIPs across an organization, it's valuable to disable the ability to have text in the proto disable linter rules.