### PR TITLE
fix(AIP-151): allow batch delete an Empty response

### DIFF
--- a/rules/aip0151/lro_response_type.go
+++ b/rules/aip0151/lro_response_type.go
@@ -40,7 +40,7 @@ var lroResponse = &lint.MethodRule{
 		}
 
 		// Unless this is a Delete method, the response type should not be Empty.
-		if strings.HasPrefix(m.GetName(), "Delete") {
+		if strings.HasPrefix(m.GetName(), "Delete") || strings.HasPrefix(m.GetName(), "BatchDelete") {
 			return nil
 		}
 		if t := lro.GetResponseType(); t == "Empty" || t == "google.protobuf.Empty" {

--- a/rules/aip0151/lro_response_type_test.go
+++ b/rules/aip0151/lro_response_type_test.go
@@ -31,6 +31,7 @@ func TestLROResponse(t *testing.T) {
 		{"InvalidEmptyString", "WriteBook", "", testutils.Problems{{Message: "must set the response type"}}},
 		{"InvalidGPEmpty", "WriteBook", "google.protobuf.Empty", testutils.Problems{{Message: "Empty"}}},
 		{"ValidGPEmptyDelete", "DeleteBook", "google.protobuf.Empty", testutils.Problems{}},
+		{"ValidGPEmptyDelete", "BatchDeleteBooks", "google.protobuf.Empty", testutils.Problems{}},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {


### PR DESCRIPTION
Allow `BatchDelete` to use `Empty` response as is allowed in AIP-235.

Fixes #1092 