### PR TITLE
fix(AIP-4232): support nested field of required field

### DIFF
--- a/rules/aip4232/required_fields.go
+++ b/rules/aip4232/required_fields.go
@@ -41,7 +41,14 @@ var requiredFields = &lint.MethodRule{
 			}
 		}
 		for i, sig := range sigs {
-			sigset := stringset.New(sig...)
+			sigset := stringset.New(sig...).Map(func(s string) string {
+				if !strings.Contains(s, ".") {
+					return s
+				}
+				// If signature contains nested fields, get the root field
+				// to use in top-level required field check.
+				return strings.Split(s, ".")[0]
+			})
 			if !sigset.Contains(requiredFields...) {
 				problems = append(problems, lint.Problem{
 					Message:    fmt.Sprintf("Method signature %q missing at least one of the required fields: %q", strings.Join(sig, ","), strings.Join(requiredFields, ",")),

--- a/rules/aip4232/required_fields_test.go
+++ b/rules/aip4232/required_fields_test.go
@@ -27,7 +27,8 @@ func TestRequiredFields(t *testing.T) {
 		FieldBehavior string
 		problems      testutils.Problems
 	}{
-		{"Valid", "name,paperback_only", "REQUIRED", nil},
+		{"Valid", "name,paperback_only,shelf", "REQUIRED", nil},
+		{"ValidNested", "name,paperback_only,shelf.name", "REQUIRED", nil},
 		{"ValidNotRequired", "paperback_only", "OPTIONAL", nil},
 		{"Invalid", "paperback_only", "REQUIRED", testutils.Problems{{Message: "missing at least one"}}},
 	}
@@ -46,8 +47,13 @@ func TestRequiredFields(t *testing.T) {
 					string name = 1 [(google.api.field_behavior) = {{.FieldBehavior}}];
 
 					bool paperback_only = 2;
+
+					Shelf shelf = 3 [(google.api.field_behavior) = {{.FieldBehavior}}];
 				}
 				message ArchiveBookResponse {}
+				message Shelf {
+					string name = 1;
+				}
 			`, test)
 			method := f.GetServices()[0].GetMethods()[0]
 			if diff := test.problems.SetDescriptor(method).Diff(requiredFields.Lint(f)); diff != "" {


### PR DESCRIPTION
When a method signature contains a nested field of a message type field that is required in the top level request message, that should be sufficient to fulfill the "all required fields in method signature" requirement.

Internal bug b/325252841