### PR TITLE
docs(AIP-191): remove ambiguity in java_outer_classname

### DIFF
--- a/docs/rules/0191/java-outer-classname.md
+++ b/docs/rules/0191/java-outer-classname.md
@@ -31,7 +31,7 @@ package google.example.v1;
 
 option java_package = "com.google.example.v1";
 option java_multiple_files = true;
-// Needs `option java_outer_classname = "LibraryProto";` or similar.
+// Needs `option java_outer_classname = "LibraryProto";`
 
 message Book {}
 ```


### PR DESCRIPTION
Addresses confusion in [internal bug](http://b/318621685) by removing ambiguity in the linter rule docs allowing for `java_out_classname` variance when AIP-191 states it **should** be named as the proto.