### PR TITLE
fix(AIP-203): resource etag should not have behavior

### DIFF
--- a/rules/aip0203/field_behavior_required.go
+++ b/rules/aip0203/field_behavior_required.go
@@ -27,6 +27,11 @@ var minimumRequiredFieldBehavior = stringset.New(
 	"OPTIONAL", "REQUIRED", "OUTPUT_ONLY", "IMMUTABLE",
 )
 
+var excusedResourceFields = stringset.New(
+	"name", // Uses https://google.aip.dev/203#identifier
+	"etag", // Prohibited by https://google.aip.dev/154
+)
+
 var fieldBehaviorRequired = &lint.MethodRule{
 	Name: lint.NewRuleName(203, "field-behavior-required"),
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
@@ -51,7 +56,7 @@ func problems(m *desc.MessageDescriptor, pkg string, visited map[desc.Descriptor
 		}
 		visited[f] = true
 
-		if utils.IsResource(m) && f.GetName() == "name" {
+		if utils.IsResource(m) && excusedResourceFields.Contains(f.GetName()) {
 			continue
 		}
 

--- a/rules/aip0203/field_behavior_required_test.go
+++ b/rules/aip0203/field_behavior_required_test.go
@@ -117,6 +117,8 @@ func TestFieldBehaviorRequired_SingleFile_SingleMessage(t *testing.T) {
 					};
 
 					string name = 1;
+
+					string etag = 2;
 				}
 			`, tc)
 			field := f.GetMessageTypes()[0].GetFields()[0]


### PR DESCRIPTION
Addresses b/334162004 under allowance in AIP-154:
> The etag field on the resource **should not** be given any behavior annotations.