### PR TITLE
fix(AIP-135): removing df check in response-message-name

### DIFF
--- a/docs/rules/0135/response-message-name.md
+++ b/docs/rules/0135/response-message-name.md
@@ -21,9 +21,6 @@ if the name of the corresponding output message is not one of:
 - `google.protobuf.Empty`
 - The name of the RPC with the prefix `Delete` removed.
 
-**Important:** For declarative-friendly resources, only the resource is
-permitted as a return type.
-
 It also permits a response of `google.longrunning.Operation`; in this case, it
 checks the `response_type` in the `google.longrunning.operation_info`
 annotation and ensures that _it_ corresponds to either `google.protobuf.Empty`

--- a/rules/aip0135/response_message_name.go
+++ b/rules/aip0135/response_message_name.go
@@ -32,7 +32,6 @@ var responseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(135, "response-message-name"),
 	OnlyIf: isDeleteMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
-		declFriendly := utils.IsDeclarativeFriendlyMethod(m)
 		resource := strings.Replace(m.GetName(), "Delete", "", 1)
 
 		// Rule check: Establish that for methods such as `DeleteFoo`, the response
@@ -41,10 +40,7 @@ var responseMessageName = &lint.MethodRule{
 		if stringset.New("Empty", "Operation").Contains(got) {
 			got = m.GetOutputType().GetFullyQualifiedName()
 		}
-		want := stringset.New(resource)
-		if !declFriendly {
-			want.Add("google.protobuf.Empty")
-		}
+		want := stringset.New(resource, "google.protobuf.Empty")
 
 		// If the return type is an Operation, use the annotated response type.
 		lro := false
@@ -63,10 +59,6 @@ var responseMessageName = &lint.MethodRule{
 			// not marked declarative-friendly)
 			msg := "Delete RPCs should have response message type of Empty or the resource, not %q."
 			suggestion := "google.protobuf.Empty"
-			if declFriendly {
-				msg = strings.Replace(msg, "Empty or ", "", 1)
-				suggestion = resource
-			}
 
 			// Customize the location based on whether an LRO is in use.
 			location := locations.MethodResponseType(m)

--- a/rules/aip0135/response_message_name_test.go
+++ b/rules/aip0135/response_message_name_test.go
@@ -87,9 +87,10 @@ func TestResponseMessageName(t *testing.T) {
 		problems     map[string]testutils.Problems
 	}{
 		{"ValidEmpty", "DeleteBook", "google.protobuf.Empty", "", problems["none"]},
+		// the declarative friendly style is no longer deviated for delete.
+		{"ValidEmptyDF", "DeleteBook", "google.protobuf.Empty", "style: DECLARATIVE_FRIENDLY", problems["none"]},
 		{"ValidResource", "DeleteBook", "Book", "", problems["none"]},
 		{"Invalid", "DeleteBook", "DeleteBookResponse", "", problems["empty"]},
-		{"InvalidEmptyDF", "DeleteBook", "google.protobuf.Empty", "style: DECLARATIVE_FRIENDLY", problems["book"]},
 		{"Irrelevant", "DestroyBook", "DestroyBookResponse", "", problems["none"]},
 	}
 


### PR DESCRIPTION
AIP-135 and AIP-128 have changed to not suggest soft-deleted
resources. This updates the linter to that recommendation.