### PR TITLE
fix(cli): resolve against cwd separately

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -165,7 +165,18 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 		},
 	}
 	// Resolve file absolute paths to relative ones.
+	// Using supplied import paths first.
 	protoFiles, err := protoparse.ResolveFilenames(c.ProtoImportPaths, c.ProtoFiles...)
+	if err != nil {
+		return err
+	}
+	// Then resolve again against ".", the local directory.
+	// This is necessary because ResolveFilenames won't resolve a path if it
+	// relative to *at least one* of the given import paths, which can result
+	// in duplicate file parsing and compilation errors, as seen in #1465 and
+	// #1471. So we resolve against local (default) and flag specified import
+	// paths separately.
+	protoFiles, err = protoparse.ResolveFilenames([]string{"."}, protoFiles...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Restore explicit proto filename resolution against `"."` removed in #1466. It was removed to facilitate proto filename resolution relative to cwd for file names that weren't prefixed with `./`, but this ended up breaking it for those prefixed with `./`. Instead of attempt to include `"."` as an import path to resolve against alongside the CLI provided ones, we resolve against it afterwards. This is because the `protoparse.ResolveFilenames` will not resolve the file name if it is relative to any of the import paths, but we need it to in case the user provides a mix of import paths and cwd relative values. In this case, the prefix `./` needs to be resolved as well.

Tested it against both reported issue cases.

Updates #1471.