### PR TITLE
feat(AIP-160): Add rule to validate filter field name

### DIFF
--- a/docs/rules/0160/filter-field-name.md
+++ b/docs/rules/0160/filter-field-name.md
@@ -1,0 +1,76 @@
+---
+rule:
+  aip: 160
+  name: [core, '0160', filter-field-name]
+  summary: |
+    The filtering field on List and custom method request messages must
+    be called "filter" and not "filters".
+permalink: /160/filter-field-name
+redirect_from:
+  - /0160/filter-field-name
+---
+
+# Filtering: filter field name
+
+This rule enforces that the field used for filtering is called `filter`
+and not `filters`, as mandated by [AIP-160][].
+
+## Details
+
+This rule looks at the request message for List methods and custom
+methods to ensure that there is no field, `string filters`. If there is,
+the rule is violated and suggests that the field be, `string filter`.
+
+## Examples
+
+**Incorrect** code for this rule:
+
+```proto
+// Incorrect.
+rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
+  string filters = 1;
+}
+```
+
+```proto
+// Incorrect.
+rpc CheckoutBook(CheckoutBookRequest) returns (CheckoutBookResponse) {
+  string filters = 1;
+}
+```
+
+**Correct** code for this rule:
+
+```proto
+// Correct.
+rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
+  string filter = 1;
+}
+```
+
+```proto
+// Correct.
+rpc CheckoutBook(CheckoutBookRequest) returns (CheckoutBookResponse) {
+  string filter = 1;
+}
+```
+
+## Disabling
+
+If you need to violate this rule, use a leading comment above the method.
+Remember to also include an [aip.dev/not-precedent][] comment explaining why.
+
+```proto
+// (-- api-linter: core::0160::filter-field-name=disabled
+//     aip.dev/not-precedent: We need to do this because reasons. --)
+rpc ListBooks(ListBooksRequest) returns (ListBooksResponse) {
+  string filters = 1;
+}
+```
+
+If you need to violate this rule for an entire file, place the comment at the
+top of the file.
+
+[aip-160]: https://aip.dev/160
+[aip.dev/not-precedent]: https://aip.dev/not-precedent
+

--- a/rules/aip0160/aip0160.go
+++ b/rules/aip0160/aip0160.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package aip0160 contains rules defined in https://aip.dev/160.
+package aip0160
+
+import (
+	"github.com/googleapis/api-linter/lint"
+)
+
+// AddRules adds all of the AIP-160 rules to the provided registry.
+func AddRules(r lint.RuleRegistry) error {
+	return r.Register(
+		160,
+		filterFieldName,
+	)
+}

--- a/rules/aip0160/aip0160_test.go
+++ b/rules/aip0160/aip0160_test.go
@@ -1,0 +1,27 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0160
+
+import (
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+)
+
+func TestAddRules(t *testing.T) {
+	if err := AddRules(lint.NewRuleRegistry()); err != nil {
+		t.Errorf("AddRules got an error: %v", err)
+	}
+}

--- a/rules/aip0160/filter_field_name.go
+++ b/rules/aip0160/filter_field_name.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0160
+
+import (
+	"fmt"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/locations"
+	"github.com/googleapis/api-linter/rules/internal/utils"
+	"github.com/jhump/protoreflect/desc"
+)
+
+const (
+	nameMessageFmt = `Guidance: use the field, "string filter", not "string %s"`
+	nameSuggestion = "filter"
+)
+
+var filterFieldName = &lint.MethodRule{
+	Name: lint.NewRuleName(160, "filter-field-name"),
+	OnlyIf: func(m *desc.MethodDescriptor) bool {
+		return utils.IsListMethod(m) || utils.IsCustomMethod(m)
+	},
+	LintMethod: func(m *desc.MethodDescriptor) []lint.Problem {
+		var problems []lint.Problem
+		for _, f := range m.GetInputType().GetFields() {
+			if f.GetName() == "filters" {
+				problems = append(problems, lint.Problem{
+					Message:    fmt.Sprintf(nameMessageFmt, f.GetName()),
+					Descriptor: f,
+					Location:   locations.DescriptorName(f),
+					Suggestion: nameSuggestion,
+				})
+			}
+		}
+		return problems
+	},
+}

--- a/rules/aip0160/filter_field_name_test.go
+++ b/rules/aip0160/filter_field_name_test.go
@@ -1,0 +1,72 @@
+// Copyright 2025 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package aip0160
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/googleapis/api-linter/lint"
+	"github.com/googleapis/api-linter/rules/internal/testutils"
+)
+
+func TestFiltersFieldName(t *testing.T) {
+	tests := []struct {
+		testName   string
+		FieldType  string
+		FieldName  string
+		MethodName string
+		wantErr    bool
+	}{
+		{"Valid", "string", "filter", "ListBooks", false},
+		{"Valid different native type List method", "bytes", "filter", "ListBooks", false},
+		{"Valid different message type List method", "BookFilters", "filter", "ListBooks", false},
+		{"Valid different native type custom method", "bytes", "filter", "SearchBooks", false},
+		{"Valid different message type custom method", "BookFilters", "filter", "SearchBooks", false},
+		{"Invalid list method", "string", "filters", "ListBooks", true},
+		{"Invalid custom method", "string", "filters", "SearchBooks", true},
+	}
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				service Library {
+					rpc {{.MethodName}}({{.MethodName}}Request) returns ({{.MethodName}}Response) {}
+					rpc GetBook(GetBookRequest) returns (Book) {}
+				}
+				message {{.MethodName}}Request {
+					{{.FieldType}} {{.FieldName}} = 1;
+				}
+				message {{.MethodName}}Response {}
+
+				message GetBookRequest {}
+				message Book { string filters = 1; }
+
+				message BookFilters {}
+		`, test)
+			field := file.GetMessageTypes()[0].GetFields()[0]
+			wantProblems := testutils.Problems{}
+			if test.wantErr {
+				wantProblems = append(wantProblems, lint.Problem{
+					Message:    fmt.Sprintf(`"string filter", not "%s %s`, test.FieldType, test.FieldName),
+					Suggestion: "filter",
+					Descriptor: field,
+				})
+			}
+			if diff := wantProblems.Diff(filterFieldName.Lint(file)); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/rules.go
+++ b/rules/rules.go
@@ -79,6 +79,7 @@ import (
 	"github.com/googleapis/api-linter/rules/aip0157"
 	"github.com/googleapis/api-linter/rules/aip0158"
 	"github.com/googleapis/api-linter/rules/aip0159"
+	"github.com/googleapis/api-linter/rules/aip0160"
 	"github.com/googleapis/api-linter/rules/aip0162"
 	"github.com/googleapis/api-linter/rules/aip0163"
 	"github.com/googleapis/api-linter/rules/aip0164"
@@ -129,6 +130,7 @@ var aipAddRulesFuncs = []addRulesFuncType{
 	aip0157.AddRules,
 	aip0158.AddRules,
 	aip0159.AddRules,
+	aip0160.AddRules,
 	aip0162.AddRules,
 	aip0163.AddRules,
 	aip0164.AddRules,


### PR DESCRIPTION
Validates that the field for filtering is called "filter" and not "filters" for List and custom methods' request messages.