### PR TITLE
fix(AIP-203): remove resource name identifier suggestion

### DIFF
--- a/rules/aip0203/resource_name_identifier.go
+++ b/rules/aip0203/resource_name_identifier.go
@@ -33,7 +33,6 @@ var resourceNameIdentifier = &lint.MessageRule{
 				Message:    "resource name field must have field_behavior IDENTIFIER",
 				Descriptor: f,
 				Location:   locations.FieldOption(f, fpb.E_FieldBehavior),
-				Suggestion: "(google.api.field_behavior) = IDENTIFIER",
 			}}
 		}
 

--- a/rules/aip0203/resource_name_identifier_test.go
+++ b/rules/aip0203/resource_name_identifier_test.go
@@ -40,12 +40,12 @@ func TestResourceNameIdentifier(t *testing.T) {
 		{
 			name:     "InvalidNoFieldBehavior",
 			Field:    "string name = 1;",
-			problems: testutils.Problems{{Message: "field_behavior IDENTIFIER", Suggestion: "(google.api.field_behavior) = IDENTIFIER"}},
+			problems: testutils.Problems{{Message: "field_behavior IDENTIFIER"}},
 		},
 		{
 			name:     "InvalidMissingIdentifier",
 			Field:    "string name = 1 [(google.api.field_behavior) = REQUIRED];",
-			problems: testutils.Problems{{Message: "field_behavior IDENTIFIER", Suggestion: "(google.api.field_behavior) = IDENTIFIER"}},
+			problems: testutils.Problems{{Message: "field_behavior IDENTIFIER"}},
 		},
 	}
 


### PR DESCRIPTION
As [reported internally](https://b.corp.google.com/issues/302714576), the suggestion from this finding replaces the entire line rather than just adding the extension.