### PR TITLE
chore(AIP-123): clean up extraneous package comments

### DIFF
--- a/rules/aip0123/resource_pattern_plural.go
+++ b/rules/aip0123/resource_pattern_plural.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0123 contains rules defined in https://aip.dev/123.
 package aip0123
 
 import (

--- a/rules/aip0123/resource_pattern_singular.go
+++ b/rules/aip0123/resource_pattern_singular.go
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0123 contains rules defined in https://aip.dev/123.
 package aip0123
 
 import (


### PR DESCRIPTION
The package comment is defined in `aip0123.go`.