### PR TITLE
chore(deps): force renovate to use Go 1.20

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,4 +7,9 @@
   ],
   labels: ["automerge"],
   postUpdateOptions: ["gomodTidy"],
+  "force": {
+    "constraints": {
+      "go": "1.20"
+    }
+  }
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,9 +7,9 @@
   ],
   labels: ["automerge"],
   postUpdateOptions: ["gomodTidy"],
-  "force": {
-    "constraints": {
-      "go": "1.20"
+  force: {
+    constraints: {
+      go: "1.20"
     }
   }
 }


### PR DESCRIPTION
renovate uses latest Go version, but that means it will be tidied with 1.22 which adds `toolchain` directive to the `go.mod` which `Go 1.20` tools (i.e. CI) do not understand.