### PR TITLE
feat(AIP-148): use uid instead of id

### DIFF
--- a/docs/rules/0148/use-uid.md
+++ b/docs/rules/0148/use-uid.md
@@ -15,9 +15,8 @@ mandated in [AIP-148][].
 
 ## Details
 
-This rule looks for fields named `first_name` and `last_name`, and complains if
-it finds them, suggesting the use of `given_name` and `family_name`
-(respectively) instead.
+This rule looks on resource messages for a field named `id`, complains if it
+finds it, and suggests the use of `uid` instead.
 
 ## Examples
 
@@ -25,9 +24,14 @@ it finds them, suggesting the use of `given_name` and `family_name`
 
 ```proto
 // Incorrect.
-message Human {
-  string first_name = 1;  // Should be `given_name`.
-  string last_name = 2;   // Should be `family_name`
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "books/{book}"
+  };
+
+  string name = 1;
+  string id = 2; // Should be `uid`
 }
 ```
 
@@ -35,9 +39,14 @@ message Human {
 
 ```proto
 // Correct.
-message Human {
-  string given_name = 1;
-  string family_name = 2;
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "books/{book}"
+  };
+
+  string name = 1;
+  string uid = 2;
 }
 ```
 
@@ -48,11 +57,16 @@ enclosing message. Remember to also include an [aip.dev/not-precedent][]
 comment explaining why.
 
 ```proto
-// (-- api-linter: core::0148::human-names=disabled
+// (-- api-linter: core::0148::use-uid=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
-message Human {
-  string first_name = 1;
-  string last_name = 2;
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "books/{book}"
+  };
+
+  string name = 1;
+  string id = 2;
 }
 ```
 

--- a/docs/rules/0148/use-uid.md
+++ b/docs/rules/0148/use-uid.md
@@ -1,0 +1,63 @@
+---
+rule:
+  aip: 148
+  name: [core, '0148', use-uid]
+  summary: Use uid instead of id in resource messages.
+permalink: /148/use-uid
+redirect_from:
+  - /0148/use-uid
+---
+
+# Human names
+
+This rule encourages the use of `uid` instead of `id` for resource messages, as
+mandated in [AIP-148][].
+
+## Details
+
+This rule looks for fields named `first_name` and `last_name`, and complains if
+it finds them, suggesting the use of `given_name` and `family_name`
+(respectively) instead.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Human {
+  string first_name = 1;  // Should be `given_name`.
+  string last_name = 2;   // Should be `family_name`
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Human {
+  string given_name = 1;
+  string family_name = 2;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the field or its
+enclosing message. Remember to also include an [aip.dev/not-precedent][]
+comment explaining why.
+
+```proto
+// (-- api-linter: core::0148::human-names=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message Human {
+  string first_name = 1;
+  string last_name = 2;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-148]: https://aip.dev/148
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0148/aip0148.go
+++ b/rules/aip0148/aip0148.go
@@ -26,5 +26,6 @@ func AddRules(r lint.RuleRegistry) error {
 		declarativeFriendlyRequired,
 		fieldBehavior,
 		humanNames,
+		useUid,
 	)
 }

--- a/rules/aip0148/use_uid.go
+++ b/rules/aip0148/use_uid.go
@@ -1,0 +1,44 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0148
+
+import (
+	"fmt"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var useUid = &lint.FieldRule{
+	Name: lint.NewRuleName(148, "use-uid"),
+	OnlyIf: func(f *desc.FieldDescriptor) bool {
+		return utils.IsResource(f.GetOwner())
+	},
+	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
+		want := "uid"
+		target := "id"
+		if f.GetName() == target {
+			return []lint.Problem{{
+				Message:    fmt.Sprintf("Use %s instead of %s.", want, target),
+				Descriptor: f,
+				Location:   locations.DescriptorName(f),
+				Suggestion: want,
+			}}
+		}
+		return nil
+	},
+}

--- a/rules/aip0148/use_uid.go
+++ b/rules/aip0148/use_uid.go
@@ -23,20 +23,23 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
+const (
+	idStr  = "id"
+	uidStr = "uid"
+)
+
 var useUid = &lint.FieldRule{
 	Name: lint.NewRuleName(148, "use-uid"),
 	OnlyIf: func(f *desc.FieldDescriptor) bool {
 		return utils.IsResource(f.GetOwner())
 	},
 	LintField: func(f *desc.FieldDescriptor) []lint.Problem {
-		want := "uid"
-		target := "id"
-		if f.GetName() == target {
+		if f.GetName() == idStr {
 			return []lint.Problem{{
-				Message:    fmt.Sprintf("Use %s instead of %s.", want, target),
+				Message:    fmt.Sprintf("Use %s instead of %s.", uidStr, idStr),
 				Descriptor: f,
 				Location:   locations.DescriptorName(f),
-				Suggestion: want,
+				Suggestion: uidStr,
 			}}
 		}
 		return nil

--- a/rules/aip0148/use_uid_test.go
+++ b/rules/aip0148/use_uid_test.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0148
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestUseUid(t *testing.T) {
+	for _, test := range []struct {
+		FieldName string
+		problems  testutils.Problems
+	}{
+		{"uid", nil},
+		{"id", testutils.Problems{{Suggestion: "uid"}}},
+	} {
+		t.Run(test.FieldName, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message Person {
+					option (google.api.resource) = {
+						type: "foo.googleapis.com/Person"
+						pattern: "people/{person}"
+					};
+					string name = 1;
+
+					string {{.FieldName}} = 2;
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[1]
+			if diff := test.problems.SetDescriptor(field).Diff(useUid.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0148/use_uid_test.go
+++ b/rules/aip0148/use_uid_test.go
@@ -27,6 +27,7 @@ func TestUseUid(t *testing.T) {
 	}{
 		{"uid", nil},
 		{"id", testutils.Problems{{Suggestion: "uid"}}},
+		{"foo_id", nil},
 	} {
 		t.Run(test.FieldName, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
The standard field for the Resource ID segment within a resource is `uid`, not `id` per AIP-148. So let's enforce that.

Fixes #1068 