### PR TITLE
feat(AIP-123): resource type name matches message

### DIFF
--- a/docs/rules/0123/resource-type-message.md
+++ b/docs/rules/0123/resource-type-message.md
@@ -1,0 +1,74 @@
+---
+rule:
+  aip: 123
+  name: [core, '0123', resource-type-message]
+  summary: Resource type names must match containing message name.
+permalink: /123/resource-type-message
+redirect_from:
+  - /0123/resource-type-message
+---
+
+# Resource type name
+
+This rule enforces that messages that have a `google.api.resource` annotation,
+have a `type` aligned with the schema, as described in [AIP-123][].
+
+## Details
+
+This rule scans messages with a `google.api.resource` annotation, and validates
+that the `{Type}` portion of the `{Service Name}/{Type}` `type` field matches
+the containing message name.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+message Book {
+  option (google.api.resource) = {
+    // Should match containing message name 'Book'.
+    type: "library.googleapis.com/Literature"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  string name = 1;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Book"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  string name = 1;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the message.
+
+```proto
+// (-- api-linter: core::0123::resource-type-message=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+message Book {
+  option (google.api.resource) = {
+    type: "library.googleapis.com/Literature"
+    pattern: "publishers/{publisher}/books/{book}"
+  };
+
+  string name = 1;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-123]: http://aip.dev/123
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0123/aip0123.go
+++ b/rules/aip0123/aip0123.go
@@ -40,6 +40,7 @@ func AddRules(r lint.RuleRegistry) error {
 		resourcePlural,
 		resourceReferenceType,
 		resourceSingular,
+		resourceTypeMessage,
 		resourceTypeName,
 		resourceVariables,
 		resourceDefinitionVariables,

--- a/rules/aip0123/resource_type_message.go
+++ b/rules/aip0123/resource_type_message.go
@@ -1,0 +1,45 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+var resourceTypeMessage = &lint.MessageRule{
+	Name:   lint.NewRuleName(123, "resource-type-message"),
+	OnlyIf: utils.IsResource,
+	LintMessage: func(m *desc.MessageDescriptor) []lint.Problem {
+		n := m.GetName()
+		typ := utils.GetResource(m).GetType()
+		typ = typ[strings.LastIndex(typ, "/")+1:]
+
+		if typ != n {
+			return []lint.Problem{{
+				Message:    fmt.Sprintf("Resource type name %q should match containing message name %q", typ, n),
+				Descriptor: m,
+				Location:   locations.MessageResource(m),
+			}}
+		}
+
+		return nil
+	},
+}

--- a/rules/aip0123/resource_type_message_test.go
+++ b/rules/aip0123/resource_type_message_test.go
@@ -1,0 +1,56 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0123
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestResourceTypeMessage(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		TypeName string
+		problems testutils.Problems
+	}{
+		{
+			name:     "Valid",
+			TypeName: "Book",
+		},
+		{
+			name:     "Invalid",
+			TypeName: "Shelf",
+			problems: testutils.Problems{{Message: "should match containing message name"}},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			f := testutils.ParseProto3Tmpl(t, `
+			import "google/api/resource.proto";
+			message Book {
+				option (google.api.resource) = {
+					type: "library.googleapis.com/{{ .TypeName }}"
+					pattern: "publishers/{publisher}/books/{book}"
+				};
+				string name = 1;
+			}
+		`, test)
+			m := f.GetMessageTypes()[0]
+			if diff := test.problems.SetDescriptor(m).Diff(resourceTypeMessage.Lint(f)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Enforce AIP-123 guidance that the resource type name should match the containing proto message name.

Addresses internal bug: http://b/384544409