### PR TITLE
chore(ci): give release workflow contents.write perm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     types:
       - created
 
+permissions:
+  contents: write
+
 env:
   # e.g. v1.0.0
   TAG_NAME: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Need to explicitly give our release workflow write permissions so that it can upload release assets.