### PR TITLE
docs(AIP-215): fix incorrect heading for `foreign-type-reference`

### DIFF
--- a/docs/rules/0215/foreign-type-reference.md
+++ b/docs/rules/0215/foreign-type-reference.md
@@ -8,7 +8,7 @@ redirect_from:
   - /0215/foreign-type-reference
 ---
 
-# Versioned packages
+# Foreign type reference
 
 This rule enforces that none of the fields in an API reference message types in a different
 proto package namespace other than well-known common packages.


### PR DESCRIPTION
This appears to be a copy-paste mistake in PR https://github.com/googleapis/api-linter/pull/1467.

![2025-02-14_22-07](https://github.com/user-attachments/assets/3d463227-2462-4b9f-8971-3216ed4b71e7)
