### PR TITLE
fix(AIP-135): allow required etag in Delete

### DIFF
--- a/docs/rules/0135/request-required-fields.md
+++ b/docs/rules/0135/request-required-fields.md
@@ -19,6 +19,7 @@ This rule looks at any message matching `Delete*Request` and complains if it
 comes across any required fields other than:
 
 - `string name` ([AIP-135][])
+- `string etag` ([AIP-135][], [AIP-154][])
 
 ## Examples
 
@@ -62,4 +63,5 @@ If you need to violate this rule for an entire file, place the comment at the
 top of the file.
 
 [aip-135]: https://aip.dev/135
+[aip-154]: https://aip.dev/154
 [aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0135/request_required_fields.go
+++ b/rules/aip0135/request_required_fields.go
@@ -29,7 +29,9 @@ var requestRequiredFields = &lint.MessageRule{
 	OnlyIf: utils.IsDeleteRequestMessage,
 	LintMessage: func(m *desc.MessageDescriptor) (problems []lint.Problem) {
 		// Rule check: Establish that there are no unexpected fields.
-		allowedRequiredFields := stringset.New("name")
+		// * name: required by AIP-135
+		// * etag: optional or required by both AIP-135 and AIP-154
+		allowedRequiredFields := stringset.New("name", "etag")
 
 		for _, f := range m.GetFields() {
 			if !utils.GetFieldBehavior(f).Contains("REQUIRED") {

--- a/rules/aip0135/request_required_fields_test.go
+++ b/rules/aip0135/request_required_fields_test.go
@@ -35,6 +35,12 @@ func TestRequiredFieldTests(t *testing.T) {
 			nil,
 		},
 		{
+			"ValidRequiredEtag",
+			"string etag = 2 [(google.api.field_behavior) = OPTIONAL];",
+			"etag",
+			nil,
+		},
+		{
 			"ValidOptionalAllowMissing",
 			"bool allow_missing = 2 [(google.api.field_behavior) = OPTIONAL];",
 			"allow_missing",


### PR DESCRIPTION
Allow Standard Field `etag` to be `REQUIRED` in Standard Delete.

Updates #1395