### PR TITLE
fix(aip-130): identify standard and custom methods

### DIFF
--- a/rules/aip0136/aip0136.go
+++ b/rules/aip0136/aip0136.go
@@ -16,11 +16,7 @@
 package aip0136
 
 import (
-	"strings"
-
 	"github.com/googleapis/api-linter/lint"
-	"github.com/googleapis/api-linter/rules/internal/utils"
-	"github.com/jhump/protoreflect/desc"
 )
 
 // AddRules accepts a register function and registers each of
@@ -41,23 +37,4 @@ func AddRules(r lint.RuleRegistry) error {
 		// httpNameVariable,
 		// httpParentVariable,
 	)
-}
-
-func isCustomMethod(m *desc.MethodDescriptor) bool {
-	// Anything with a `:` in the method URI is automatically a custom
-	// method, regardless of the RPC name.
-	for _, httpRule := range utils.GetHTTPRules(m) {
-		if strings.Contains(httpRule.GetPlainURI(), ":") {
-			return true
-		}
-	}
-
-	// Methods with no `:` in the URI are standard methods if they begin with
-	// one of the standard method names.
-	for _, prefix := range []string{"Get", "List", "Create", "Update", "Delete", "Replace"} {
-		if strings.HasPrefix(m.GetName(), prefix) {
-			return false
-		}
-	}
-	return true
 }

--- a/rules/aip0136/http_body.go
+++ b/rules/aip0136/http_body.go
@@ -27,7 +27,7 @@ import (
 
 var httpBody = &lint.MethodRule{
 	Name:   lint.NewRuleName(136, "http-body"),
-	OnlyIf: isCustomMethod,
+	OnlyIf: utils.IsCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			noBody := stringset.New("GET", "DELETE")

--- a/rules/aip0136/http_method.go
+++ b/rules/aip0136/http_method.go
@@ -25,7 +25,7 @@ import (
 
 var httpMethod = &lint.MethodRule{
 	Name:   lint.NewRuleName(136, "http-method"),
-	OnlyIf: isCustomMethod,
+	OnlyIf: utils.IsCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// DeleteFooRevision is still a custom method, but delete is expected
 		// (enforced in AIP-162 rules).

--- a/rules/aip0136/http_method_test.go
+++ b/rules/aip0136/http_method_test.go
@@ -36,7 +36,6 @@ func TestHttpMethod(t *testing.T) {
 		{"InvalidDelete", "ArchiveBook", "delete", "", testutils.Problems{{Message: "POST or GET"}}},
 		{"IrrelevantPatch", "UpdateBook", "patch", "", nil},
 		{"IrrelevantDelete", "DeleteBook", "delete", "", nil},
-		{"IrrelevantPut", "ReplaceBook", "put", "", nil},
 	}
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {

--- a/rules/aip0136/http_name_variable.go
+++ b/rules/aip0136/http_name_variable.go
@@ -27,7 +27,7 @@ import (
 
 var httpNameVariable = &lint.MethodRule{
 	Name:   lint.NewRuleName(136, "http-name-variable"),
-	OnlyIf: isCustomMethod,
+	OnlyIf: utils.IsCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		p := pluralize.NewClient()
 		for _, http := range utils.GetHTTPRules(m) {

--- a/rules/aip0136/http_parent_variable.go
+++ b/rules/aip0136/http_parent_variable.go
@@ -27,7 +27,7 @@ import (
 
 var httpParentVariable = &lint.MethodRule{
 	Name:   lint.NewRuleName(136, "http-parent-variable"),
-	OnlyIf: isCustomMethod,
+	OnlyIf: utils.IsCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		p := pluralize.NewClient()
 		for _, http := range utils.GetHTTPRules(m) {

--- a/rules/aip0136/http_uri_suffix.go
+++ b/rules/aip0136/http_uri_suffix.go
@@ -29,7 +29,7 @@ import (
 var uriSuffix = &lint.MethodRule{
 	Name: lint.NewRuleName(136, "http-uri-suffix"),
 	OnlyIf: func(m *desc.MethodDescriptor) bool {
-		return isCustomMethod(m) && httpNameVariable.LintMethod(m) == nil && httpParentVariable.LintMethod(m) == nil
+		return utils.IsCustomMethod(m) && httpNameVariable.LintMethod(m) == nil && httpParentVariable.LintMethod(m) == nil
 	},
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {

--- a/rules/aip0136/http_uri_suffix_test.go
+++ b/rules/aip0136/http_uri_suffix_test.go
@@ -39,14 +39,8 @@ func TestURISuffix(t *testing.T) {
 		{"ValidOneWord", "Translate", "/v3:translate", testutils.Problems{}},
 		{"ValidStdMethod", "GetBook", "/v1/{name=publishers/*/books/*}", testutils.Problems{}},
 		{"ValidTwoWordNoun", "WriteAudioBook", "/v1/{name=publishers/*/audioBooks/*}:write", testutils.Problems{}},
-		{"ValidListRevisions", "ListBookRevisions", "/v1/{name=publishers/*/books/*}:listRevisions", testutils.Problems{}},
-		{"ValidTagRevision", "TagBookRevision", "/v1/{name=publishers/*/books/*}:tagRevision", testutils.Problems{}},
-		{"ValidDeleteRevision", "DeleteBookRevision", "/v1/{name=publishers/*/books/*}:deleteRevision", testutils.Problems{}},
 		{"ValidCollection", "SortBooks", "/v1/{publisher=publishers/*}/books:sort", testutils.Problems{}},
 		{"ValidNoParent", "SearchBooks", "/v1/books:search", testutils.Problems{}},
-		{"InvalidListRevisions", "ListBookRevisions", "/v1/{name=publishers/*/books/*}:list", testutils.Problems{{Message: ":listRevisions"}}},
-		{"InvalidTagRevision", "TagBookRevision", "/v1/{name=publishers/*/books/*}:tag", testutils.Problems{{Message: ":tagRevision"}}},
-		{"InvalidDeleteRevision", "DeleteBookRevision", "/v1/{name=publishers/*/books/*}:delete", testutils.Problems{{Message: ":deleteRevision"}}},
 		{"IgnoredFailsVariables", "AddPages", "/v1/{name=publishers/*/books/*}:addPages", testutils.Problems{}},
 	}
 	for _, test := range tests {

--- a/rules/aip0136/request_message_name.go
+++ b/rules/aip0136/request_message_name.go
@@ -22,6 +22,6 @@ import (
 // Custom methods should have a properly named Request message.
 var requestMessageName = &lint.MethodRule{
 	Name:       lint.NewRuleName(136, "request-message-name"),
-	OnlyIf:     isCustomMethod,
+	OnlyIf:     utils.IsCustomMethod,
 	LintMethod: utils.LintMethodHasMatchingRequestName,
 }

--- a/rules/aip0136/response_message_name.go
+++ b/rules/aip0136/response_message_name.go
@@ -31,7 +31,7 @@ const responseMessageNameErrorMessage = "" +
 // with a Response suffix, or the resource being operated on.
 var responseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(136, "response-message-name"),
-	OnlyIf: isCustomMethod,
+	OnlyIf: utils.IsCustomMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// A response is considered valid if
 		// - The response name matches the RPC name with a `Response` suffix

--- a/rules/aip0136/response_message_name_test.go
+++ b/rules/aip0136/response_message_name_test.go
@@ -162,4 +162,41 @@ func TestResponseMessageName(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("Batch methods", func(t *testing.T) {
+		// Set up the testing permutations.
+		tests := []struct {
+			testName   string
+			MethodName string
+			problems   testutils.Problems
+		}{
+			{"BatchGet", "BatchGetBooks", testutils.Problems{}},
+			{"BatchUpdate", "BatchUpdateBooks", testutils.Problems{}},
+			{"BatchCreate", "BatchCreateBooks", testutils.Problems{}},
+			{"BatchDelete", "BatchDeleteBooks", testutils.Problems{}},
+		}
+
+		for _, test := range tests {
+			t.Run(test.testName, func(t *testing.T) {
+				// Batch methods are standard methods according to AIP-130, as such they should not
+				// be considered for this lint rule.  These tests are setting up request and response
+				// models that should fail this linter if it were to run
+				file := testutils.ParseProto3Tmpl(t, `
+				package test;
+
+				service Library {
+					rpc {{.MethodName}}(DummyRequest) returns (DummyResponse) {};
+				}
+
+				message DummyRequest {}
+				message DummyResponse {}
+				`, test)
+				method := file.GetServices()[0].GetMethods()[0]
+				problems := responseMessageName.Lint(file)
+				if diff := test.problems.SetDescriptor(method).Diff(problems); diff != "" {
+					t.Error(diff)
+				}
+			})
+		}
+	})
 }

--- a/rules/internal/utils/method.go
+++ b/rules/internal/utils/method.go
@@ -29,6 +29,7 @@ var (
 	deleteMethodRegexp               = regexp.MustCompile("^Delete(?:[A-Z]|$)")
 	deleteRevisionMethodRegexp       = regexp.MustCompile("^Delete[A-Za-z0-9]*Revision$")
 	legacyListRevisionsURINameRegexp = regexp.MustCompile(`:listRevisions$`)
+	standardMethodRegexp             = regexp.MustCompile("^(Batch(Get|Create|Update|Delete))|(Get|Create|Update|Delete|List)(?:[A-Z]|$)")
 )
 
 // IsCreateMethod returns true if this is a AIP-133 Create method.
@@ -113,4 +114,14 @@ func GetListResourceMessage(m *desc.MethodDescriptor) *desc.MessageDescriptor {
 // IsStreaming returns if the method is either client or server streaming.
 func IsStreaming(m *desc.MethodDescriptor) bool {
 	return m.IsClientStreaming() || m.IsServerStreaming()
+}
+
+// IsStandardMethod returns true if this is a AIP-130 Standard Method
+func IsStandardMethod(m *desc.MethodDescriptor) bool {
+	return standardMethodRegexp.MatchString(m.GetName())
+}
+
+// IsCustomMethod returns true if this is a AIP-130 Custom Method
+func IsCustomMethod(m *desc.MethodDescriptor) bool {
+	return !IsStandardMethod(m)
 }


### PR DESCRIPTION
There is a problem with the Response Message Name linter of AIP-136 currently.

For reference: https://github.com/googleapis/api-linter/blob/main/rules/aip0136/response_message_name.go

This, and all linter methods in aip0136 used a method `isCustomMethod`.  The logic of this method is incomplete/incorrect. It assumed anything with a `":"` in it's URI was considered a custom method.  But, according to https://google.aip.dev/130, Batch methods are also considered Standard methods.  Batch methods have the following URI segments: `:batchGet`, `:batchUpdate`, `:batchCreate` and `:batchDelete`.

What happens?

```proto
service Library {
  // This fails the aip0136 response_message_name lint rule
  rpc BatchDeleteBooks(BatchDeleteBooksRequest) returns (google.protobuf.Empty) {
    option (google.api.http) = {
      post: "/v1/{parent=publishers/*}/books:batchDelete"
      body: "*"
    };
  }
}
```