### PR TITLE
chore(lint): update staticcheck version, disable its go install

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,9 +21,10 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: staticcheck
-        uses: dominikh/staticcheck-action@v1.3.0
+        uses: dominikh/staticcheck-action@v1.3.1
         with:
           version: "2022.1.1"
+          install-go: false
   quality-checker:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2022.1.1"
+          version: "2023.1"
           install-go: false
   quality-checker:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Simple update to latest patch version, but also disable Staticcheck installing its own Go binary, which is unnecessary because our workflow already install Go based on our `go.mod` file.