### PR TITLE
feat: test across multiple files, ignore name on resource

### DIFF
--- a/rules/aip0203/field_behavior_required.go
+++ b/rules/aip0203/field_behavior_required.go
@@ -44,7 +44,7 @@ func problems(m *desc.MessageDescriptor) []lint.Problem {
 	var ps []lint.Problem
 
 	for _, f := range m.GetFields() {
-		if r := utils.GetResource(m); r != nil && f.GetName() == "name" {
+		if utils.IsResource(m) && f.GetName() == "name" {
 			continue
 		}
 

--- a/rules/aip0203/field_behavior_required.go
+++ b/rules/aip0203/field_behavior_required.go
@@ -75,7 +75,7 @@ func checkFieldBehavior(f *desc.FieldDescriptor) *lint.Problem {
 		// check for at least one valid annotation
 		return &lint.Problem{
 			Message: fmt.Sprintf(
-				"google.api.field_behavior must contain at least one, \"%v\"", fbs),
+				"google.api.field_behavior on field %q must contain at least one, \"%v\"", f.GetName(), fbs),
 			Descriptor: f,
 		}
 	}

--- a/rules/aip0203/field_behavior_required.go
+++ b/rules/aip0203/field_behavior_required.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
-var fbs = stringset.New(
+var minimumRequiredFieldBehavior = stringset.New(
 	"OPTIONAL", "REQUIRED", "OUTPUT_ONLY", "IMMUTABLE",
 )
 
@@ -66,16 +66,16 @@ func checkFieldBehavior(f *desc.FieldDescriptor) *lint.Problem {
 
 	if len(fb) == 0 {
 		return &lint.Problem{
-			Message:    fmt.Sprintf("google.api.field_behavior annotation must be set on %q and contain one of, \"%v\"", f.GetName(), fbs),
+			Message:    fmt.Sprintf("google.api.field_behavior annotation must be set on %q and contain one of, \"%v\"", f.GetName(), minimumRequiredFieldBehavior),
 			Descriptor: f,
 		}
 	}
 
-	if !fbs.Intersects(fb) {
+	if !minimumRequiredFieldBehavior.Intersects(fb) {
 		// check for at least one valid annotation
 		return &lint.Problem{
 			Message: fmt.Sprintf(
-				"google.api.field_behavior on field %q must contain at least one, \"%v\"", f.GetName(), fbs),
+				"google.api.field_behavior on field %q must contain at least one, \"%v\"", f.GetName(), minimumRequiredFieldBehavior),
 			Descriptor: f,
 		}
 	}

--- a/rules/aip0203/field_behavior_required_test.go
+++ b/rules/aip0203/field_behavior_required_test.go
@@ -90,7 +90,7 @@ func TestFieldBehaviorRequired_SingleFile_SingleMessage(t *testing.T) {
 						pattern: "books/{book}"
 					};
 
-					string name = 1;
+					string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
 				}
 			`, tc)
 
@@ -110,14 +110,14 @@ func TestFieldBehaviorRequired_Resource_SingleFile(t *testing.T) {
 		problems      testutils.Problems
 	}{
 		{
-			name:          "valid",
+			name:          "valid with field behavior",
 			FieldBehavior: "[(google.api.field_behavior) = OUTPUT_ONLY]",
 			problems:      nil,
 		},
 		{
-			name:          "invalid",
+			name:          "valid without field behavior",
 			FieldBehavior: "",
-			problems:      testutils.Problems{{Message: "annotation must be set"}},
+			problems:      nil,
 		},
 	}
 	for _, tc := range testCases {
@@ -141,11 +141,13 @@ func TestFieldBehaviorRequired_Resource_SingleFile(t *testing.T) {
 						pattern: "books/{book}"
 					};
 
-					string name = 1 {{.FieldBehavior}};
+					string name = 1;
+
+					string title = 2 {{.FieldBehavior}};
 				}
 			`, tc)
 
-			field := f.GetMessageTypes()[1].GetFields()[0]
+			field := f.GetMessageTypes()[1].GetFields()[1]
 
 			if diff := tc.problems.SetDescriptor(field).Diff(fieldBehaviorRequired.Lint(f)); diff != "" {
 				t.Errorf(diff)

--- a/rules/aip0203/field_behavior_required_test.go
+++ b/rules/aip0203/field_behavior_required_test.go
@@ -90,7 +90,7 @@ func TestFieldBehaviorRequired_SingleFile_SingleMessage(t *testing.T) {
 						pattern: "books/{book}"
 					};
 
-					string name = 1 [(google.api.field_behavior) = OUTPUT_ONLY];
+					string name = 1;
 				}
 			`, tc)
 


### PR DESCRIPTION
This commit tests that the logic works across multiple files and also lints response messages that are resources or of depth greater than 0.