### PR TITLE
fix(cli): exclude cwd from input path resolution

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -94,7 +94,7 @@ func newCli(args []string) *cli {
 		FormatType:                fmtFlag,
 		OutputPath:                outFlag,
 		ExitStatusOnLintFailure:   setExitStatusOnLintFailure,
-		ProtoImportPaths:          append(protoImportFlag, "."),
+		ProtoImportPaths:          protoImportFlag,
 		ProtoDescPath:             protoDescFlag,
 		EnabledRules:              ruleEnableFlag,
 		DisabledRules:             ruleDisableFlag,
@@ -152,7 +152,7 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 	var lock sync.Mutex
 	// Parse proto files into `protoreflect` file descriptors.
 	p := protoparse.Parser{
-		ImportPaths:           c.ProtoImportPaths,
+		ImportPaths:           append(c.ProtoImportPaths, "."),
 		IncludeSourceCodeInfo: true,
 		LookupImport:          lookupImport,
 		ErrorReporter: func(errorWithPos protoparse.ErrorWithPos) error {

--- a/cmd/api-linter/cli_test.go
+++ b/cmd/api-linter/cli_test.go
@@ -30,7 +30,7 @@ func TestNewCli(t *testing.T) {
 				OutputPath:       "out",
 				FormatType:       "json",
 				ProtoDescPath:    []string{"proto_desc1", "proto_desc2"},
-				ProtoImportPaths: []string{"proto_path_a", "proto_path_b", "."},
+				ProtoImportPaths: []string{"proto_path_a", "proto_path_b"},
 				ProtoFiles:       []string{"a.proto", "b.proto"},
 			},
 		},
@@ -41,7 +41,6 @@ func TestNewCli(t *testing.T) {
 			},
 			wantCli: &cli{
 				ExitStatusOnLintFailure: true,
-				ProtoImportPaths:        []string{"."},
 				ProtoFiles:              []string{},
 			},
 		},


### PR DESCRIPTION
Exclude `"."` from `c.ProtoImportPaths` and append only when building the `protoparse.Parser`. The `"."` was interfering with filename resolution of `protoparse.ResolveFilenames` by preventing cwd relative input protos from being resolved against the cwd-relative import path value. As per the [docs](https://pkg.go.dev/github.com/jhump/protoreflect@v1.16.0/desc/protoparse#ResolveFilenames):
> If a file name is already relative to one of the given import paths, it will be unchanged in the returned slice

By having `"."` present in the import paths during filename resolution, any relative path provided was considered "relative to one of the give import paths" and the user-provided import path(s) that prefix the proto-to-lint filenames are not resolved.

This meant that the protos parsed with unresolved filenames and those imported, if the overlapping, would produce a "already defined" error during descriptor compilation.

Discussion/debugging discussed in relevant issue.

Updates #1465 