### PR TITLE
feat(AIP-133): ignore create methods with invalid LRO response types

### DIFF
--- a/rules/aip0133/request_required_fields.go
+++ b/rules/aip0133/request_required_fields.go
@@ -28,7 +28,7 @@ import (
 // The create request message should not have unrecognized fields.
 var requestRequiredFields = &lint.MethodRule{
 	Name:   lint.NewRuleName(133, "request-required-fields"),
-	OnlyIf: utils.IsCreateMethod,
+	OnlyIf: utils.IsCreateMethodWithResolvedReturnType,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		ot := utils.GetResponseType(m)
 		r := utils.GetResource(ot)

--- a/rules/internal/utils/method.go
+++ b/rules/internal/utils/method.go
@@ -45,12 +45,7 @@ func IsCreateMethodWithResolvedReturnType(m *desc.MethodDescriptor) bool {
 		return false
 	}
 
-	res := m.GetOutputType()
-
-	if info := GetOperationInfo(m); info != nil {
-		res = FindMessage(m.GetFile(), info.GetResponseType())
-	}
-	return res != nil
+	return GetResponseType(m) != nil
 }
 
 // IsGetMethod returns true if this is a AIP-131 Get method.

--- a/rules/internal/utils/method.go
+++ b/rules/internal/utils/method.go
@@ -36,6 +36,23 @@ func IsCreateMethod(m *desc.MethodDescriptor) bool {
 	return createMethodRegexp.MatchString(m.GetName())
 }
 
+// IsCreateMethod returns true if this is a AIP-133 Create method with
+// a non-nil response type. This method should be used for filtering in linter
+// rules which access the response type of the method, to avoid crashing due
+// to dereferencing a nil pointer to the response.
+func IsCreateMethodWithResolvedReturnType(m *desc.MethodDescriptor) bool {
+	if !IsCreateMethod(m) {
+		return false
+	}
+
+	res := m.GetOutputType()
+
+	if info := GetOperationInfo(m); info != nil {
+		res = FindMessage(m.GetFile(), info.GetResponseType())
+	}
+	return res != nil
+}
+
 // IsGetMethod returns true if this is a AIP-131 Get method.
 func IsGetMethod(m *desc.MethodDescriptor) bool {
 	methodName := m.GetName()


### PR DESCRIPTION
This addresses a nil dereferencing error due to `ot` being `nil` in https://github.com/andrei-scripniciuc/api-linter/blob/f6108f07532aae07c4f305c7da99092f0114cea2/rules/aip0133/request_required_fields.go#L50