### PR TITLE
feat(AIP-148): add uid-format rule

### DIFF
--- a/docs/rules/0148/uid-format.md
+++ b/docs/rules/0148/uid-format.md
@@ -58,8 +58,6 @@ enclosing message. Remember to also include an [aip.dev/not-precedent][]
 comment explaining why.
 
 ```proto
-// (-- api-linter: core::0148::uid-format=disabled
-//     aip.dev/not-precedent: We need to do this because reasons. --)
 message Book {
   option (google.api.resource) = {
     type: "library.googleapis.com/Book"
@@ -68,6 +66,8 @@ message Book {
 
   string name = 1;
 
+  // (-- api-linter: core::0148::uid-format=disabled
+  //     aip.dev/not-precedent: We need to do this because reasons. --)
   string uid = 2;
 }
 ```

--- a/docs/rules/0148/uid-format.md
+++ b/docs/rules/0148/uid-format.md
@@ -31,7 +31,7 @@ message Book {
     pattern: "books/{book}"
   };
 
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
   string uid = 2; // missing (google.api.field_info).format = UUID4
 }
 ```
@@ -46,7 +46,7 @@ message Book {
     pattern: "books/{book}"
   };
 
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
   string uid = 2 [(google.api.field_info).format = UUID4];
 }
 ```
@@ -64,7 +64,7 @@ message Book {
     pattern: "books/{book}"
   };
 
-  string name = 1;
+  string name = 1 [(google.api.field_behavior) = IDENTIFIER];
 
   // (-- api-linter: core::0148::uid-format=disabled
   //     aip.dev/not-precedent: We need to do this because reasons. --)

--- a/docs/rules/0148/uid-format.md
+++ b/docs/rules/0148/uid-format.md
@@ -1,22 +1,23 @@
 ---
 rule:
   aip: 148
-  name: [core, '0148', use-uid]
-  summary: Use uid instead of id in resource messages.
-permalink: /148/use-uid
+  name: [core, '0148', uid-format]
+  summary: Annotate uid with UUID4 format.
+permalink: /148/uid-format
 redirect_from:
-  - /0148/use-uid
+  - /0148/uid-format
 ---
 
-# Use `uid` as the resource ID field
+# `uid` format annotation
 
-This rule encourages the use of `uid` instead of `id` for resource messages, as
-mandated in [AIP-148][].
+This rule encourages the use of the `UUID4` format annotation on the `uid`
+field, as mandated in [AIP-148][].
 
 ## Details
 
-This rule looks on resource messages for a field named `id`, complains if it
-finds it, and suggests the use of `uid` instead.
+This rule looks on for fields named `uid` and complains if it does not have the
+`(google.api.field_info).format = UUID4` annotation or has a format other than
+`UUID4`.
 
 ## Examples
 
@@ -31,7 +32,7 @@ message Book {
   };
 
   string name = 1;
-  string id = 2; // Should be `uid`
+  string uid = 2; // missing (google.api.field_info).format = UUID4
 }
 ```
 
@@ -46,7 +47,7 @@ message Book {
   };
 
   string name = 1;
-  string uid = 2;
+  string uid = 2 [(google.api.field_info).format = UUID4];
 }
 ```
 
@@ -57,7 +58,7 @@ enclosing message. Remember to also include an [aip.dev/not-precedent][]
 comment explaining why.
 
 ```proto
-// (-- api-linter: core::0148::use-uid=disabled
+// (-- api-linter: core::0148::uid-format=disabled
 //     aip.dev/not-precedent: We need to do this because reasons. --)
 message Book {
   option (google.api.resource) = {
@@ -66,7 +67,8 @@ message Book {
   };
 
   string name = 1;
-  string id = 2;
+
+  string uid = 2;
 }
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.11
-	cloud.google.com/go/longrunning v0.5.1
+	cloud.google.com/go/longrunning v0.5.2
 	github.com/bmatcuk/doublestar/v4 v4.6.0
 	github.com/gertd/go-pluralize v0.2.1
 	github.com/golang/protobuf v1.5.3
@@ -24,9 +24,9 @@ require (
 require (
 	github.com/bufbuild/protocompile v0.6.0 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
-	golang.org/x/net v0.10.0 // indirect
+	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect
-	golang.org/x/sys v0.8.0 // indirect
+	golang.org/x/sys v0.13.0 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20230920204549-e6e6cdab5c13 // indirect
 	google.golang.org/grpc v1.57.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
 bitbucket.org/creachadair/stringset v0.0.11 h1:6Sv4CCv14Wm+OipW4f3tWOb0SQVpBDLW0knnJqUnmZ8=
 bitbucket.org/creachadair/stringset v0.0.11/go.mod h1:wh0BHewFe+j0HrzWz7KcGbSNpFzWwnpmgPRlB57U5jU=
-cloud.google.com/go/longrunning v0.5.1 h1:Fr7TXftcqTudoyRJa113hyaqlGdiBQkp0Gq7tErFDWI=
-cloud.google.com/go/longrunning v0.5.1/go.mod h1:spvimkwdz6SPWKEt/XBij79E9fiTkHSQl/fRUUQJYJc=
+cloud.google.com/go/longrunning v0.5.2 h1:u+oFqfEwwU7F9dIELigxbe0XVnBAo9wqMuQLA50CZ5k=
+cloud.google.com/go/longrunning v0.5.2/go.mod h1:nqo6DQbNV2pXhGDbDMoN2bWz68MjZUzqv2YttZiveCs=
 github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvzIZhEXc=
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bufbuild/protocompile v0.6.0 h1:Uu7WiSQ6Yj9DbkdnOe7U4mNKp58y9WDMKDn28/ZlunY=
@@ -38,12 +38,12 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
-golang.org/x/net v0.10.0 h1:X2//UzNDwYmtCLn7To6G58Wr6f5ahEAQgKNzv9Y951M=
-golang.org/x/net v0.10.0/go.mod h1:0qNGK6F8kojg2nk9dLZ2mShWaEBan6FAoqfSigmmuDg=
+golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/sync v0.3.0 h1:ftCYgMx6zT/asHUrPw8BLLscYtGznsLAnjq5RH9P66E=
 golang.org/x/sync v0.3.0/go.mod h1:FU7BRWz2tNW+3quACPkgCx/L+uEAv1htQ0V83Z9Rj+Y=
-golang.org/x/sys v0.8.0 h1:EBmGv8NaZBZTWvrbjNoL6HVt+IVy3QDQpJs7VRIw3tU=
-golang.org/x/sys v0.8.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.13.0 h1:Af8nKPmuFypiUBjVoU9V20FiaFXOcuZI21p0ycVYYGE=
+golang.org/x/sys v0.13.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
 golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/rules/aip0148/aip0148.go
+++ b/rules/aip0148/aip0148.go
@@ -27,5 +27,6 @@ func AddRules(r lint.RuleRegistry) error {
 		fieldBehavior,
 		humanNames,
 		useUid,
+		uidFormat,
 	)
 }

--- a/rules/aip0148/uid_format.go
+++ b/rules/aip0148/uid_format.go
@@ -19,12 +19,13 @@ import (
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	"google.golang.org/protobuf/types/descriptorpb"
 )
 
 var uidFormat = &lint.FieldRule{
 	Name: lint.NewRuleName(148, "uid-format"),
 	OnlyIf: func(fd *desc.FieldDescriptor) bool {
-		return fd.GetName() == uidStr
+		return fd.GetType() == descriptorpb.FieldDescriptorProto_TYPE_STRING && fd.GetName() == uidStr
 	},
 	LintField: func(fd *desc.FieldDescriptor) []lint.Problem {
 		if !utils.HasFormat(fd) || utils.GetFormat(fd) != annotations.FieldInfo_UUID4 {

--- a/rules/aip0148/uid_format.go
+++ b/rules/aip0148/uid_format.go
@@ -1,0 +1,39 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0148
+
+import (
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+	"google.golang.org/genproto/googleapis/api/annotations"
+)
+
+var uidFormat = &lint.FieldRule{
+	Name: lint.NewRuleName(148, "uid-format"),
+	OnlyIf: func(fd *desc.FieldDescriptor) bool {
+		return fd.GetName() == uidStr
+	},
+	LintField: func(fd *desc.FieldDescriptor) []lint.Problem {
+		if !utils.HasFormat(fd) || utils.GetFormat(fd) != annotations.FieldInfo_UUID4 {
+			return []lint.Problem{{
+				Message:    "The `uid` field must have a `(google.api.field_info).format = UUID4` annotation.",
+				Descriptor: fd,
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0148/uid_format_test.go
+++ b/rules/aip0148/uid_format_test.go
@@ -22,27 +22,36 @@ import (
 
 func TestUidFormat(t *testing.T) {
 	for _, test := range []struct {
-		name, FieldName, Annotation string
-		problems                    testutils.Problems
+		name, Annotation, FieldName, Type string
+		problems                          testutils.Problems
 	}{
 		{
 			name:       "ValidUidFormat",
 			FieldName:  "uid",
 			Annotation: "[(google.api.field_info).format = UUID4]",
+			Type:       "string",
 		},
 		{
 			name:      "SkipNonUid",
 			FieldName: "other",
+			Type:      "string",
+		},
+		{
+			name:      "SkipNonStringUid",
+			FieldName: "uid",
+			Type:      "Foo",
 		},
 		{
 			name:      "InvalidMissingFormat",
 			FieldName: "uid",
+			Type:      "string",
 			problems:  testutils.Problems{{Message: "format = UUID4"}},
 		},
 		{
 			name:       "InvalidWrongFormat",
 			FieldName:  "uid",
 			Annotation: "[(google.api.field_info).format = IPV4]",
+			Type:       "string",
 			problems:   testutils.Problems{{Message: "format = UUID4"}},
 		},
 	} {
@@ -51,8 +60,10 @@ func TestUidFormat(t *testing.T) {
 				import "google/api/field_info.proto";
 
 				message Person {
-					string {{.FieldName}} = 2 {{.Annotation}};
+					{{.Type}} {{.FieldName}} = 2 {{.Annotation}};
 				}
+
+				message Foo {}
 			`, test)
 			field := f.GetMessageTypes()[0].GetFields()[0]
 			if diff := test.problems.SetDescriptor(field).Diff(uidFormat.Lint(f)); diff != "" {

--- a/rules/aip0148/uid_format_test.go
+++ b/rules/aip0148/uid_format_test.go
@@ -1,0 +1,63 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0148
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestUidFormat(t *testing.T) {
+	for _, test := range []struct {
+		name, FieldName, Annotation string
+		problems                    testutils.Problems
+	}{
+		{
+			name:       "ValidUidFormat",
+			FieldName:  "uid",
+			Annotation: "[(google.api.field_info).format = UUID4]",
+		},
+		{
+			name:      "SkipNonUid",
+			FieldName: "other",
+		},
+		{
+			name:      "InvalidMissingFormat",
+			FieldName: "uid",
+			problems:  testutils.Problems{{Message: "format = UUID4"}},
+		},
+		{
+			name:       "InvalidWrongFormat",
+			FieldName:  "uid",
+			Annotation: "[(google.api.field_info).format = IPV4]",
+			problems:   testutils.Problems{{Message: "format = UUID4"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+				import "google/api/field_info.proto";
+
+				message Person {
+					string {{.FieldName}} = 2 {{.Annotation}};
+				}
+			`, test)
+			field := f.GetMessageTypes()[0].GetFields()[0]
+			if diff := test.problems.SetDescriptor(field).Diff(uidFormat.Lint(f)); diff != "" {
+				t.Errorf(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
As mandated in AIP-148, the `uid` field **must** have `(google.api.field_info).format = UUID4`. This rule enforces that.

Also fix incorrect doc title for `use-uid` rule doc.