### PR TITLE
fix(AIP-122): allow display_name suffix

### DIFF
--- a/rules/aip0122/name_suffix_test.go
+++ b/rules/aip0122/name_suffix_test.go
@@ -31,6 +31,7 @@ func TestNameSuffix(t *testing.T) {
 		{"ValidStandardGiven", "given_name", testutils.Problems{}},
 		{"ValidStandardFamily", "family_name", testutils.Problems{}},
 		{"ValidStandardFull", "full_resource_name", testutils.Problems{}},
+		{"SkipValidDisplayNameSuffix", "foo_display_name", testutils.Problems{}},
 		{"Invalid", "author_name", testutils.Problems{{Suggestion: "author"}}},
 	} {
 		f := testutils.ParseProto3Tmpl(t, `


### PR DESCRIPTION
The field `display_name` is an allowed use of `_name` suffix. I've seen some Custom Methods that create multiple resources and want to allow specifying the resulting `display_name` fields, so they prefix them with the resource it would correlate to post-creation e.g. `instance_display_name` and `network_display_name`, while other resource fields would be populated on behalf of the user (if there are any to begin with). 

Fixes http://b/270956831