### PR TITLE
fix(internal/utils): refine Get, Create, Update, Delete request regex

### DIFF
--- a/rules/internal/utils/message.go
+++ b/rules/internal/utils/message.go
@@ -22,14 +22,14 @@ import (
 )
 
 var (
-	getReqMessageRegexp            = regexp.MustCompile("^Get[A-Za-z0-9]*Request$")
+	getReqMessageRegexp            = regexp.MustCompile("^Get[A-Z]+[A-Za-z0-9]*Request$")
 	listReqMessageRegexp           = regexp.MustCompile("^List[A-Z]+[A-Za-z0-9]*Request$")
 	listRespMessageRegexp          = regexp.MustCompile("^List([A-Z]+[A-Za-z0-9]*)Response$")
 	listRevisionsReqMessageRegexp  = regexp.MustCompile(`^List(?:[A-Z]+[A-Za-z0-9]+)RevisionsRequest$`)
 	listRevisionsRespMessageRegexp = regexp.MustCompile(`^List(?:[A-Z]+[A-Za-z0-9]+)RevisionsResponse$`)
-	createReqMessageRegexp         = regexp.MustCompile("^Create[A-Za-z0-9]*Request$")
-	updateReqMessageRegexp         = regexp.MustCompile("^Update[A-Za-z0-9]*Request$")
-	deleteReqMessageRegexp         = regexp.MustCompile("^Delete[A-Za-z0-9]*Request$")
+	createReqMessageRegexp         = regexp.MustCompile("^Create[A-Z]+[A-Za-z0-9]*Request$")
+	updateReqMessageRegexp         = regexp.MustCompile("^Update[A-Z]+[A-Za-z0-9]*Request$")
+	deleteReqMessageRegexp         = regexp.MustCompile("^Delete[A-Z]+[A-Za-z0-9]*Request$")
 )
 
 // Returns true if this is an AIP-131 Get request message, false otherwise.

--- a/rules/internal/utils/message_test.go
+++ b/rules/internal/utils/message_test.go
@@ -200,3 +200,159 @@ func TestIsListRevisionsRequestMessage(t *testing.T) {
 		})
 	}
 }
+
+func TestIsGetRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid get request",
+			RPC:  "GetBook",
+			want: true,
+		},
+		{
+			name: "not get request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Getup",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "GetupFinder",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Request {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsGetRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsCreateRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid create request",
+			RPC:  "CreateBook",
+			want: true,
+		},
+		{
+			name: "not create request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Created",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "CreatedBook",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Request {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsCreateRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsUpdateRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid update request",
+			RPC:  "UpdateBook",
+			want: true,
+		},
+		{
+			name: "not update request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Updater",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "UpdaterAndCreator",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Request {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsUpdateRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestIsDeleteRequestMessage(t *testing.T) {
+	for _, test := range []struct {
+		name string
+		RPC  string
+		want bool
+	}{
+		{
+			name: "valid delete request",
+			RPC:  "DeleteBook",
+			want: true,
+		},
+		{
+			name: "not delete request",
+			RPC:  "ArchiveBook",
+			want: false,
+		},
+		{
+			name: "lookalike request",
+			RPC:  "Deleter",
+			want: false,
+		},
+		{
+			name: "multiword lookalike request",
+			RPC:  "DeleterAndPurge",
+			want: false,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				message {{.RPC}}Request {}
+			`, test)
+			m := file.GetMessageTypes()[0]
+			if got, want := IsDeleteRequestMessage(m), test.want; got != want {
+				t.Errorf("got %v, want %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Similar to #1420 we need to refine the standard request message regexes.

The examples are a bit contrived, but better to have the refinement than not!