### PR TITLE
fix(AIP-133/AIP-134): handle qualified lro response type name comparison

### DIFF
--- a/rules/aip0133/response_message_name.go
+++ b/rules/aip0133/response_message_name.go
@@ -30,12 +30,14 @@ var outputName = &lint.MethodRule{
 	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
 		want := utils.GetResourceMessageName(m, "Create")
 
-		// If this is an LRO, then use the annotated response type instead of
-		// the actual RPC return type.
-		got := m.GetOutputType().GetName()
-		if utils.IsOperation(m.GetOutputType()) {
-			got = utils.GetOperationInfo(m).GetResponseType()
+		// Load the response type, resolving the
+		// `google.longrunning.OperationInfo.response_type` if necessary.
+		resp := utils.GetResponseType(m)
+		if resp == nil {
+			// If we can't resolve it, let the AIP-151 rule warn about this.
+			return nil
 		}
+		got := resp.GetName()
 
 		// Rule check: Establish that for methods such as `CreateFoo`, the response
 		// message should be named `Foo`

--- a/rules/aip0134/response_message_name.go
+++ b/rules/aip0134/response_message_name.go
@@ -32,12 +32,15 @@ var responseMessageName = &lint.MethodRule{
 		// Rule check: Establish that for methods such as `UpdateFoo`, the response
 		// message is `Foo` or `google.longrunning.Operation`.
 		want := strings.Replace(m.GetName(), "Update", "", 1)
-		got := m.GetOutputType().GetName()
 
-		// If the return type is an LRO, use the annotated response type instead.
-		if utils.IsOperation(m.GetOutputType()) {
-			got = utils.GetOperationInfo(m).GetResponseType()
+		// Load the response type, resolving the
+		// `google.longrunning.OperationInfo.response_type` if necessary.
+		resp := utils.GetResponseType(m)
+		if resp == nil {
+			// If we can't resolve it, let the AIP-151 rule warn about this.
+			return nil
 		}
+		got := resp.GetName()
 
 		// Return a problem if we did not get the expected return name.
 		//

--- a/rules/internal/utils/find_test.go
+++ b/rules/internal/utils/find_test.go
@@ -41,7 +41,13 @@ func TestFindMessage(t *testing.T) {
 		t.Errorf("Got nil, expected Book message.")
 	}
 	if scroll := FindMessage(files["c.proto"], "Scroll"); scroll != nil {
-		t.Errorf("Got Sctoll message, expected nil.")
+		t.Errorf("Got Scroll message, expected nil.")
+	}
+	if book := FindMessage(files["c.proto"], "test.Book"); book == nil {
+		t.Errorf("Got nil, expected Book message from qualified name.")
+	}
+	if scroll := FindMessage(files["c.proto"], "other.Scroll"); scroll == nil {
+		t.Errorf("Got nil message, expected Scroll message from qualified name.")
 	}
 }
 


### PR DESCRIPTION
The AIP-133 and AIP-134 rules for response message checks were naively comparing the LRO `response_type` value directly, instead of resolving the proto type and comparing the simple message name. This breaks down when a fully qualified name, even within the same package, is specified. Instead, we should attempt to resolve the type and check simple names. This makes an adjustment to the `FindMessage` utility to account for qualified references and matching against imported types that have a matching package. Not sure why this wasn't handled previously.

Internal bug http://b/396418619