### PR TITLE
fix(cli): only call ResolveFilenames with ProtoImportPaths if specified

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -166,9 +166,12 @@ func (c *cli) lint(rules lint.RuleRegistry, configs lint.Configs) error {
 	}
 	// Resolve file absolute paths to relative ones.
 	// Using supplied import paths first.
-	protoFiles, err := protoparse.ResolveFilenames(c.ProtoImportPaths, c.ProtoFiles...)
-	if err != nil {
-		return err
+	protoFiles := c.ProtoFiles
+	if len(c.ProtoImportPaths) > 0 {
+		protoFiles, err = protoparse.ResolveFilenames(c.ProtoImportPaths, c.ProtoFiles...)
+		if err != nil {
+			return err
+		}
 	}
 	// Then resolve again against ".", the local directory.
 	// This is necessary because ResolveFilenames won't resolve a path if it


### PR DESCRIPTION
Only attempt to resolve against the `--proto-path` import paths if there were some specified, to avoid an error from `protoparse.ResolveFilenames` that requires some import path when provided absolute paths. Still want to keep the `.` resolution separate so that relative input filenames are still able to be resolved against the provided import paths ahead of the attempt to resolve against cwd to avoid proto file name collisions in the subsequent Parse action.

Note: Filed separate bug to come up with a testing harness for the CLI https://github.com/googleapis/api-linter/issues/1479

Updates #1465 again improving on that fix and the one for #1471