### PR TITLE
fix(134): compare message types for required fields

### DIFF
--- a/rules/aip0134/request_required_fields_test.go
+++ b/rules/aip0134/request_required_fields_test.go
@@ -68,6 +68,14 @@ func TestRequiredFieldTests(t *testing.T) {
 				{Message: `Update RPCs must only require fields explicitly described in AIPs, not "create_iam"`},
 			},
 		},
+		{
+			"InvalidRequiredUnknownMessageField",
+			"Foo foo = 3 [(google.api.field_behavior) = REQUIRED];",
+			"foo",
+			testutils.Problems{
+				{Message: `Update RPCs must only require fields explicitly described in AIPs, not "foo"`},
+			},
+		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
@@ -99,6 +107,8 @@ func TestRequiredFieldTests(t *testing.T) {
 					];
 					{{.Fields}}
 				}
+
+				message Foo {}
 			`, test)
 			var dbr desc.Descriptor = f.FindMessage("UpdateBookShelfRequest")
 			if test.problematicFieldName != "" {


### PR DESCRIPTION
Refactors `core::0134::request-required-fields` into a `MethodRule` so as to get access to the expected response type a.k.a the exact resource type being updated. Then fix the message type field check to compare the Resource message type to the field message type if applicable. Similar to #1165 