### PR TITLE
chore: make all directories safe for release tool to inspect

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,7 +14,9 @@ jobs:
           fetch-depth: 0
       - name: Get release information
         id: release_tool
-        run: go run ./.github/release-tool/
+        run: |
+          git config --global --add safe.directory '*'
+          go run ./.github/release-tool/
     outputs:
       version: ${{ steps.release_tool.outputs.version }}
       release_notes: ${{ steps.release_tool.outputs.release_notes }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Get release information
         id: release_tool
         run: |
-          git config --global --add safe.directory '*'
+          git config --global --add safe.directory $GITHUB_WORKSPACE
           go run ./.github/release-tool/
     outputs:
       version: ${{ steps.release_tool.outputs.version }}


### PR DESCRIPTION
The release job is [failing](https://github.com/googleapis/api-linter/actions/runs/5720431147/job/15501448609) with the following error:
```
2023/07/31 23:58:17 exec failed: fatal: detected dubious ownership in repository at '/__w/api-linter/api-linter'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/api-linter/api-linter

exit status 12[8](https://github.com/googleapis/api-linter/actions/runs/5720431147/job/15501448609#step:4:9)
exit status 1
```

The internet says that one can just specify `*` to allow all. 

Note: This is a good reason to move to `release-please` for release creation. It will just take some time to set up the configs and migrate the jobs. See #925.