### PR TITLE
fix(AIP-121): ignore standard method lookalikes

### DIFF
--- a/rules/aip0121/resource_must_support_get.go
+++ b/rules/aip0121/resource_must_support_get.go
@@ -33,16 +33,16 @@ var resourceMustSupportGet = &lint.ServiceRule{
 		// Iterate all RPCs and try to find resources. Mark the
 		// resources which have a Get method, and which ones do not.
 		for _, m := range s.GetMethods() {
-			if utils.IsGetMethod(m) {
+			if utils.IsGetMethod(m) && utils.IsResource(utils.GetResponseType(m)) {
 				t := utils.GetResource(m.GetOutputType()).GetType()
 				resourcesWithGet.Add(t)
 			} else if utils.IsCreateMethod(m) || utils.IsUpdateMethod(m) {
-				if msg := utils.GetResponseType(m); msg != nil {
+				if msg := utils.GetResponseType(m); msg != nil && utils.IsResource(msg) {
 					t := utils.GetResource(msg).GetType()
 					resourcesWithOtherMethods.Add(t)
 				}
 			} else if utils.IsListMethod(m) {
-				if msg := utils.GetListResourceMessage(m); msg != nil {
+				if msg := utils.GetListResourceMessage(m); msg != nil && utils.IsResource(msg) {
 					t := utils.GetResource(msg).GetType()
 					resourcesWithOtherMethods.Add(t)
 				}

--- a/rules/aip0121/resource_must_support_get_test.go
+++ b/rules/aip0121/resource_must_support_get_test.go
@@ -51,6 +51,15 @@ func TestResourceMustSupportGet(t *testing.T) {
 			rpc GetBook(GetBookRequest) returns (Book) {};
 			rpc UpdateBook(UpdateBookRequest) returns (Book) {};
 		`, nil},
+		{"ValidIgnoreNonResourceUpdate", `
+			rpc UpdateBook(UpdateBookRequest) returns (Other) {};
+		`, nil},
+		{"ValidIgnoreNonResourceCreate", `
+			rpc CreateBook(CreateBookRequest) returns (Other) {};
+		`, nil},
+		{"ValidIgnoreNonResourceList", `
+			rpc ListBooks(ListBooksRequest) returns (RepeatedOther) {};
+		`, nil},
 		{"InvalidCreateOnly", `
 			rpc CreateBook(CreateBookRequest) returns (Book) {};
 		`, []lint.Problem{
@@ -123,6 +132,12 @@ func TestResourceMustSupportGet(t *testing.T) {
 				 message ListBooksResponse {
 					repeated Book books = 1;
 					string next_page_token = 2;
+				 }
+
+				 message Other {}
+
+				 message RepeatedOther {
+					repeated Other others = 1;
 				 }
 			`, test)
 			s := file.GetServices()[0]


### PR DESCRIPTION
Ignore methods that look like standard methods but don't actually operate on a resource as a standard method would. This prevents false positive findings related for messages that aren't actually resources but have some standard method lookalikes. Similar to #1235