### PR TITLE
feat(AIP-191): enforce java package has the prefix `com.google`

### DIFF
--- a/rules/aip0191/java_package.go
+++ b/rules/aip0191/java_package.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -23,6 +23,8 @@ import (
 	"github.com/jhump/protoreflect/desc"
 )
 
+var JAVA_PACKAGE_PREFIX = "com.google"
+
 var javaPackage = &lint.FileRule{
 	Name: lint.NewRuleName(191, "java-package"),
 	OnlyIf: func(f *desc.FileDescriptor) bool {
@@ -45,6 +47,13 @@ var javaPackage = &lint.FileRule{
 				Location:   locations.FileJavaPackage(f),
 			}}
 		}
+		if !strings.HasPrefix(javaPkg, JAVA_PACKAGE_PREFIX) {
+			return []lint.Problem{{
+			 Message:    fmt.Sprintf(`The Java Package should have prefix "%s".`, JAVA_PACKAGE_PREFIX),
+			 Descriptor: f,
+			 Location:   locations.FileJavaPackage(f),
+			}}
+		 }
 		return nil
 	},
 }

--- a/rules/aip0191/java_package_test.go
+++ b/rules/aip0191/java_package_test.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2023 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -27,13 +27,16 @@ func TestJavaPackage(t *testing.T) {
 		statements []string
 		problems   testutils.Problems
 	}{
-		{"Valid", []string{"package foo.v1;", `option java_package = "com.foo.v1";`}, testutils.Problems{}},
+		{"Valid", []string{"package foo.v1;", `option java_package = "com.google.foo.v1";`}, testutils.Problems{}},
 		{"InvalidEmpty", []string{"package foo.v1;", ""}, testutils.Problems{{Message: "java_package"}}},
 		{"InvalidWrong", []string{"package foo.v1;", `option java_package = "something.else";`}, testutils.Problems{{
 			Suggestion: `option java_package = "com.foo.v1";`,
 		}}},
 		{"Ignored", []string{"", ""}, testutils.Problems{}},
 		{"IgnoredMaster", []string{"package foo.master;", ""}, testutils.Problems{}},
+		{"InvalidPrefix", []string{"package maps.foo.v1;", `option java_package = "google.maps.foo.v1";`}, testutils.Problems{{
+			Message: `The Java Package should have prefix "com.google".`,
+		}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3String(t, strings.Join(test.statements, "\n"))


### PR DESCRIPTION
Fix: #1108 