### PR TITLE
fix(AIP-133): compare types instead for message fields

### DIFF
--- a/rules/aip0133/request_required_fields.go
+++ b/rules/aip0133/request_required_fields.go
@@ -32,9 +32,7 @@ var requestRequiredFields = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		ot := utils.GetResponseType(m)
 		r := utils.GetResource(ot)
-		// The `singular` will be lowerCamelCase, while the Type Name will be
-		// UpperCamelCase. For simplicity, upper-case it always.
-		resourceMsgName := strcase.UpperCamelCase(utils.GetResourceSingular(r))
+		resourceMsgName := utils.GetResourceSingular(r)
 
 		// Rule check: Establish that there are no unexpected fields.
 		allowedRequiredFields := stringset.New(
@@ -47,8 +45,9 @@ var requestRequiredFields = &lint.MethodRule{
 			if !utils.GetFieldBehavior(f).Contains("REQUIRED") {
 				continue
 			}
-			// Skip the check with the field that is the body.
-			if t := f.GetMessageType(); t != nil && t.GetName() == resourceMsgName {
+			// Skip the check with the field that is the resource, which for
+			// Standard Create, is the output type.
+			if t := f.GetMessageType(); t != nil && t.GetName() == ot.GetName() {
 				continue
 			}
 			// Iterate remaining fields. If they're not in the allowed list,

--- a/rules/aip0133/request_required_fields.go
+++ b/rules/aip0133/request_required_fields.go
@@ -32,7 +32,9 @@ var requestRequiredFields = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		ot := utils.GetResponseType(m)
 		r := utils.GetResource(ot)
-		resourceMsgName := utils.GetResourceSingular(r)
+		// The `singular` will be lowerCamelCase, while the Type Name will be
+		// UpperCamelCase. For simplicity, upper-case it always.
+		resourceMsgName := strcase.UpperCamelCase(utils.GetResourceSingular(r))
 
 		// Rule check: Establish that there are no unexpected fields.
 		allowedRequiredFields := stringset.New(

--- a/rules/aip0133/request_required_fields_test.go
+++ b/rules/aip0133/request_required_fields_test.go
@@ -44,6 +44,13 @@ func TestRequiredFieldTests(t *testing.T) {
 			nil,
 		},
 		{
+			"ValidWithSingularAndIdField",
+			"string book_shelf_id = 3 [(google.api.field_behavior) = OPTIONAL];",
+			"",
+			"bookShelf",
+			nil,
+		},
+		{
 			"ValidOptionalValidateOnly",
 			"string validate_only = 3 [(google.api.field_behavior) = OPTIONAL];",
 			"validate_only",
@@ -66,6 +73,15 @@ func TestRequiredFieldTests(t *testing.T) {
 			"",
 			testutils.Problems{
 				{Message: `Create RPCs must only require fields explicitly described in AIPs, not "create_iam"`},
+			},
+		},
+		{
+			"InvalidRequiredUnknownMessageField",
+			"Foo foo = 3 [(google.api.field_behavior) = REQUIRED];",
+			"foo",
+			"",
+			testutils.Problems{
+				{Message: `Create RPCs must only require fields explicitly described in AIPs, not "foo"`},
 			},
 		},
 	} {
@@ -91,6 +107,8 @@ func TestRequiredFieldTests(t *testing.T) {
 					};
 					string name = 1;
 				}
+
+				message Foo {}
 
 				message CreateBookShelfRequest {
 					string parent = 1 [

--- a/rules/aip0133/request_required_fields_test.go
+++ b/rules/aip0133/request_required_fields_test.go
@@ -26,24 +26,35 @@ func TestRequiredFieldTests(t *testing.T) {
 		name                 string
 		Fields               string
 		problematicFieldName string
+		Singular             string
 		problems             testutils.Problems
 	}{
 		{
 			"ValidNoExtraFields",
 			"",
 			"",
+			"",
+			nil,
+		},
+		{
+			"ValidWithSingularNoExtraFields",
+			"",
+			"",
+			"bookShelf",
 			nil,
 		},
 		{
 			"ValidOptionalValidateOnly",
 			"string validate_only = 3 [(google.api.field_behavior) = OPTIONAL];",
 			"validate_only",
+			"",
 			nil,
 		},
 		{
 			"InvalidRequiredValidateOnly",
 			"bool validate_only = 3 [(google.api.field_behavior) = REQUIRED];",
 			"validate_only",
+			"",
 			testutils.Problems{
 				{Message: `Create RPCs must only require fields explicitly described in AIPs, not "validate_only"`},
 			},
@@ -52,6 +63,7 @@ func TestRequiredFieldTests(t *testing.T) {
 			"InvalidRequiredUnknownField",
 			"bool create_iam = 3 [(google.api.field_behavior) = REQUIRED];",
 			"create_iam",
+			"",
 			testutils.Problems{
 				{Message: `Create RPCs must only require fields explicitly described in AIPs, not "create_iam"`},
 			},
@@ -75,6 +87,7 @@ func TestRequiredFieldTests(t *testing.T) {
 					option (google.api.resource) = {
 						type: "library.googleapis.com/BookShelf"
 						pattern: "publishers/{publisher}/bookShelves/{book_shelf}"
+						singular: "{{.Singular}}"
 					};
 					string name = 1;
 				}


### PR DESCRIPTION
Change the filter for the resource message field to compare the field type to the response type (which should be the resource for a Standard Create), instead of a case sensitive derivation of the resource type name or singular name.

Add some tests for when `singular` is set.

Should be a fix for item 2 of http://yaqs/4607975166683643904 (internal link)