### PR TITLE
fix(AIP-132): refine List request response regex

### DIFF
--- a/rules/internal/utils/message.go
+++ b/rules/internal/utils/message.go
@@ -23,10 +23,10 @@ import (
 
 var (
 	getReqMessageRegexp            = regexp.MustCompile("^Get[A-Za-z0-9]*Request$")
-	listReqMessageRegexp           = regexp.MustCompile("^List[A-Za-z0-9]*Request$")
-	listRespMessageRegexp          = regexp.MustCompile("^List([A-Za-z0-9]*)Response$")
-	listRevisionsReqMessageRegexp  = regexp.MustCompile(`^List(?:[A-Za-z0-9]+)RevisionsRequest$`)
-	listRevisionsRespMessageRegexp = regexp.MustCompile(`^List(?:[A-Za-z0-9]+)RevisionsResponse$`)
+	listReqMessageRegexp           = regexp.MustCompile("^List[A-Z]+[A-Za-z0-9]*Request$")
+	listRespMessageRegexp          = regexp.MustCompile("^List([A-Z]+[A-Za-z0-9]*)Response$")
+	listRevisionsReqMessageRegexp  = regexp.MustCompile(`^List(?:[A-Z]+[A-Za-z0-9]+)RevisionsRequest$`)
+	listRevisionsRespMessageRegexp = regexp.MustCompile(`^List(?:[A-Z]+[A-Za-z0-9]+)RevisionsResponse$`)
 	createReqMessageRegexp         = regexp.MustCompile("^Create[A-Za-z0-9]*Request$")
 	updateReqMessageRegexp         = regexp.MustCompile("^Update[A-Za-z0-9]*Request$")
 	deleteReqMessageRegexp         = regexp.MustCompile("^Delete[A-Za-z0-9]*Request$")

--- a/rules/internal/utils/message_test.go
+++ b/rules/internal/utils/message_test.go
@@ -44,3 +44,159 @@ func TestListResponseResourceName(t *testing.T) {
 		})
 	}
 }
+
+func TestIsListResponseMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid list response",
+			RPC:  "ListBooks",
+			want: true,
+		},
+		{
+			name: "not list response",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike response",
+			RPC:  "Listen",
+			want: false,
+		},
+		{
+			name: "multiword lookalike response",
+			RPC:  "ListenForever",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Response {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsListResponseMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsListRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid list request",
+			RPC:  "ListBooks",
+			want: true,
+		},
+		{
+			name: "not list request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Listen",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "ListenForever",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Request {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsListRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsListRevisionsResponseMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid list revisions response",
+			RPC:  "ListBook",
+			want: true,
+		},
+		{
+			name: "not list revisions response",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike response",
+			RPC:  "Listen",
+			want: false,
+		},
+		{
+			name: "multiword lookalike response",
+			RPC:  "ListenForever",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}RevisionsResponse {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsListRevisionsResponseMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsListRevisionsRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid list revisions request",
+			RPC:  "ListBook",
+			want: true,
+		},
+		{
+			name: "not list revisions request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Listen",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "ListenForever",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}RevisionsRequest {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsListRevisionsRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Updates all `List` request/response regular expressions to expect a capital letter following `"List"` so as to avoid capturing verbs that start with `"List"`, but which are not `List`, like `"Listen"`.

This is a reasonable refinement to make because all standard Lists are `List{PluralNoun}` so we get `List{PluralNoun}Request` and `List{PluralNoun}Response`. 

Updates #922