### PR TITLE
fix(AIP-203): lint non-maps and same package

### DIFF
--- a/docs/rules/0203/field-behavior-required.md
+++ b/docs/rules/0203/field-behavior-required.md
@@ -23,6 +23,10 @@ This rule looks at all fields and ensures they have a
 one of the options `OUTPUT_ONLY`, `REQUIRED`, or `OPTIONAL`: all fields must
 fall into one of these categories.
 
+Although all request messages **must** be annotated, this linter only verifies
+messages that are in the same package as some upstream protos (e.g. common
+protos) may be difficult to modify.
+
 ## Examples
 
 **Incorrect** code for this rule:

--- a/rules/aip0203/field_behavior_required.go
+++ b/rules/aip0203/field_behavior_required.go
@@ -31,7 +31,8 @@ var fieldBehaviorRequired = &lint.MethodRule{
 	Name: lint.NewRuleName(203, "field-behavior-required"),
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		req := m.GetInputType()
-		ps := problems(req)
+		p := m.GetFile().GetPackage()
+		ps := problems(req, p)
 		if len(ps) == 0 {
 			return nil
 		}
@@ -40,7 +41,7 @@ var fieldBehaviorRequired = &lint.MethodRule{
 	},
 }
 
-func problems(m *desc.MessageDescriptor) []lint.Problem {
+func problems(m *desc.MessageDescriptor, pkg string) []lint.Problem {
 	var ps []lint.Problem
 
 	for _, f := range m.GetFields() {
@@ -53,8 +54,8 @@ func problems(m *desc.MessageDescriptor) []lint.Problem {
 			ps = append(ps, *p)
 		}
 
-		if mt := f.GetMessageType(); mt != nil {
-			ps = append(ps, problems(mt)...)
+		if mt := f.GetMessageType(); mt != nil && !mt.IsMapEntry() && mt.GetFile().GetPackage() == pkg {
+			ps = append(ps, problems(mt, pkg)...)
 		}
 	}
 


### PR DESCRIPTION
Although all request messages **must** be annotated, this linter only verifies
messages that are in the same package as some upstream protos (e.g. common
protos) may be difficult to modify.