### PR TITLE
fix(ci): fix release asset job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,10 +26,10 @@ jobs:
           - os: windows
             arch: amd64
     steps:
+      - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
         with:
           go-version-file: 'go.mod'
-      - uses: actions/checkout@v3
       # The API linter does not use these,  but we need them to build the
       # binaries.
       #

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -2,6 +2,7 @@
     "release-type": "go-yoshi",
     "include-component-in-tag": false,
     "include-v-in-tag": true,
+    "changelog-path": "CHANGELOG.md",
     "packages": {
         ".": {
             "component": "api-linter"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,9 @@
 # Changelog
+
+## [1.55.1](https://github.com/googleapis/api-linter/compare/v1.55.0...v1.55.1) (2023-08-02)
+
+
+### Bug Fixes
+
+* **locations:** add arbitrary field option helper ([#1213](https://github.com/googleapis/api-linter/issues/1213)) ([b8a0992](https://github.com/googleapis/api-linter/commit/b8a09921324769f882d14efb95014cadc81b8644))
+* refactor Standard Method message helpers into utils ([#1212](https://github.com/googleapis/api-linter/issues/1212)) ([c6b5d10](https://github.com/googleapis/api-linter/commit/c6b5d10eadf72b71437d5639d3ad17d07af22082))

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,9 +1,0 @@
-# Changelog
-
-## [1.55.1](https://github.com/googleapis/api-linter/compare/v1.55.0...v1.55.1) (2023-08-02)
-
-
-### Bug Fixes
-
-* **locations:** add arbitrary field option helper ([#1213](https://github.com/googleapis/api-linter/issues/1213)) ([b8a0992](https://github.com/googleapis/api-linter/commit/b8a09921324769f882d14efb95014cadc81b8644))
-* refactor Standard Method message helpers into utils ([#1212](https://github.com/googleapis/api-linter/issues/1212)) ([c6b5d10](https://github.com/googleapis/api-linter/commit/c6b5d10eadf72b71437d5639d3ad17d07af22082))


### PR DESCRIPTION
Needed to move the `checkout` step ahead of the `setup-go` step in order to reference the `go.mod` in the project. Also attempts to configure the change log path to CHANGELOG.md instead of the default CHANGES.md.