### PR TITLE
chore(deps): block stringset updates until 1.21

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,6 +7,14 @@
   ],
   labels: ["automerge"],
   postUpdateOptions: ["gomodTidy"],
+  packageRules: [
+    {
+      matchPackageNames: [
+        "^bitbucket.org/creachadair/stringset",
+      ],
+      enabled: false
+    }
+  ],
   force: {
     constraints: {
       go: "1.20"


### PR DESCRIPTION
Blocks updates to `stringset` until we migrate to Go 1.21, at which point we can take new versions of it.