### PR TITLE
chore(deps): freeze tablewriter updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -13,6 +13,7 @@
         "bitbucket.org/creachadair/stringset",
         "dominikh/staticcheck-action",
         "github.com/jhump/protoreflect",
+        "github.com/olekukonko/tablewriter",
       ],
       enabled: false
     }


### PR DESCRIPTION
Freeze updates for `github.com/olekukonko/tablewriter` after it took a major version with incompatible changes.

It is only used for CLI printing.