### PR TITLE
feat(AIP-215): augment foreign type checking

### DIFF
--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -3,9 +3,9 @@ rule:
   aip: 215
   name: [core, '0215', foreign-type-reference]
   summary: API-specific protos should be in versioned packages.
-permalink: /215/versioned-packages
+permalink: /215/foreign-type-reference
 redirect_from:
-  - /0215/versioned-packages
+  - /0215/foreign-type-reference
 ---
 
 # Versioned packages
@@ -47,8 +47,18 @@ message SomeMessage {
 
 ## Known issues
 
-This package disallows subpackaging, and allows any package that ends with `.type` to
-avoid flagging possible legitimate uses of AIP-213 component packages.
+This check only allows subpackage usage if you're within a versioned path, but generates warnings for unversioned subpackage usage.
+It also ignores if the referenced package is a "common" package like google.api, or if the package path ends in ".type" indicating
+the package is an AIP-213 component package.
+
+Examples of foreign type references and their expected results:
+
+| Calling Package | Referenced Package | Result       |
+| --------------- | ------------------ | ------------ |
+| foo.bar         | foo.xyz            | lint warning |
+| foo.v2.bar      | foo.v2.xyz         | ok           |
+| foo.bar         | foo.type           | ok           |
+| foo.bar         | google.api         | ok           |
 
 ## Disabling
 

--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -47,7 +47,7 @@ message SomeMessage {
 
 ## Known issues
 
-This check only allows subpackage usage if you're within a versioned path, but generates warnings for unversioned subpackage usage.
+This check only allows subpackage usage within a versioned path, but generates warnings for unversioned subpackage usage.
 It also ignores if the referenced package is a "common" package like google.api, or if the package path ends in ".type" indicating
 the package is an AIP-213 component package.
 

--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -48,7 +48,7 @@ message SomeMessage {
 ## Known issues
 
 This check only allows subpackage usage within a versioned path, but generates warnings for unversioned subpackage usage.
-It also ignores if the referenced package is a "common" package like google.api, or if the package path ends in ".type" indicating
+It also ignores if the referenced package is a "common" package like `google.api`, or if the package path ends in `.type` indicating
 the package is an AIP-213 component package.
 
 Examples of foreign type references and their expected results:

--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -2,7 +2,7 @@
 rule:
   aip: 215
   name: [core, '0215', foreign-type-reference]
-  summary: API-specific protos should be in versioned packages.
+  summary: API should not reference foreign types outside of the API scope.
 permalink: /215/foreign-type-reference
 redirect_from:
   - /0215/foreign-type-reference

--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -1,0 +1,65 @@
+---
+rule:
+  aip: 215
+  name: [core, '0215', foreign-type-reference]
+  summary: API-specific protos should be in versioned packages.
+permalink: /215/versioned-packages
+redirect_from:
+  - /0215/versioned-packages
+---
+
+# Versioned packages
+
+This rule enforces that none of the fields in an API reference message types in a different
+proto package namespace other than well-known common packages.
+
+## Details
+
+This rule examines all fields in an API's messages and complains if the package of the
+referenced message type is not the same or from one of the common packages such as
+`google.api`, `google.protobuf`, etc.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+package foo.bar;
+import "some/other.proto";
+
+message SomeMessage {
+    some.OtherMessage other_message = 1;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+package foo.bar;
+import "other.proto";
+
+message SomeMessage {
+    OtherMessage other_message = 1;
+}
+```
+
+## Known issues
+
+This package disallows subpackaging, and allows any package that ends with `.type` to
+avoid flagging possible legitimate uses of AIP-213 component packages.
+
+## Disabling
+
+If you need to violate this rule, place the comment above the package statement.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0215::foreign-type-reference=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+package foo.bar;
+```
+
+[aip-215]: https://aip.dev/215
+[aip.dev/not-precedent]: https://aip.dev/not-precedent

--- a/rules/aip0215/foreign_type_reference.go
+++ b/rules/aip0215/foreign_type_reference.go
@@ -57,8 +57,5 @@ func getPackage(d desc.Descriptor) string {
 // Valid component packages are expected to end in ".type".
 func isComponentPackage(pkg string) bool {
 	parts := strings.Split(pkg, ".")
-	if parts[len(parts)-1] == "type" {
-		return true
-	}
-	return false
+	return parts[len(parts)-1] == "type"
 }

--- a/rules/aip0215/foreign_type_reference.go
+++ b/rules/aip0215/foreign_type_reference.go
@@ -16,6 +16,7 @@ package aip0215
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/googleapis/api-linter/lint"
 	"github.com/googleapis/api-linter/rules/internal/utils"
@@ -35,7 +36,7 @@ var foreignTypeReference = &lint.FieldRule{
 			if !utils.IsCommonProto(fd.GetMessageType().GetFile()) {
 				// TODO: consider whether this should be less strict, and shares some common path fragment.
 				// If relaxed, how much path deviation is allowed?  AIP-213 likely relates here (common components).
-				if curPkg != "" && msgPkg != "" && curPkg != msgPkg {
+				if curPkg != "" && msgPkg != "" && !isComponentPackage(msgPkg) && curPkg != msgPkg {
 					return []lint.Problem{{
 						Message:    fmt.Sprintf("foreign type referenced, current field in %q message in %q", curPkg, msgPkg),
 						Descriptor: fd,
@@ -52,4 +53,12 @@ func getPackage(d desc.Descriptor) string {
 		return f.GetPackage()
 	}
 	return ""
+}
+
+func isComponentPackage(pkg string) bool {
+	parts := strings.Split(pkg, ".")
+	if parts[len(parts)-1] == "type" {
+		return true
+	}
+	return false
 }

--- a/rules/aip0215/foreign_type_reference.go
+++ b/rules/aip0215/foreign_type_reference.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0215
+
+import (
+	"fmt"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+	"google.golang.org/protobuf/types/descriptorpb"
+)
+
+var foreignTypeReference = &lint.FieldRule{
+	Name: lint.NewRuleName(202, "foreign-type-reference"),
+	OnlyIf: func(fd *desc.FieldDescriptor) bool {
+		return fd.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
+	},
+	LintField: func(fd *desc.FieldDescriptor) []lint.Problem {
+		curPkg := getPackage(fd)
+		if msg := fd.GetMessageType(); msg != nil {
+			msgPkg := getPackage(msg)
+			if !utils.IsCommonProto(fd.GetMessageType().GetFile()) {
+				// TODO: consider whether this should be less strict, and shares some common path fragment.
+				// If relaxed, how much path deviation is allowed?  AIP-213 likely relates here (common components).
+				if curPkg != "" && msgPkg != "" && curPkg != msgPkg {
+					return []lint.Problem{{
+						Message:    fmt.Sprintf("foreign type referenced, current field in %q message in %q", curPkg, msgPkg),
+						Descriptor: fd,
+					}}
+				}
+			}
+		}
+		return nil
+	},
+}
+
+func getPackage(d desc.Descriptor) string {
+	if f := d.GetFile(); f != nil {
+		return f.GetPackage()
+	}
+	return ""
+}

--- a/rules/aip0215/foreign_type_reference.go
+++ b/rules/aip0215/foreign_type_reference.go
@@ -24,7 +24,7 @@ import (
 )
 
 var foreignTypeReference = &lint.FieldRule{
-	Name: lint.NewRuleName(202, "foreign-type-reference"),
+	Name: lint.NewRuleName(215, "foreign-type-reference"),
 	OnlyIf: func(fd *desc.FieldDescriptor) bool {
 		return fd.GetType() == descriptorpb.FieldDescriptorProto_TYPE_MESSAGE
 	},

--- a/rules/aip0215/foreign_type_reference.go
+++ b/rules/aip0215/foreign_type_reference.go
@@ -34,8 +34,6 @@ var foreignTypeReference = &lint.FieldRule{
 		if msg := fd.GetMessageType(); msg != nil {
 			msgPkg := getPackage(msg)
 			if !utils.IsCommonProto(fd.GetMessageType().GetFile()) {
-				// TODO: consider whether this should be less strict, and shares some common path fragment.
-				// If relaxed, how much path deviation is allowed?  AIP-213 likely relates here (common components).
 				if curPkg != "" && msgPkg != "" && !isComponentPackage(msgPkg) && curPkg != msgPkg {
 					return []lint.Problem{{
 						Message:    fmt.Sprintf("foreign type referenced, current field in %q message in %q", curPkg, msgPkg),
@@ -55,6 +53,8 @@ func getPackage(d desc.Descriptor) string {
 	return ""
 }
 
+// check if a package path is an AIP-213 component package path.
+// Valid component packages are expected to end in ".type".
 func isComponentPackage(pkg string) bool {
 	parts := strings.Split(pkg, ".")
 	if parts[len(parts)-1] == "type" {

--- a/rules/aip0215/foreign_type_reference_test.go
+++ b/rules/aip0215/foreign_type_reference_test.go
@@ -64,6 +64,13 @@ func TestForeignTypeReference(t *testing.T) {
 			ReferencedMsg: "somepackage.sub.OtherMessage",
 			problems:      testutils.Problems{{Message: "foreign type referenced"}},
 		},
+		{
+			description:   "refers to component package",
+			CallingPkg:    "somepackage",
+			ReferencePkg:  "otherpackage.type",
+			ReferencedMsg: "otherpackage.type.OtherMessage",
+			problems:      nil,
+		},
 	} {
 		t.Run(tc.description, func(t *testing.T) {
 			files := testutils.ParseProto3Tmpls(t, map[string]string{

--- a/rules/aip0215/foreign_type_reference_test.go
+++ b/rules/aip0215/foreign_type_reference_test.go
@@ -16,8 +16,77 @@ package aip0215
 
 import (
 	"testing"
+
+	"github.com/googleapis/api-linter/rules/internal/testutils"
 )
 
 func TestForeignTypeReference(t *testing.T) {
-	t.Errorf("unimplemented")
+
+	for _, tc := range []struct {
+		description   string
+		CallingPkg    string
+		ReferencePkg  string
+		ReferencedMsg string
+		problems      testutils.Problems
+	}{
+		{
+			description:   "same pkg",
+			CallingPkg:    "same",
+			ReferencePkg:  "same",
+			ReferencedMsg: "OtherMessage",
+			problems:      nil,
+		},
+		{
+			description:   "refers to google.api",
+			CallingPkg:    "same",
+			ReferencePkg:  "google.api",
+			ReferencedMsg: "google.api.OtherMessage",
+			problems:      nil,
+		},
+		{
+			description:   "refers to google.protobuf",
+			CallingPkg:    "same",
+			ReferencePkg:  "google.protobuf",
+			ReferencedMsg: "google.protobuf.OtherMessage",
+			problems:      nil,
+		},
+		{
+			description:   "refers to foreign pkg",
+			CallingPkg:    "same",
+			ReferencePkg:  "other",
+			ReferencedMsg: "other.OtherMessage",
+			problems:      testutils.Problems{{Message: "foreign type referenced"}},
+		},
+		{
+			description:   "refers to subpkg",
+			CallingPkg:    "somepackage",
+			ReferencePkg:  "somepackage.sub",
+			ReferencedMsg: "somepackage.sub.OtherMessage",
+			problems:      testutils.Problems{{Message: "foreign type referenced"}},
+		},
+	} {
+		t.Run(tc.description, func(t *testing.T) {
+			files := testutils.ParseProto3Tmpls(t, map[string]string{
+				"calling.proto": `
+					package {{.CallingPkg}};
+					import "ref.proto";
+					message Caller {
+						string foo = 1;
+						{{.ReferencedMsg}} bar = 2;
+					}
+				`,
+				"ref.proto": `
+					package {{.ReferencePkg}};
+					message OtherMessage {
+						int32 baz = 1;
+					}
+				`,
+			}, tc)
+			file := files["calling.proto"]
+			field := file.GetMessageTypes()[0].GetFields()[1]
+			if diff := tc.problems.SetDescriptor(field).Diff(foreignTypeReference.Lint(file)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
 }

--- a/rules/aip0215/foreign_type_reference_test.go
+++ b/rules/aip0215/foreign_type_reference_test.go
@@ -1,10 +1,10 @@
-// Copyright 2019 Google LLC
+// Copyright 2025 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//     https://www.apache.org/licenses/LICENSE-2.0
+//	https://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,18 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package aip0215 contains rules defined in https://aip.dev/215.
 package aip0215
 
 import (
-	"github.com/googleapis/api-linter/lint"
+	"testing"
 )
 
-// AddRules adds all of the AIP-215 rules to the provided registry.
-func AddRules(r lint.RuleRegistry) error {
-	return r.Register(
-		215,
-		versionedPackages,
-		foreignTypeReference,
-	)
+func TestForeignTypeReference(t *testing.T) {
+	t.Errorf("unimplemented")
 }


### PR DESCRIPTION
This PR augments AIP-215 rules to look for package mismatches.  It leverages comparisons between a FieldDescriptor that references a Message type, and compares based on the proto package of the two.

Updates: #1018

internal: b/391975695