### PR TITLE
fix(locations): add arbitrary field option helper

### DIFF
--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -18,7 +18,14 @@ import (
 	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	apb "google.golang.org/genproto/googleapis/api/annotations"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
+
+// FieldOption returns the precise location for the given extension on the
+// given field. This is useful for those writing rules for their own extensions.
+func FieldOption(f *desc.FieldDescriptor, e *protoimpl.ExtensionInfo) *dpb.SourceCodeInfo_Location {
+	return pathLocation(f, 8, int(e.TypeDescriptor().Number()))
+}
 
 // FieldResourceReference returns the precise location for a field's
 // resource reference annotation.

--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -26,7 +26,7 @@ import (
 //
 // Example: locations.FieldOption(field, fieldbehaviorpb.E_FieldBehavior)
 func FieldOption(f *desc.FieldDescriptor, e *protoimpl.ExtensionInfo) *dpb.SourceCodeInfo_Location {
-	return pathLocation(f, 8, int(e.TypeDescriptor().Number()))
+	return pathLocation(f, 8, int(e.TypeDescriptor().Number())) // FieldDescriptor.options == 8
 }
 
 // FieldResourceReference returns the precise location for a field's

--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -21,8 +21,10 @@ import (
 	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
-// FieldOption returns the precise location for the given extension on the
-// given field. This is useful for those writing rules for their own extensions.
+// FieldOption returns the precise location for the given extension defintion on
+// the given field. This is useful for writing rules against custom extensions.
+//
+// Example: locations.FieldOption(field, fieldbehaviorpb.E_FieldBehavior)
 func FieldOption(f *desc.FieldDescriptor, e *protoimpl.ExtensionInfo) *dpb.SourceCodeInfo_Location {
 	return pathLocation(f, 8, int(e.TypeDescriptor().Number()))
 }

--- a/locations/field_locations_test.go
+++ b/locations/field_locations_test.go
@@ -82,6 +82,7 @@ func TestFieldResourceReference(t *testing.T) {
 		}
 	`)
 	loc := FieldResourceReference(f.GetMessageTypes()[0].GetFields()[0])
+	// resource_reference annotation location is roughly line 4, column 19.
 	if diff := cmp.Diff(loc.GetSpan(), []int32{4, 19, 6, 3}); diff != "" {
 		t.Errorf(diff)
 	}

--- a/locations/field_locations_test.go
+++ b/locations/field_locations_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/jhump/protoreflect/desc"
+	apb "google.golang.org/genproto/googleapis/api/annotations"
 )
 
 func TestFieldLocations(t *testing.T) {
@@ -81,6 +82,21 @@ func TestFieldResourceReference(t *testing.T) {
 		}
 	`)
 	loc := FieldResourceReference(f.GetMessageTypes()[0].GetFields()[0])
+	if diff := cmp.Diff(loc.GetSpan(), []int32{4, 19, 6, 3}); diff != "" {
+		t.Errorf(diff)
+	}
+}
+
+func TestFieldOption(t *testing.T) {
+	f := parse(t, `
+		import "google/api/resource.proto";
+		message GetBookRequest {
+		  string name = 1 [(google.api.resource_reference) = {
+		    type: "library.googleapis.com/Book"
+		  }];
+		}
+	`)
+	loc := FieldOption(f.GetMessageTypes()[0].GetFields()[0], apb.E_ResourceReference)
 	if diff := cmp.Diff(loc.GetSpan(), []int32{4, 19, 6, 3}); diff != "" {
 		t.Errorf(diff)
 	}


### PR DESCRIPTION
Similar to the `MethodOption` helper, this enables retrieving source code info for an arbitrary Field option.