### PR TITLE
fix(AIP-121): strict check of resource type

### DIFF
--- a/rules/aip0121/resource_must_support_list.go
+++ b/rules/aip0121/resource_must_support_list.go
@@ -34,12 +34,12 @@ var resourceMustSupportList = &lint.ServiceRule{
 		// resources which have a List method, and which ones do not.
 		for _, m := range s.GetMethods() {
 			if utils.IsListMethod(m) {
-				if msg := utils.GetListResourceMessage(m); msg != nil {
+				if msg := utils.GetListResourceMessage(m); msg != nil && utils.IsResource(msg) {
 					t := utils.GetResource(msg).GetType()
 					resourcesWithList.Add(t)
 				}
 			} else if utils.IsCreateMethod(m) || utils.IsUpdateMethod(m) || utils.IsGetMethod(m) {
-				if msg := utils.GetResponseType(m); msg != nil {
+				if msg := utils.GetResponseType(m); msg != nil && utils.IsResource(msg) {
 					// Skip tracking Singleton resources, they do not need List.
 					if utils.IsSingletonResource(msg) {
 						continue

--- a/rules/aip0121/resource_must_support_list_test.go
+++ b/rules/aip0121/resource_must_support_list_test.go
@@ -78,6 +78,9 @@ func TestResourceMustSupportList(t *testing.T) {
 		{"ValidIgnoreSingleton", `
 			rpc GetBookCover(GetBookCoverRequest) returns (BookCover) {};
 		`, nil},
+		{"ValidIgnoreNonResource", `
+			rpc GetBookCover(GetBookCoverRequest) returns (Other) {};
+		`, nil},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			file := testutils.ParseProto3Tmpl(t, `
@@ -138,6 +141,10 @@ func TestResourceMustSupportList(t *testing.T) {
 				 message ListBooksResponse {
 					repeated Book books = 1;
 					string next_page_token = 2;
+				 }
+
+				 message Other {
+					string other = 1;
 				 }
 			`, test)
 			s := file.GetServices()[0]


### PR DESCRIPTION
Previous code assumed that if the standard method checks responded positively that the resulting message retrieved would be a resource. This is not always the case when the API has some non-compliant RPCs that look like Standard Methods.