### PR TITLE
chore: fix typos

### DIFF
--- a/docs/rules/0123/resource-name-components-alternate.md
+++ b/docs/rules/0123/resource-name-components-alternate.md
@@ -2,8 +2,9 @@
 rule:
   aip: 123
   name: [core, '0123', resource-name-components-alternate]
-  summary: Resource name components should alternate between collection and
-  identifiers.
+  summary: |
+    Resource name components should alternate between collection and
+    identifiers.
 permalink: /123/resource-name-components-alternate
 redirect_from:
   - /0123/resource-name-components-alternate

--- a/docs/rules/0131/request-required-fields.md
+++ b/docs/rules/0131/request-required-fields.md
@@ -1,7 +1,7 @@
 ---
 rule:
   aip: 131
-  name: [core, '0131', request-unknown-fields]
+  name: [core, '0131', request-required-fields]
   summary: Get RPCs must not have unexpected required fields in the request.
 permalink: /131/request-required-fields
 redirect_from:

--- a/docs/rules/0132/request-required-fields.md
+++ b/docs/rules/0132/request-required-fields.md
@@ -1,7 +1,7 @@
 ---
 rule:
   aip: 132
-  name: [core, '0132', request-unknown-fields]
+  name: [core, '0132', request-required-fields]
   summary: List RPCs must not have unexpected required fields in the request.
 permalink: /132/request-required-fields
 redirect_from:

--- a/docs/rules/0133/request-required-fields.md
+++ b/docs/rules/0133/request-required-fields.md
@@ -1,7 +1,7 @@
 ---
 rule:
   aip: 133
-  name: [core, '0133', request-unknown-fields]
+  name: [core, '0133', request-required-fields]
   summary: Create RPCs must not have unexpected required fields in the request.
 permalink: /133/request-required-fields
 redirect_from:

--- a/docs/rules/0134/request-required-fields.md
+++ b/docs/rules/0134/request-required-fields.md
@@ -1,7 +1,7 @@
 ---
 rule:
   aip: 134
-  name: [core, '0134', request-unknown-fields]
+  name: [core, '0134', request-required-fields]
   summary: Update RPCs must not have unexpected required fields in the request.
 permalink: /134/request-required-fields
 redirect_from:

--- a/docs/rules/0135/request-required-fields.md
+++ b/docs/rules/0135/request-required-fields.md
@@ -1,7 +1,7 @@
 ---
 rule:
   aip: 135
-  name: [core, '0135', request-unknown-fields]
+  name: [core, '0135', request-required-fields]
   summary: Delete RPCs must not have unexpected required fields in the request.
 permalink: /135/request-required-fields
 redirect_from:

--- a/docs/rules/0203/field-behavior-required.md
+++ b/docs/rules/0203/field-behavior-required.md
@@ -2,8 +2,9 @@
 rule:
   aip: 203
   name: [core, '0203', field-behavior-required]
-  summary: Field behavior is required, and must have one of OUTPUT_ONLY,
-  REQUIRED, or OPTIONAL.
+  summary: |
+    Field behavior is required, and must have one of OUTPUT_ONLY, REQUIRED, or
+    OPTIONAL.
 permalink: /203/field-behavior-required
 redirect_from:
   - /0203/field-behavior-required


### PR DESCRIPTION
some pages were not rendering (warnings in the serving), while
others were categorized under an incorrect name.