### PR TITLE
feat: resource-names-alternating-components check for AIP-122

### DIFF
--- a/docs/rules/0122/resource-names-alternating-components.md
+++ b/docs/rules/0122/resource-names-alternating-components.md
@@ -1,0 +1,71 @@
+---
+rule:
+  aip: 122
+  name: [core, '0122', resource-names-alternating-components]
+  summary: Resource name components should usually alternate between collection identifiers and resource IDs.
+permalink: /122/resource-names-alternating-components
+redirect_from:
+  - /0122/resource-names-alternating-components
+---
+
+# Alternating resource name components
+
+This rule enforces that resource name components should alternate between collection identifiers
+(example: `publishers`, `books`, `users`) and resource IDs (example: `123`, `les-miserables`, `vhugo1802`),
+as mandated in [AIP-122][].
+
+## Details
+
+This rule scans all `google.api.resource` annotations and checks that the path template segments alternate
+between collection identifiers and resource IDs.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    // Should be "books/{book}"
+    pattern: "books/book"
+  };
+  string name = 1;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "books/{book}"
+  };
+  string name = 1;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the message.
+
+```proto
+// (-- api-linter: core::0122::resource-names-alternating-components=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "books/book"
+  };
+  string name = 1;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-122]: http://aip.dev/122
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0122/aip0122.go
+++ b/rules/aip0122/aip0122.go
@@ -29,5 +29,6 @@ func AddRules(r lint.RuleRegistry) error {
 		nameSuffix,
 		resourceReferenceType,
 		resourceIdOutputOnly,
+		resourceNamesAlternatingComponents,
 	)
 }

--- a/rules/aip0122/resource_names_alternating_components.go
+++ b/rules/aip0122/resource_names_alternating_components.go
@@ -1,0 +1,64 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0122
+
+import (
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+type SegmentType int64
+
+const (
+	Undefined            SegmentType = 0
+	CollectionIdentifier SegmentType = 1
+	ResourceId           SegmentType = 2
+)
+
+var resourceNamesAlternatingComponents = &lint.MessageRule{
+	Name: lint.NewRuleName(122, "resource-names-alternating-components"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		return utils.GetResource(m) != nil
+	},
+	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		var problems []lint.Problem
+		resource := utils.GetResource(m)
+		for _, p := range resource.GetPattern() {
+			segs := strings.Split(p, "/")
+			previousSegmentType := Undefined
+			for _, seg := range segs {
+				c := []rune(seg)[0]
+				currentSegmentType := CollectionIdentifier
+				if c == '{' {
+					currentSegmentType = ResourceId
+				}
+				if previousSegmentType == currentSegmentType {
+					return append(problems, lint.Problem{
+						Message:    "Resource name components should usually alternate between collection identifiers and resource IDs.",
+						Descriptor: m,
+						Location:   locations.MessageResource(m),
+					})
+				}
+				previousSegmentType = currentSegmentType
+			}
+		}
+
+		return problems
+	},
+}

--- a/rules/aip0122/resource_names_alternating_components_test.go
+++ b/rules/aip0122/resource_names_alternating_components_test.go
@@ -1,0 +1,56 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0122
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceNamesAlternatingComponents(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		Pattern  string
+		problems testutils.Problems
+	}{
+		{"ValidProject", "projects/{project}", testutils.Problems{}},
+		{"InvalidProjectNoResource", "projects/project", testutils.Problems{{Message: "should usually alternate"}}},
+		{"InvalidProjectNoCollection", "{projects}/{project}", testutils.Problems{{Message: "should usually alternate"}}},
+		{"ValidLocation", "projects/{project}/locations/{location}", testutils.Problems{}},
+		{"InvalidLocationNoResource", "projects/{project}/locations/location", testutils.Problems{{Message: "should usually alternate"}}},
+		{"InvalidLocationNoCollection", "{projects}/project/{locations}/{location}", testutils.Problems{{Message: "should usually alternate"}}},
+		{"ValidSingleton", "projects/{project}/locations/{location}/settings", testutils.Problems{}},
+		{"InvalidSingleton", "projects/{project}/locations/{location}/{settings}", testutils.Problems{{Message: "should usually alternate"}}},
+	} {
+		f := testutils.ParseProto3Tmpl(t, `
+			import "google/api/resource.proto";
+			import "google/api/field_behavior.proto";
+
+			message Book {
+				option (google.api.resource) = {
+					type: "library.googleapis.com/Book"
+					pattern: "{{.Pattern}}"
+				};
+				string project = 1;
+				string location = 2;
+			}
+		`, test)
+		message := f.GetMessageTypes()[0]
+		if diff := test.problems.SetDescriptor(message).Diff(resourceNamesAlternatingComponents.Lint(f)); diff != "" {
+			t.Errorf(diff)
+		}
+	}
+}


### PR DESCRIPTION
Adding a rule to check that resource names components alternate between `collection_name` and `{resource_id}` as described in [AIP-122](https://google.aip.dev/122).