### PR TITLE
feat(AIP-142): adding purge_time field

### DIFF
--- a/rules/aip0142/time_field_names.go
+++ b/rules/aip0142/time_field_names.go
@@ -32,6 +32,7 @@ var fieldNames = &lint.FieldRule{
 			"expired":  "expire_time",
 			"modified": "update_time",
 			"updated":  "update_time",
+			"purged":   "purged_time",
 		}
 		for got, want := range mistakes {
 			if strings.Contains(f.GetName(), got) {

--- a/rules/aip0164/resource_expire_time_field.go
+++ b/rules/aip0164/resource_expire_time_field.go
@@ -14,11 +14,16 @@ var resourceExpireTimeField = &lint.MessageRule{
 		return utils.FindMethod(m.GetFile(), "Undelete"+resource) != nil
 	},
 	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		// for backwards compatibility, do not lint on expire_time.
+		// previously expire_time was the recommended term.
 		if m.FindFieldByName("expire_time") != nil {
 			return nil
 		}
+		if m.FindFieldByName("purge_time") != nil {
+			return nil
+		}
 		return []lint.Problem{{
-			Message:    "Resources supporting soft delete must have a `google.protobuf.Timestamp expire_time` field.",
+			Message:    "Resources supporting soft delete must have a `google.protobuf.Timestamp purge_time` field.",
 			Descriptor: m,
 		}}
 	},

--- a/rules/aip0164/resource_expire_time_field_test.go
+++ b/rules/aip0164/resource_expire_time_field_test.go
@@ -13,7 +13,8 @@ func TestResourceExpireTimeField(t *testing.T) {
 		ResourceField string
 		problems      testutils.Problems
 	}{
-		{"Valid", `UndeleteBook`, `google.protobuf.Timestamp expire_time = 1;`, nil},
+		{"Valid", `UndeleteBook`, `google.protobuf.Timestamp purge_time = 1;`, nil},
+		{"Valid", `UndeleteBookLegacyExpireTime`, `google.protobuf.Timestamp expire_time = 1;`, nil},
 		{"Invalid", `UndeleteBook`, ``, testutils.Problems{{Message: "Resources supporting soft delete"}}},
 		{"IrrelevantNoSoftDelete", `GetBook`, ``, nil},
 	} {


### PR DESCRIPTION
Updating checking for purge_time to align with
https://github.com/aip-dev/google.aip.dev/pull/1169.

Continued to ignore expire_time for soft-deleted resources
for backwards-compatibility.