### PR TITLE
fix(AIP-136): ignore revision methods

### DIFF
--- a/rules/aip0136/response_message_name_test.go
+++ b/rules/aip0136/response_message_name_test.go
@@ -31,6 +31,7 @@ func TestResponseMessageName(t *testing.T) {
 		}{
 			{"Valid", "ArchiveBook", "ArchiveBookResponse", testutils.Problems{}},
 			{"Invalid", "ArchiveBook", "ArchiveBookResp", testutils.Problems{{Message: "not \"ArchiveBookResp\"."}}},
+			{"SkipRevisionMethod", "CommitBook", "Book", testutils.Problems{}},
 		}
 
 		for _, test := range tests {

--- a/rules/aip0162/aip0162.go
+++ b/rules/aip0162/aip0162.go
@@ -68,15 +68,9 @@ func AddRules(r lint.RuleRegistry) error {
 }
 
 var (
-	tagRevisionMethodRegexp     = regexp.MustCompile(`^Tag([A-Za-z0-9]+)Revision$`)
 	tagRevisionReqMessageRegexp = regexp.MustCompile(`^Tag(?:[A-Za-z0-9]+)RevisionRequest$`)
 	tagRevisionURINameRegexp    = regexp.MustCompile(`:tagRevision$`)
 )
-
-// Returns true if this is an AIP-162 Tag Revision method, false otherwise.
-func isTagRevisionMethod(m *desc.MethodDescriptor) bool {
-	return tagRevisionMethodRegexp.MatchString(m.GetName())
-}
 
 // Returns true if this is an AIP-162 Tag Revision request message, false otherwise.
 func isTagRevisionRequestMessage(m *desc.MessageDescriptor) bool {
@@ -84,15 +78,9 @@ func isTagRevisionRequestMessage(m *desc.MessageDescriptor) bool {
 }
 
 var (
-	commitMethodRegexp     = regexp.MustCompile(`^Commit([A-Za-z0-9]+)$`)
 	commitReqMessageRegexp = regexp.MustCompile(`^Commit(?:[A-Za-z0-9]+)Request$`)
 	commitURINameRegexp    = regexp.MustCompile(`:commit$`)
 )
-
-// Returns true if this is an AIP-162 Commit method, false otherwise.
-func isCommitMethod(m *desc.MethodDescriptor) bool {
-	return commitMethodRegexp.MatchString(m.GetName())
-}
 
 // Returns true if this is an AIP-162 Commit request message, false otherwise.
 func isCommitRequestMessage(m *desc.MessageDescriptor) bool {
@@ -100,15 +88,9 @@ func isCommitRequestMessage(m *desc.MessageDescriptor) bool {
 }
 
 var (
-	rollbackMethodRegexp     = regexp.MustCompile(`^Rollback([A-Za-z0-9]+)$`)
 	rollbackReqMessageRegexp = regexp.MustCompile(`^Rollback(?:[A-Za-z0-9]+)Request$`)
 	rollbackURINameRegexp    = regexp.MustCompile(`:rollback$`)
 )
-
-// Returns true if this is an AIP-162 Rollback method, false otherwise.
-func isRollbackMethod(m *desc.MethodDescriptor) bool {
-	return rollbackMethodRegexp.MatchString(m.GetName())
-}
 
 // Returns true if this is an AIP-162 Rollback request message, false otherwise.
 func isRollbackRequestMessage(m *desc.MessageDescriptor) bool {
@@ -116,15 +98,9 @@ func isRollbackRequestMessage(m *desc.MessageDescriptor) bool {
 }
 
 var (
-	deleteRevisionMethodRegexp     = regexp.MustCompile(`^Delete(?:[A-Za-z0-9]+)Revision$`)
 	deleteRevisionReqMessageRegexp = regexp.MustCompile(`^Delete(?:[A-Za-z0-9]+)RevisionRequest$`)
 	deleteRevisionURINameRegexp    = regexp.MustCompile(`:deleteRevision$`)
 )
-
-// Returns true if this is an AIP-162 Delete Revision method, false otherwise.
-func isDeleteRevisionMethod(m *desc.MethodDescriptor) bool {
-	return deleteRevisionMethodRegexp.MatchString(m.GetName())
-}
 
 // Returns true if this is an AIP-162 Delete Revision request message, false otherwise.
 func isDeleteRevisionRequestMessage(m *desc.MessageDescriptor) bool {

--- a/rules/aip0162/commit_http_body.go
+++ b/rules/aip0162/commit_http_body.go
@@ -22,6 +22,6 @@ import (
 // Commit methods should have "*" as the HTTP body.
 var commitHTTPBody = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "commit-http-body"),
-	OnlyIf:     isCommitMethod,
+	OnlyIf:     utils.IsCommitRevisionMethod,
 	LintMethod: utils.LintWildcardHTTPBody,
 }

--- a/rules/aip0162/commit_http_method.go
+++ b/rules/aip0162/commit_http_method.go
@@ -22,6 +22,6 @@ import (
 // Commit methods should use the HTTP POST method.
 var commitHTTPMethod = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "commit-http-method"),
-	OnlyIf:     isCommitMethod,
+	OnlyIf:     utils.IsCommitRevisionMethod,
 	LintMethod: utils.LintHTTPMethod("POST"),
 }

--- a/rules/aip0162/commit_http_uri_suffix.go
+++ b/rules/aip0162/commit_http_uri_suffix.go
@@ -24,7 +24,7 @@ import (
 // Commit methods should have a proper HTTP pattern.
 var commitHTTPURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "commit-http-uri-suffix"),
-	OnlyIf: isCommitMethod,
+	OnlyIf: utils.IsCommitRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			if !commitURINameRegexp.MatchString(httpRule.URI) {

--- a/rules/aip0162/commit_request_message_name.go
+++ b/rules/aip0162/commit_request_message_name.go
@@ -22,6 +22,6 @@ import (
 // Commit messages should have a properly named request message.
 var commitRequestMessageName = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "commit-request-message-name"),
-	OnlyIf:     isCommitMethod,
+	OnlyIf:     utils.IsCommitRevisionMethod,
 	LintMethod: utils.LintMethodHasMatchingRequestName,
 }

--- a/rules/aip0162/commit_response_message_name.go
+++ b/rules/aip0162/commit_response_message_name.go
@@ -19,16 +19,20 @@ import (
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
 var commitResponseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "commit-response-message-name"),
-	OnlyIf: isCommitMethod,
+	OnlyIf: utils.IsCommitRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that for methods such as `CommitBook`, the response
 		// message is `Book`.
-		want := commitMethodRegexp.FindStringSubmatch(m.GetName())[1]
+		want, ok := utils.ExtractRevisionResource(m)
+		if !ok {
+			return nil
+		}
 		got := m.GetOutputType().GetName()
 
 		// Return a problem if we did not get the expected return name.

--- a/rules/aip0162/delete_revision_http_body.go
+++ b/rules/aip0162/delete_revision_http_body.go
@@ -22,6 +22,6 @@ import (
 // Delete Revision methods should have no HTTP body.
 var deleteRevisionHTTPBody = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "delete-revision-http-body"),
-	OnlyIf:     isDeleteRevisionMethod,
+	OnlyIf:     utils.IsDeleteRevisionMethod,
 	LintMethod: utils.LintNoHTTPBody,
 }

--- a/rules/aip0162/delete_revision_http_method.go
+++ b/rules/aip0162/delete_revision_http_method.go
@@ -22,6 +22,6 @@ import (
 // Delete Revision methods should use the HTTP DELETE method.
 var deleteRevisionHTTPMethod = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "delete-revision-http-method"),
-	OnlyIf:     isDeleteRevisionMethod,
+	OnlyIf:     utils.IsDeleteRevisionMethod,
 	LintMethod: utils.LintHTTPMethod("DELETE"),
 }

--- a/rules/aip0162/delete_revision_http_uri_suffix.go
+++ b/rules/aip0162/delete_revision_http_uri_suffix.go
@@ -24,7 +24,7 @@ import (
 // Delete Revision methods should have a proper HTTP pattern.
 var deleteRevisionHTTPURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "delete-revision-http-uri-suffix"),
-	OnlyIf: isDeleteRevisionMethod,
+	OnlyIf: utils.IsDeleteRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			if !deleteRevisionURINameRegexp.MatchString(httpRule.URI) {

--- a/rules/aip0162/delete_revision_request_message_name.go
+++ b/rules/aip0162/delete_revision_request_message_name.go
@@ -22,6 +22,6 @@ import (
 // Delete Revision messages should have a properly named request message.
 var deleteRevisionRequestMessageName = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "delete-revision-request-message-name"),
-	OnlyIf:     isDeleteRevisionMethod,
+	OnlyIf:     utils.IsDeleteRevisionMethod,
 	LintMethod: utils.LintMethodHasMatchingRequestName,
 }

--- a/rules/aip0162/delete_revision_response_message_name.go
+++ b/rules/aip0162/delete_revision_response_message_name.go
@@ -16,20 +16,23 @@ package aip0162
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
 // Delete Revision methods should return the resource itself.
 var deleteRevisionResponseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "delete-revision-response-message-name"),
-	OnlyIf: isDeleteRevisionMethod,
+	OnlyIf: utils.IsDeleteRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		got := m.GetOutputType().GetName()
-		want := strings.TrimPrefix(strings.TrimSuffix(m.GetName(), "Revision"), "Delete")
+		want, ok := utils.ExtractRevisionResource(m)
+		if !ok {
+			return nil
+		}
 		if got != want {
 			return []lint.Problem{{
 				Message:    fmt.Sprintf("Delete Revision methods should return the resource itself (`%s`), not `%s`.", want, got),

--- a/rules/aip0162/rollback_http_body.go
+++ b/rules/aip0162/rollback_http_body.go
@@ -22,6 +22,6 @@ import (
 // Rollback methods should have "*" as the HTTP body.
 var rollbackHTTPBody = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "rollback-http-body"),
-	OnlyIf:     isRollbackMethod,
+	OnlyIf:     utils.IsRollbackRevisionMethod,
 	LintMethod: utils.LintWildcardHTTPBody,
 }

--- a/rules/aip0162/rollback_http_method.go
+++ b/rules/aip0162/rollback_http_method.go
@@ -22,6 +22,6 @@ import (
 // Rollback methods should use the HTTP POST method.
 var rollbackHTTPMethod = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "rollback-http-method"),
-	OnlyIf:     isRollbackMethod,
+	OnlyIf:     utils.IsRollbackRevisionMethod,
 	LintMethod: utils.LintHTTPMethod("POST"),
 }

--- a/rules/aip0162/rollback_http_uri_suffix.go
+++ b/rules/aip0162/rollback_http_uri_suffix.go
@@ -24,7 +24,7 @@ import (
 // Rollback methods should have a proper HTTP pattern.
 var rollbackHTTPURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "rollback-http-uri-suffix"),
-	OnlyIf: isRollbackMethod,
+	OnlyIf: utils.IsRollbackRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			if !rollbackURINameRegexp.MatchString(httpRule.URI) {

--- a/rules/aip0162/rollback_request_message_name.go
+++ b/rules/aip0162/rollback_request_message_name.go
@@ -22,6 +22,6 @@ import (
 // Rollback messages should have a properly named request message.
 var rollbackRequestMessageName = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "rollback-request-message-name"),
-	OnlyIf:     isRollbackMethod,
+	OnlyIf:     utils.IsRollbackRevisionMethod,
 	LintMethod: utils.LintMethodHasMatchingRequestName,
 }

--- a/rules/aip0162/rollback_response_message_name.go
+++ b/rules/aip0162/rollback_response_message_name.go
@@ -26,11 +26,14 @@ import (
 
 var rollbackResponseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "rollback-response-message-name"),
-	OnlyIf: isRollbackMethod,
+	OnlyIf: utils.IsRollbackRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that for methods such as `RollbackBook`, the response
 		// message is `Book`.
-		want := rollbackMethodRegexp.FindStringSubmatch(m.GetName())[1]
+		want, ok := utils.ExtractRevisionResource(m)
+		if !ok {
+			return nil
+		}
 		got := m.GetOutputType().GetName()
 		loc := locations.MethodResponseType(m)
 

--- a/rules/aip0162/tag_revision_http_body.go
+++ b/rules/aip0162/tag_revision_http_body.go
@@ -22,6 +22,6 @@ import (
 // Tag Revision methods should have "*" as the HTTP body.
 var tagRevisionHTTPBody = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "tag-revision-http-body"),
-	OnlyIf:     isTagRevisionMethod,
+	OnlyIf:     utils.IsTagRevisionMethod,
 	LintMethod: utils.LintWildcardHTTPBody,
 }

--- a/rules/aip0162/tag_revision_http_method.go
+++ b/rules/aip0162/tag_revision_http_method.go
@@ -22,6 +22,6 @@ import (
 // Tag Revision methods should use the HTTP POST method.
 var tagRevisionHTTPMethod = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "tag-revision-http-method"),
-	OnlyIf:     isTagRevisionMethod,
+	OnlyIf:     utils.IsTagRevisionMethod,
 	LintMethod: utils.LintHTTPMethod("POST"),
 }

--- a/rules/aip0162/tag_revision_http_uri_suffix.go
+++ b/rules/aip0162/tag_revision_http_uri_suffix.go
@@ -24,7 +24,7 @@ import (
 // Tag Revision methods should have a proper HTTP pattern.
 var tagRevisionHTTPURISuffix = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "tag-revision-http-uri-suffix"),
-	OnlyIf: isTagRevisionMethod,
+	OnlyIf: utils.IsTagRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		for _, httpRule := range utils.GetHTTPRules(m) {
 			if !tagRevisionURINameRegexp.MatchString(httpRule.URI) {

--- a/rules/aip0162/tag_revision_request_message_name.go
+++ b/rules/aip0162/tag_revision_request_message_name.go
@@ -22,6 +22,6 @@ import (
 // Tag Revision messages should have a properly named request message.
 var tagRevisionRequestMessageName = &lint.MethodRule{
 	Name:       lint.NewRuleName(162, "tag-revision-request-message-name"),
-	OnlyIf:     isTagRevisionMethod,
+	OnlyIf:     utils.IsTagRevisionMethod,
 	LintMethod: utils.LintMethodHasMatchingRequestName,
 }

--- a/rules/aip0162/tag_revision_response_message_name.go
+++ b/rules/aip0162/tag_revision_response_message_name.go
@@ -19,16 +19,20 @@ import (
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
 	"github.com/jhump/protoreflect/desc"
 )
 
 var tagRevisionResponseMessageName = &lint.MethodRule{
 	Name:   lint.NewRuleName(162, "tag-revision-response-message-name"),
-	OnlyIf: isTagRevisionMethod,
+	OnlyIf: utils.IsTagRevisionMethod,
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		// Rule check: Establish that for methods such as `TagBookRevision`, the response
 		// message is `Book`.
-		want := tagRevisionMethodRegexp.FindStringSubmatch(m.GetName())[1]
+		want, ok := utils.ExtractRevisionResource(m)
+		if !ok {
+			return nil
+		}
 		got := m.GetOutputType().GetName()
 
 		// Return a problem if we did not get the expected return name.


### PR DESCRIPTION
This ensures that the `IsCustomMethod` check ignores the "standard" AIP-162 Revision RPCs - these shouldn't be linted as custom methods generally, they have their own rules defined by AIP-162.

Also refactors all of the revision method regexes and capturing logic into the (internal) utilities package.

Internal bug http://b/367697721