### PR TITLE
chore(ci): build release assets from trigger tag

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -30,6 +30,8 @@ jobs:
             arch: amd64
     steps:
       - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.release.tag_name }}
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'


### PR DESCRIPTION
Now that we have a `v2` branch that we want to make a release candidate from, we need to ensure that if we tag a release from that branch, we build release assets from that tag specifically - not from `main`. This changes the `checkout` action to specifically checkout the release tag prior to building anything.

This is also a general improvement for the `main` branch as it ensures the assets we build/upload are from the exact same tag rather than whatever is in `main` when the release was created (which may be after the tag was created in non-Release-Please cases, which would be exceptional).