### PR TITLE
fix(AIP-133): use resource field in signature suggestion

### DIFF
--- a/rules/aip0133/method_signature_test.go
+++ b/rules/aip0133/method_signature_test.go
@@ -126,7 +126,7 @@ func TestMethodSignature(t *testing.T) {
 				rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
 					option (google.api.method_signature) = "book,book_id";
 					option (google.longrunning.operation_info) = {
-					    response_type: "Book"
+						response_type: "Book"
 						metadata_type: "Book"
 					};
 				}
@@ -146,8 +146,8 @@ func TestMethodSignature(t *testing.T) {
 			t.Errorf(diff)
 		}
 	})
-	// Add a separate test for the LRO case rather than introducing yet
-	// another knob on the above test.
+	// Add a separate test for the non-standard resource field case rather than
+	// introducing yet another knob on the above test.
 	t.Run("NonStandardResourceFieldName", func(t *testing.T) {
 		file := testutils.ParseProto3String(t, `
 			import "google/api/client.proto";

--- a/rules/aip0133/method_signature_test.go
+++ b/rules/aip0133/method_signature_test.go
@@ -78,7 +78,7 @@ func TestMethodSignature(t *testing.T) {
 				message Book {
 				  option (google.api.resource) = {
 				    type: "library.googleapis.com/Book"
-					pattern: "libraries/{library}/books/{book}"
+					  pattern: "libraries/{library}/books/{book}"
 				  };
 				}
 			`, test)

--- a/rules/aip0133/method_signature_test.go
+++ b/rules/aip0133/method_signature_test.go
@@ -157,7 +157,7 @@ func TestMethodSignature(t *testing.T) {
 				rpc CreateBook(CreateBookRequest) returns (google.longrunning.Operation) {
 					option (google.api.method_signature) = "book,book_id";
 					option (google.longrunning.operation_info) = {
-					    response_type: "Book"
+						response_type: "Book"
 						metadata_type: "Book"
 					};
 				}


### PR DESCRIPTION
Fix the way that the expected resource field name is derived for Standard Create method_signatures. When the resource field in the request message uses a name that doesn't exactly mirror the resource type/RPC name, the previous logic suggested a method_signature including a field that didn't exist. Since this rule isn't supposed to also govern the field's name itself, just roll with it.

Also fixes the way the output type is evaluated for the resource parent/no-parent case when the response type is an Operation.

Moves the LRO test to its own case.

Addresses internal feedback http://b/372508475