### PR TITLE
fix(AIP-203): ignore behavior in internal comments

### DIFF
--- a/rules/aip0192/absolute_links.go
+++ b/rules/aip0192/absolute_links.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -28,7 +29,7 @@ var absoluteLinks = &lint.DescriptorRule{
 	Name: lint.NewRuleName(192, "absolute-links"),
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
 		comment := strings.Join(
-			separateInternalComments(d.GetSourceInfo().GetLeadingComments()).External,
+			utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments()).External,
 			"\n",
 		)
 

--- a/rules/aip0192/aip0192.go
+++ b/rules/aip0192/aip0192.go
@@ -16,8 +16,6 @@
 package aip0192
 
 import (
-	"strings"
-
 	"github.com/googleapis/api-linter/lint"
 	"github.com/jhump/protoreflect/desc"
 )
@@ -47,41 +45,4 @@ func isDeprecated(d desc.Descriptor) bool {
 	default:
 		return false
 	}
-}
-
-func separateInternalComments(comments ...string) struct {
-	Internal []string
-	External []string
-} {
-	answer := struct {
-		Internal []string
-		External []string
-	}{}
-	for _, c := range comments {
-		for len(c) > 0 {
-			// Anything before the `(--` is external string.
-			open := strings.SplitN(c, "(--", 2)
-			if ex := strings.TrimSpace(open[0]); ex != "" {
-				answer.External = append(answer.External, ex)
-			}
-			if len(open) > 1 {
-				c = strings.TrimSpace(open[1])
-			} else {
-				break
-			}
-
-			// Now that the opening component is tokenized, anything before
-			// the `--)` is internal string.
-			close := strings.SplitN(c, "--)", 2)
-			if in := strings.TrimSpace(close[0]); in != "" {
-				answer.Internal = append(answer.Internal, in)
-			}
-			if len(close) > 1 {
-				c = strings.TrimSpace(close[1])
-			} else {
-				break
-			}
-		}
-	}
-	return answer
 }

--- a/rules/aip0192/deprecated_comment.go
+++ b/rules/aip0192/deprecated_comment.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -25,7 +26,7 @@ var deprecatedComment = &lint.DescriptorRule{
 	Name:   lint.NewRuleName(192, "deprecated-comment"),
 	OnlyIf: isDeprecated,
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
-		comment := separateInternalComments(d.GetSourceInfo().GetLeadingComments())
+		comment := utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments())
 		if len(comment.External) > 0 && strings.HasPrefix(comment.External[0], "Deprecated:") {
 			return nil
 		}

--- a/rules/aip0192/has_comments.go
+++ b/rules/aip0192/has_comments.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -26,7 +27,7 @@ import (
 var hasComments = &lint.DescriptorRule{
 	Name: lint.NewRuleName(192, "has-comments"),
 	LintDescriptor: func(d desc.Descriptor) (problems []lint.Problem) {
-		comment := separateInternalComments(d.GetSourceInfo().GetLeadingComments())
+		comment := utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments())
 		if len(comment.External) == 0 {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf("Missing comment over %q.", d.GetName()),

--- a/rules/aip0192/no_html.go
+++ b/rules/aip0192/no_html.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -27,7 +28,7 @@ var noHTML = &lint.DescriptorRule{
 		return d.GetSourceInfo() != nil
 	},
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
-		for _, comment := range separateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
+		for _, comment := range utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
 			if htmlTag.MatchString(comment) {
 				return []lint.Problem{{
 					Message:    "Comments must not include raw HTML.",

--- a/rules/aip0192/no_markdown_headings.go
+++ b/rules/aip0192/no_markdown_headings.go
@@ -19,13 +19,14 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
 var noMarkdownHeadings = &lint.DescriptorRule{
 	Name: lint.NewRuleName(192, "no-markdown-headings"),
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
-		for _, cmt := range separateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
+		for _, cmt := range utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
 			for _, line := range strings.Split(cmt, "\n") {
 				if heading.FindString(line) != "" {
 					return []lint.Problem{{

--- a/rules/aip0192/no_markdown_tables.go
+++ b/rules/aip0192/no_markdown_tables.go
@@ -19,13 +19,14 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
 var noMarkdownTables = &lint.DescriptorRule{
 	Name: lint.NewRuleName(192, "no-markdown-tables"),
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
-		for _, cmt := range separateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
+		for _, cmt := range utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments()).External {
 			for _, line := range strings.Split(cmt, "\n") {
 				line = strings.TrimSpace(line)
 				if table.FindString(line) != "" {

--- a/rules/aip0192/only_leading_comments.go
+++ b/rules/aip0192/only_leading_comments.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -28,7 +29,7 @@ var onlyLeadingComments = &lint.DescriptorRule{
 	LintDescriptor: func(d desc.Descriptor) []lint.Problem {
 		problems := []lint.Problem{}
 		c := d.GetSourceInfo()
-		if len(separateInternalComments(c.GetTrailingComments()).External) > 0 {
+		if len(utils.SeparateInternalComments(c.GetTrailingComments()).External) > 0 {
 			problems = append(problems, lint.Problem{
 				Message: fmt.Sprintf(
 					"%q should have only leading (not trailing) public comments.",
@@ -37,7 +38,7 @@ var onlyLeadingComments = &lint.DescriptorRule{
 				Descriptor: d,
 			})
 		}
-		if len(separateInternalComments(c.GetLeadingDetachedComments()...).External) > 0 {
+		if len(utils.SeparateInternalComments(c.GetLeadingDetachedComments()...).External) > 0 {
 			problems = append(problems, lint.Problem{
 				Message: fmt.Sprintf(
 					"%q has comments with empty lines between the comment and %q.",

--- a/rules/aip0192/trademarked_names.go
+++ b/rules/aip0192/trademarked_names.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
@@ -64,7 +65,7 @@ var trademarkedNames = &lint.DescriptorRule{
 	Name: lint.NewRuleName(192, "trademarked-names"),
 	LintDescriptor: func(d desc.Descriptor) (problems []lint.Problem) {
 		c := strings.Join(
-			separateInternalComments(d.GetSourceInfo().GetLeadingComments()).External,
+			utils.SeparateInternalComments(d.GetSourceInfo().GetLeadingComments()).External,
 			"\n",
 		)
 		for want, badThings := range tmRegexes {

--- a/rules/aip0203/aip0203.go
+++ b/rules/aip0203/aip0203.go
@@ -18,6 +18,7 @@ package aip0203
 import (
 	"fmt"
 	"regexp"
+	"strings"
 
 	"bitbucket.org/creachadair/stringset"
 	"github.com/googleapis/api-linter/lint"
@@ -48,6 +49,7 @@ func AddRules(r lint.RuleRegistry) error {
 func checkLeadingComments(pattern *regexp.Regexp, annotation string, unless ...*regexp.Regexp) func(*desc.FieldDescriptor) []lint.Problem {
 	return func(f *desc.FieldDescriptor) []lint.Problem {
 		leadingComments := f.GetSourceInfo().GetLeadingComments()
+		leadingComments = strings.Join(utils.SeparateInternalComments(leadingComments).External, "\n")
 		for _, ul := range unless {
 			if ul.MatchString(leadingComments) {
 				return nil

--- a/rules/aip0203/immutable_test.go
+++ b/rules/aip0203/immutable_test.go
@@ -39,6 +39,12 @@ func TestImmutable(t *testing.T) {
 			problems: nil,
 		},
 		{
+			name:     "ValidInternal",
+			comment:  "Hello, World! (-- Immutable --)",
+			field:    fieldPart,
+			problems: nil,
+		},
+		{
 			name:     "Valid",
 			comment:  "@immutable",
 			field:    fieldPartWithImmtutableBehavior,

--- a/rules/aip0203/input_only_test.go
+++ b/rules/aip0203/input_only_test.go
@@ -34,6 +34,12 @@ func TestInputOnly(t *testing.T) {
 			problems: nil,
 		},
 		{
+			name:     "ValidInternal",
+			comment:  "Hello, World! (-- inputonly --)",
+			field:    "string secret = 1;",
+			problems: nil,
+		},
+		{
 			name:     "valid_exclude_etag",
 			comment:  "Input only.",
 			field:    "string etag = 1;",

--- a/rules/aip0203/optional_test.go
+++ b/rules/aip0203/optional_test.go
@@ -39,6 +39,12 @@ func TestOptional(t *testing.T) {
 			problems: nil,
 		},
 		{
+			name:     "ValidInternal",
+			comment:  "Hello, World! (-- Optional --)",
+			field:    titleField,
+			problems: nil,
+		},
+		{
 			name:     "Valid",
 			comment:  "@optional",
 			field:    titleWithOptionalBehavior,

--- a/rules/aip0203/output_only_test.go
+++ b/rules/aip0203/output_only_test.go
@@ -40,6 +40,12 @@ func TestOutput(t *testing.T) {
 			problems: nil,
 		},
 		{
+			name:     "ValidInternal",
+			comment:  "Hello, World! (-- Output only --)",
+			field:    generatedURI,
+			problems: nil,
+		},
+		{
 			name:     "Valid",
 			comment:  "@OutputOnly",
 			field:    generatedURIWithOutputOnlyBehavior,

--- a/rules/aip0203/required_test.go
+++ b/rules/aip0203/required_test.go
@@ -40,6 +40,12 @@ func TestRequired(t *testing.T) {
 		},
 		{
 			name:     "Valid",
+			comment:  "Hello world! (-- Required --)",
+			field:    title,
+			problems: nil,
+		},
+		{
+			name:     "Valid",
 			comment:  "@required",
 			field:    titleWithRequiredBehavior,
 			problems: nil,


### PR DESCRIPTION
All of the field behavior rules that suggest the use of the annotation over documenting it in a comment should ignore internal comment contents.

Refactors `separateInternaComments` into a utility API.

Should be a fix for item 3 in http://yaqs/4607975166683643904 (internal link).