### PR TITLE
fix(AIP-158): reference resource plural for field name

### DIFF
--- a/rules/aip0158/response_plural_first_field.go
+++ b/rules/aip0158/response_plural_first_field.go
@@ -34,9 +34,9 @@ var responsePluralFirstField = &lint.MessageRule{
 
 		// If the field is a resource, use the `plural` annotation to decide the
 		// appropriate plural field name.
-		var want string
-		if res := utils.GetResource(firstField.GetMessageType()); res != nil && res.GetPlural() != "" {
-			want = strcase.SnakeCase(res.GetPlural())
+		want := utils.GetResourcePlural(utils.GetResource(firstField.GetMessageType()))
+		if want != "" {
+			want = strcase.SnakeCase(want)
 		} else {
 			want = utils.ToPlural(firstField.GetName())
 		}

--- a/rules/internal/utils/resource.go
+++ b/rules/internal/utils/resource.go
@@ -14,7 +14,9 @@
 
 package utils
 
-import apb "google.golang.org/genproto/googleapis/api/annotations"
+import (
+	apb "google.golang.org/genproto/googleapis/api/annotations"
+)
 
 // GetResourceSingular returns the resource singular. The
 // empty string is returned if the singular cannot be found.
@@ -36,4 +38,14 @@ func GetResourceSingular(r *apb.ResourceDescriptor) string {
 		}
 	}
 	return ""
+}
+
+// GetResourcePlural is a convenience method for getting the `plural` field of a
+// resource.
+func GetResourcePlural(r *apb.ResourceDescriptor) string {
+	if r == nil {
+		return ""
+	}
+
+	return r.Plural
 }

--- a/rules/internal/utils/resource_test.go
+++ b/rules/internal/utils/resource_test.go
@@ -20,7 +20,7 @@ import (
 	apb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
-func TestMatches(t *testing.T) {
+func TestGetResourceSingular(t *testing.T) {
 	for _, test := range []struct {
 		name     string
 		resource *apb.ResourceDescriptor
@@ -65,6 +65,39 @@ func TestMatches(t *testing.T) {
 			got := GetResourceSingular(test.resource)
 			if got != test.want {
 				t.Errorf("GetResourceSingular: expected %v, got %v", test.want, got)
+			}
+		})
+	}
+}
+
+func TestGetResourcePlural(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		resource *apb.ResourceDescriptor
+		want     string
+	}{
+		{
+			name: "PluralSpecified",
+			resource: &apb.ResourceDescriptor{
+				Plural: "bookShelves",
+			},
+			want: "bookShelves",
+		},
+		{
+			name:     "NothingSpecified",
+			resource: &apb.ResourceDescriptor{},
+			want:     "",
+		},
+		{
+			name:     "Nil",
+			resource: nil,
+			want:     "",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := GetResourcePlural(test.resource)
+			if got != test.want {
+				t.Errorf("GetResourcePlural: expected %v, got %v", test.want, got)
 			}
 		})
 	}


### PR DESCRIPTION
As we start to require `plural` in `google.api.resource`, we should referencing it in rules that attempt to pluralize words for things like field names or collection IDs. This is a reasonable heuristic to use for the AIP-158 `response-plural-first-field` when that first field is a resource.

Fixes http://b/271479822