### PR TITLE
fix(AIP-158): clarify pluralized response field finding

### DIFF
--- a/rules/aip0136/response_message_name.go
+++ b/rules/aip0136/response_message_name.go
@@ -53,8 +53,17 @@ var responseMessageName = &lint.MethodRule{
 			// just exit.
 			return nil
 		}
+		res := utils.GetResource(response)
+		responseResourceType := res.GetType()
 		requestResourceType := utils.GetResourceReference(m.GetInputType().FindFieldByName("name")).GetType()
-		responseResourceType := utils.GetResource(response).GetType()
+
+		// Check to see if the custom method uses the resource type name as the target
+		// field name and use that instead if `name` is not present as well.
+		// AIP-144 methods recommend this naming style.
+		resourceFieldType := utils.GetResourceReference(m.GetInputType().FindFieldByName(utils.GetResourceSingular(res))).GetType()
+		if requestResourceType == "" && resourceFieldType != "" {
+			requestResourceType = resourceFieldType
+		}
 
 		// Short-circuit: Output type is the resource being operated on
 		if utils.IsResource(response) && responseResourceType == requestResourceType {


### PR DESCRIPTION
## Description

The error message for the `response-plural-first-field` rule (AIP-158) was generic and did not provide sufficient context when a resource defines a `(google.api.resource).plural` annotation. This could be confusing for developers when dealing with irregular, non-standard pluralizations, or simply mismatched pluralizations.

## Fix

The rule's logic has been updated to check for the presence of the `(google.api.resource).plural` annotation. If the annotation exists, the error message now explicitly states that the suggested plural form is based on that annotation. This provides clearer guidance to the developer. If no annotation is found, the rule falls back to the original generic message.

Internal bug http://b/430460300
