### PR TITLE
feat(AIP-135): add cascading delete force-field rule

### DIFF
--- a/docs/rules/0135/force-field.md
+++ b/docs/rules/0135/force-field.md
@@ -1,0 +1,73 @@
+---
+rule:
+  aip: 135
+  name: [core, '0135', force-field]
+  summary: Delete RPCs for resources with child collections should have a `force` field in the request.
+permalink: /135/force-field
+redirect_from:
+  - /0135/force-field
+---
+
+# Delete methods: Name field
+
+This rule enforces that the standard `Delete` method for a resource that parents
+other resources in the service have a `bool force` field in the request message,
+as mandated in [AIP-135][].
+
+## Details
+
+This rule looks at any message matching `Delete*Request` for a resource with
+child resources in the same service and complains if the `force` field is
+missing.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message DeletePublisherRequest {
+  // Where Publisher parents the Book resource.
+  string name = 1 [
+    (google.api.resource_reference).type = "library.googleapis.com/Publisher"]; 
+
+  // Missing `bool force` field.
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message DeletePublisherRequest {
+  // Where Publisher parents the Book resource.
+  string name = 1 [
+    (google.api.resource_reference).type = "library.googleapis.com/Publisher"]; 
+
+  // If set to true, any books from this publisher will also be deleted.
+  // (Otherwise, the request will only work if the publisher has no books.)
+  bool force = 2;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the message (if
+the `name` field is missing) or above the field (if it is the wrong type).
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0135::force-field=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message DeletePublisherRequest {
+  // Where Publisher parents the Book resource.
+  string name = 1 [
+    (google.api.resource_reference).type = "library.googleapis.com/Publisher"]; 
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-135]: https://aip.dev/135#cascading-delete
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0135/aip0135.go
+++ b/rules/aip0135/aip0135.go
@@ -27,6 +27,7 @@ import (
 func AddRules(r lint.RuleRegistry) error {
 	return r.Register(
 		135,
+		forceField,
 		httpBody,
 		httpMethod,
 		httpNameField,

--- a/rules/aip0135/force_field.go
+++ b/rules/aip0135/force_field.go
@@ -1,0 +1,51 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0135
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+// Delete methods for resources that are parents should have a bool force field.
+var forceField = &lint.MessageRule{
+	Name: lint.NewRuleName(135, "force-field"),
+	OnlyIf: func(m *desc.MessageDescriptor) bool {
+		name := m.FindFieldByName("name")
+		ref := utils.GetResourceReference(name)
+		validRef := ref != nil && ref.GetType() != "" && utils.FindResource(ref.GetType(), m.GetFile()) != nil
+
+		return isDeleteRequestMessage(m) && validRef
+	},
+	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		force := m.FindFieldByName("force")
+		name := m.FindFieldByName("name")
+		ref := utils.GetResourceReference(name)
+		res := utils.FindResource(ref.GetType(), m.GetFile())
+
+		children := utils.FindResourceChildren(res, m.GetFile())
+		if len(children) > 0 && force == nil {
+			return []lint.Problem{
+				{
+					Message:    "Delete requests for resources with children should have a `bool force` field",
+					Descriptor: m,
+				},
+			}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0135/force_field_test.go
+++ b/rules/aip0135/force_field_test.go
@@ -1,0 +1,72 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0135
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestForceField(t *testing.T) {
+	tests := []struct {
+		name      string
+		Reference string
+		BoolField string
+		problems  testutils.Problems
+	}{
+		{"ValidWithChildren", `.type = "library.googleapis.com/Publisher"`, "force", nil},
+		{"ValidWithoutChildren", `.type = "library.googleapis.com/Book"`, "other", nil},
+		{"SkipIncorrectChildTypeReference", `.child_type = "library.googleapis.com/Publisher"`, "other", nil},
+		{"InvalidMissingForce", `.type = "library.googleapis.com/Publisher"`, "other", testutils.Problems{{Message: "bool force"}}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message Book {
+					option (google.api.resource) = {
+						type: "library.googleapis.com/Book"
+						pattern: "publishers/{publisher}/books/{book}"
+					};
+	
+					string name = 1;
+				}
+
+				message Publisher {
+					option (google.api.resource) = {
+						type: "library.googleapis.com/Publisher"
+						pattern: "publishers/{publisher}"
+					};
+	
+					string name = 1;
+				}
+
+				message DeleteResourceRequest {
+					string name = 1 [(google.api.resource_reference){{.Reference}}];
+
+					bool {{.BoolField}} = 2;
+				}
+			`, test)
+			msg := f.FindMessage("DeleteResourceRequest")
+			problems := forceField.Lint(f)
+			if diff := test.problems.SetDescriptor(msg).Diff(problems); diff != "" {
+				t.Errorf("Problems did not match: %v", diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds rule `core::0135::force-field` that will complain if the Standard Delete request for a resource that parents other resources does not have a `bool force` field to implement Cascading Delete with.

Also adds a helper for collecting the child resources of a given resource, within the same service.

Fixes #1188