### PR TITLE
fix(AIP-123): multiword singleton reduction

### DIFF
--- a/rules/aip0123/resource_pattern_singular.go
+++ b/rules/aip0123/resource_pattern_singular.go
@@ -46,6 +46,11 @@ var resourcePatternSingular = &lint.MessageRule{
 		if !utils.IsSingletonResource(m) {
 			singular = fmt.Sprintf("{%s}", strcase.SnakeCase(singular))
 			nn = fmt.Sprintf("{%s}", nn)
+		} else {
+			// singular is already in lower camel case
+			// but nested name is returned in snake_case form
+			// and final segment of singleton is lowerCamelCase
+			nn = strcase.LowerCamelCase(nn)
 		}
 
 		// If the first pattern is reduced or non-compliant, but is nested name eligible, we want to recommend the nested name.


### PR DESCRIPTION
There was a bug in `resource-pattern-singular` for the multi-word nested name reduction singleton case caused by not converting the `snake_case` value from the `nestedName` helper into `lowerCamelCase` - it was comparing a lowerCamelCase pattern suffix against a snake_case expected value.

Added a bunch more tests specifically using a type name with more than two words for extended matching.

Internal bug report: http://b/359848757