### PR TITLE
fix(AIP-136): support response msg lint with resource singular name

### DIFF
--- a/rules/aip0136/response_message_name.go
+++ b/rules/aip0136/response_message_name.go
@@ -53,8 +53,17 @@ var responseMessageName = &lint.MethodRule{
 			// just exit.
 			return nil
 		}
+		res := utils.GetResource(response)
+		responseResourceType := res.GetType()
 		requestResourceType := utils.GetResourceReference(m.GetInputType().FindFieldByName("name")).GetType()
-		responseResourceType := utils.GetResource(response).GetType()
+
+		// Check to see if the custom method uses the resource type name as the target
+		// field name and use that instead if `name` is not present as well.
+		// AIP-144 methods recommend this naming style.
+		resourceFieldType := utils.GetResourceReference(m.GetInputType().FindFieldByName(utils.GetResourceSingular(res))).GetType()
+		if requestResourceType == "" && resourceFieldType != "" {
+			requestResourceType = resourceFieldType
+		}
 
 		// Short-circuit: Output type is the resource being operated on
 		if utils.IsResource(response) && responseResourceType == requestResourceType {


### PR DESCRIPTION
The `core::0136::response-message-name` rule uses a heursitic to verify and account for the _target_ resource type being the response type of the custom method (rather than a message type that aligns with the RPC name). It did this by checking for a `name` field with a `resource_reference` annotation and comparing the `type` there to the `type` of a `google.api.resource` annotation on the response to see if they matched. However, some AIPs recommend using a resource-singular-aligned field name in the request message e.g. the AIP-144 Add/Remove methods. So rather than `AddAuthor`, which returns a `Book`, checking for a `name` field, it will check for a `book` field as well and use that allow the custom method response type to be a `Book` rather than `AddAuthorResponse`.

This still prefers `name` if present in addition to a resource-singular-aligned field.

Internal bug http://b/424243407