### PR TITLE
chore(renovate): update Go runtime version

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -18,7 +18,7 @@
   ],
   force: {
     constraints: {
-      go: "1.20"
+      go: "1.21"
     }
   }
 }


### PR DESCRIPTION
Should've been updated when our `go.mod` was updated.