### PR TITLE
fix(AIP-136): handle LRO response names

### DIFF
--- a/rules/aip0136/response_message_name.go
+++ b/rules/aip0136/response_message_name.go
@@ -55,10 +55,15 @@ var responseMessageName = &lint.MethodRule{
 			return nil
 		}
 
+		loc := locations.MethodResponseType(m)
+		if utils.IsOperation(m.GetOutputType()) {
+			loc = locations.MethodOperationInfo(m)
+		}
+
 		return []lint.Problem{{
 			Message:    fmt.Sprintf(responseMessageNameErrorMessage, response.GetName()),
 			Descriptor: m,
-			Location:   locations.MethodResponseType(m),
+			Location:   loc,
 		}}
 
 	},

--- a/rules/aip0136/response_message_name_test.go
+++ b/rules/aip0136/response_message_name_test.go
@@ -27,12 +27,44 @@ func TestResponseMessageName(t *testing.T) {
 			testName        string
 			MethodName      string
 			RespMessageName string
-			MessageName     string
 			problems        testutils.Problems
 		}{
-			{"Valid", "ArchiveBook", "ArchiveBookResponse", "ArchiveBookResponse", testutils.Problems{}},
-			{"ValidLongRunningOperation", "ArchiveBook", "ArchiveBookResponse", "ArchiveBookResponse", testutils.Problems{}},
-			{"Invalid", "ArchiveBook", "ArchiveBookResp", "ArchiveBookResp", testutils.Problems{{Message: "not \"ArchiveBookResp\"."}}},
+			{"Valid", "ArchiveBook", "ArchiveBookResponse", testutils.Problems{}},
+			{"Invalid", "ArchiveBook", "ArchiveBookResp", testutils.Problems{{Message: "not \"ArchiveBookResp\"."}}},
+		}
+
+		for _, test := range tests {
+			t.Run(test.testName, func(t *testing.T) {
+				file := testutils.ParseProto3Tmpl(t, `
+				package test;
+				import "google/api/resource.proto";
+
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.RespMessageName}});
+				}
+
+				message {{.MethodName}}Request {}
+				message {{.RespMessageName}} {}
+				`, test)
+				method := file.GetServices()[0].GetMethods()[0]
+				problems := responseMessageName.Lint(file)
+				if diff := test.problems.SetDescriptor(method).Diff(problems); diff != "" {
+					t.Error(diff)
+				}
+			})
+		}
+	})
+
+	t.Run("Response Suffix - LRO", func(t *testing.T) {
+		// Set up the testing permutations.
+		tests := []struct {
+			testName    string
+			MethodName  string
+			MessageName string
+			problems    testutils.Problems
+		}{
+			{"Valid", "ArchiveBook", "ArchiveBookResponse", testutils.Problems{}},
+			{"Invalid", "ArchiveBook", "ArchiveBookResp", testutils.Problems{{Message: "not \"ArchiveBookResp\"."}}},
 		}
 
 		for _, test := range tests {
@@ -43,7 +75,7 @@ func TestResponseMessageName(t *testing.T) {
 				import "google/longrunning/operations.proto";
 
 				service Library {
-					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.RespMessageName}}) {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns (google.longrunning.Operation) {
 						option (google.longrunning.operation_info) = {
 							response_type: "{{.MessageName}}"
 							metadata_type: "OperationMetadata"

--- a/rules/internal/utils/common_lints_test.go
+++ b/rules/internal/utils/common_lints_test.go
@@ -205,20 +205,31 @@ func TestLintMethodHasMatchingRequestName(t *testing.T) {
 
 func TestLintMethodHasMatchingResponseName(t *testing.T) {
 	for _, test := range []struct {
-		testName    string
-		MessageName string
-		problems    testutils.Problems
+		testName     string
+		ResponseName string
+		MessageName  string
+		problems     testutils.Problems
 	}{
-		{"Valid", "GetBookResponse", nil},
-		{"Invalid", "AcquireBookResponse", testutils.Problems{{Suggestion: "GetBookResponse"}}},
+		{"Valid", "GetBookResponse", "GetBookResponse", nil},
+		{"ValidLongRunningOperation", "google.longrunning.Operation", "GetBookResponse", nil},
+		{"Invalid", "AcquireBookResponse", "AcquireBookResponse", testutils.Problems{{Suggestion: "GetBookResponse"}}},
+		{"InvalidLongRunningOperation", "google.longrunning.Operation", "AcquireBookResponse", testutils.Problems{{Message: "GetBookResponse"}}},
 	} {
 		t.Run(test.testName, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				import "google/longrunning/operations.proto";
+
 				service Library {
-					rpc GetBook(GetBookRequest) returns ({{.MessageName}});
+					rpc GetBook(GetBookRequest) returns ({{.ResponseName}}) {
+						option (google.longrunning.operation_info) = {
+							response_type: "{{.MessageName}}"
+							metadata_type: "OperationMetadata"
+						};
+					}
 				}
 				message GetBookRequest {}
 				message {{.MessageName}} {}
+				message OperationMetadata {}
 			`, test)
 			method := f.GetServices()[0].GetMethods()[0]
 			problems := LintMethodHasMatchingResponseName(method)


### PR DESCRIPTION
The common lint for response message name matching needs to better handle LRO Methods which have their response message encoded in the `google.longrunning.operation_info` annotation.

This fixes the common lint to properly compare the response_type name instead of the rpc return type in the LRO case, as well as the AIP-136 implementation to warn on the proper spot.

Internal bug b/342434484

cc: @liveFreeOrCode just an fyi - the helper we used had a little bug in it that would let it fall through to the finding logic on valid RPCs using LRO. I should've asked for LRO case in the tests! my bad