### PR TITLE
fix: ignore proto3_optional fields in oneof check

### DIFF
--- a/rules/internal/utils/common_lints.go
+++ b/rules/internal/utils/common_lints.go
@@ -74,7 +74,7 @@ func LintFieldMask(f *desc.FieldDescriptor) []lint.Problem {
 
 // LintNotOneof returns a problem if the field is a oneof.
 func LintNotOneof(f *desc.FieldDescriptor) []lint.Problem {
-	if f.GetOneOf() != nil {
+	if f.GetOneOf() != nil && !f.IsProto3Optional() {
 		return []lint.Problem{{
 			Message:    fmt.Sprintf("The `%s` field should not be a oneof field.", f.GetName()),
 			Descriptor: f,

--- a/rules/internal/utils/common_lints_test.go
+++ b/rules/internal/utils/common_lints_test.go
@@ -260,6 +260,7 @@ func TestLintNotOneof(t *testing.T) {
 		problems testutils.Problems
 	}{
 		{"Valid", `string foo = 1;`, nil},
+		{"ValidProto3Optional", `optional string foo = 1;`, nil},
 		{"Invalid", `oneof foo_oneof { string foo = 1; }`, testutils.Problems{{Message: "should not be a oneof"}}},
 	} {
 		t.Run(test.testName, func(t *testing.T) {


### PR DESCRIPTION
When linting if a field is a oneof, ignore those fields that are proto3_optional, which are wrapped in a synthetic oneof.

Updates #1323