### PR TITLE
fix(AIP-126): Allow prefixed UNKNOWN value

### DIFF
--- a/rules/aip0126/unspecified.go
+++ b/rules/aip0126/unspecified.go
@@ -30,8 +30,9 @@ var unspecified = &lint.EnumRule{
 	Name: lint.NewRuleName(126, "unspecified"),
 	LintEnum: func(e *desc.EnumDescriptor) []lint.Problem {
 		name := endNum.ReplaceAllString(e.GetName(), "${1}_${2}")
-		unspec := strings.ToUpper(strcase.SnakeCase(name) + "_UNSPECIFIED")
-		allowed := stringset.New(unspec, "UNKNOWN")
+		sn := strings.ToUpper(strcase.SnakeCase(name))
+		unspec := sn + "_UNSPECIFIED"
+		allowed := stringset.New(unspec, "UNKNOWN", sn+"_UNKNOWN")
 		for _, element := range e.GetValues() {
 			if allowed.Contains(element.GetName()) && element.GetNumber() == 0 {
 				return nil

--- a/rules/aip0126/unspecified_test.go
+++ b/rules/aip0126/unspecified_test.go
@@ -30,8 +30,9 @@ func TestUnspecified(t *testing.T) {
 		{"Valid", "BookFormat", "BOOK_FORMAT_UNSPECIFIED", testutils.Problems{}},
 		{"ValidWithNum", "Ipv6Format", "IPV6_FORMAT_UNSPECIFIED", nil},
 		{"ValidUnknown", "BookFormat", "UNKNOWN", nil},
+		{"ValidPrefixedUnknown", "BookFormat", "BOOK_FORMAT_UNKNOWN", nil},
 		{"InvalidNoPrefix", "BookFormat", "UNSPECIFIED", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
-		{"InvalidWrongSuffix", "BookFormat", "BOOK_FORMAT_UNKNOWN", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
+		{"InvalidWrongSuffix", "BookFormat", "BOOK_FORMAT_NOT_SET", testutils.Problems{{Suggestion: "BOOK_FORMAT_UNSPECIFIED"}}},
 		{"InvalidWithNum", "Ipv6Format", "IPV6FORMAT_UNSPECIFIED", testutils.Problems{{Suggestion: "IPV6_FORMAT_UNSPECIFIED"}}},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
AIP-126 has guidance on prefixing enum values to avoid collisions. This should also apply to the `UNKNOWN` affordance, so that APIs may use `UNKNOWN` in a collision-safe way.

Internal bug http://b/389683192