### PR TITLE
fix(AIP-123): skip resource-pattern-plural when there is no plural

### DIFF
--- a/rules/aip0123/resource_pattern_plural.go
+++ b/rules/aip0123/resource_pattern_plural.go
@@ -28,7 +28,7 @@ import (
 var resourcePatternPlural = &lint.MessageRule{
 	Name: lint.NewRuleName(123, "resource-pattern-plural"),
 	OnlyIf: func(m *desc.MessageDescriptor) bool {
-		return utils.IsResource(m) && len(utils.GetResource(m).GetPattern()) > 0 && !utils.IsSingletonResource(m)
+		return utils.IsResource(m) && len(utils.GetResource(m).GetPattern()) > 0 && utils.GetResourcePlural(utils.GetResource(m)) != "" && !utils.IsSingletonResource(m)
 	},
 	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
 		var problems []lint.Problem

--- a/rules/aip0123/resource_pattern_plural_test.go
+++ b/rules/aip0123/resource_pattern_plural_test.go
@@ -106,3 +106,23 @@ func TestResourcePatternPluralNested(t *testing.T) {
 		})
 	}
 }
+
+func TestResourcePatternPluralSkipNoPlural(t *testing.T) {
+	f := testutils.ParseProto3String(t, `
+		import "google/api/resource.proto";
+
+		message BookShelf {
+			option (google.api.resource) = {
+				type: "library.googleapis.com/BookShelf"
+				singular: "bookShelf"
+				plural: ""
+				pattern: "shelves/{shelf}/missingPlural/{book_shelf}"
+			};
+			string name = 1;
+		}
+	`)
+	findings := resourcePatternPlural.Lint(f)
+	if got, want := len(findings), 0; got != want {
+		t.Errorf("expected %d findings, got %d: %v", want, got, findings)
+	}
+}


### PR DESCRIPTION
When there is no `plural` field in the `google.api.resource`, skip check if the plural exists in the `pattern`(s).