### PR TITLE
chore: replace v1 proto-go with v2

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -22,13 +22,13 @@ import (
 	"strings"
 	"sync"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/internal"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/protoparse"
 	"github.com/spf13/pflag"
 	"google.golang.org/protobuf/proto"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 	"gopkg.in/yaml.v2"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	cloud.google.com/go/longrunning v0.5.2
 	github.com/bmatcuk/doublestar/v4 v4.6.1
 	github.com/gertd/go-pluralize v0.2.1
-	github.com/golang/protobuf v1.5.3
 	github.com/google/go-cmp v0.6.0
 	github.com/jhump/protoreflect v1.15.3
 	github.com/lithammer/dedent v1.1.0
@@ -23,6 +22,7 @@ require (
 
 require (
 	github.com/bufbuild/protocompile v0.6.0 // indirect
+	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/sync v0.3.0 // indirect

--- a/lint/problem.go
+++ b/lint/problem.go
@@ -17,8 +17,8 @@ package lint
 import (
 	"encoding/json"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // Problem contains information about a result produced by an API Linter.

--- a/lint/problem_test.go
+++ b/lint/problem_test.go
@@ -19,8 +19,8 @@ import (
 	"strings"
 	"testing"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc/builder"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 	"gopkg.in/yaml.v2"
 )
 

--- a/lint/rule.go
+++ b/lint/rule.go
@@ -18,8 +18,8 @@ import (
 	"regexp"
 	"strings"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // ProtoRule defines a lint rule that checks Google Protobuf APIs.

--- a/lint/rule_enabled.go
+++ b/lint/rule_enabled.go
@@ -17,8 +17,8 @@ package lint
 import (
 	"strings"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // defaultDisabledRules is the list of rules or groups that are by default

--- a/lint/rule_enabled_test.go
+++ b/lint/rule_enabled_test.go
@@ -17,9 +17,9 @@ package lint
 import (
 	"testing"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestRuleIsEnabled(t *testing.T) {

--- a/locations/descriptor_locations.go
+++ b/locations/descriptor_locations.go
@@ -15,8 +15,8 @@
 package locations
 
 import (
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // DescriptorName returns the precise location for a descriptor's name.

--- a/locations/field_locations.go
+++ b/locations/field_locations.go
@@ -15,10 +15,10 @@
 package locations
 
 import (
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	apb "google.golang.org/genproto/googleapis/api/annotations"
 	"google.golang.org/protobuf/reflect/protoreflect"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // FieldOption returns the precise location for the given extension defintion on

--- a/locations/file_locations.go
+++ b/locations/file_locations.go
@@ -15,9 +15,9 @@
 package locations
 
 import (
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	apb "google.golang.org/genproto/googleapis/api/annotations"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // FileSyntax returns the location of the syntax definition in a file descriptor.

--- a/locations/file_locations_test.go
+++ b/locations/file_locations_test.go
@@ -17,10 +17,10 @@ package locations
 import (
 	"testing"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/google/go-cmp/cmp"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestLocations(t *testing.T) {

--- a/locations/locations.go
+++ b/locations/locations.go
@@ -23,8 +23,8 @@
 package locations
 
 import (
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // pathLocation returns the precise location for a given descriptor and path.

--- a/locations/message_locations.go
+++ b/locations/message_locations.go
@@ -15,9 +15,9 @@
 package locations
 
 import (
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	apb "google.golang.org/genproto/googleapis/api/annotations"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // MessageResource returns the precise location of the `google.api.resource`

--- a/locations/method_locations.go
+++ b/locations/method_locations.go
@@ -16,9 +16,9 @@ package locations
 
 import (
 	lrpb "cloud.google.com/go/longrunning/autogen/longrunningpb"
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/jhump/protoreflect/desc"
 	apb "google.golang.org/genproto/googleapis/api/annotations"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 // MethodRequestType returns the precise location of the method's input type.

--- a/rules/aip0123/duplicate_resource.go
+++ b/rules/aip0123/duplicate_resource.go
@@ -19,11 +19,11 @@ import (
 	"sort"
 	"strings"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 type resourceDef struct {

--- a/rules/aip0123/resource_pattern.go
+++ b/rules/aip0123/resource_pattern.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 var resourcePattern = &lint.MessageRule{

--- a/rules/aip0123/resource_variables.go
+++ b/rules/aip0123/resource_variables.go
@@ -18,12 +18,12 @@ import (
 	"fmt"
 	"strings"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
 	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 	"google.golang.org/genproto/googleapis/api/annotations"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 var resourceVariables = &lint.MessageRule{

--- a/rules/aip0191/file_option_consistency.go
+++ b/rules/aip0191/file_option_consistency.go
@@ -19,10 +19,10 @@ import (
 	"sort"
 	"strconv"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
 	"github.com/jhump/protoreflect/desc"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 var consistentOptions = map[string]func(*dpb.FileOptions) string{

--- a/rules/aip0191/file_option_consistency_test.go
+++ b/rules/aip0191/file_option_consistency_test.go
@@ -19,13 +19,13 @@ import (
 	"sort"
 	"testing"
 
-	dpb "github.com/golang/protobuf/protoc-gen-go/descriptor"
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/rules/internal/testutils"
 	"github.com/jhump/protoreflect/desc"
 	"github.com/jhump/protoreflect/desc/builder"
 	"github.com/stoewer/go-strcase"
 	"google.golang.org/protobuf/proto"
+	dpb "google.golang.org/protobuf/types/descriptorpb"
 )
 
 func TestFileOptionConsistency(t *testing.T) {


### PR DESCRIPTION
Swap out instances of the deprecated protobuf-go v1 module with drop-in replacement using protobuf-go v2 module.