### PR TITLE
fix(cli): deduplicate descriptor sets on load

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -287,13 +287,23 @@ func loadFileDescriptorsAsResolver(filePaths ...string) (protocompile.Resolver, 
 	if len(filePaths) == 0 {
 		return nil, nil
 	}
-	fds := &dpb.FileDescriptorSet{}
+
+	fdsSet := make(map[string]*dpb.FileDescriptorProto)
 	for _, filePath := range filePaths {
 		fs, err := readFileDescriptorSet(filePath)
 		if err != nil {
 			return nil, err
 		}
-		fds.File = append(fds.File, fs.GetFile()...)
+		for _, fd := range fs.GetFile() {
+			if _, exists := fdsSet[fd.GetName()]; !exists {
+				fdsSet[fd.GetName()] = fd
+			}
+		}
+	}
+
+	fds := &dpb.FileDescriptorSet{}
+	for _, fd := range fdsSet {
+		fds.File = append(fds.File, fd)
 	}
 	files, err := protodesc.NewFiles(fds)
 	if err != nil {

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -389,3 +389,24 @@ func writeFile(path, content string) error {
 	}
 	return os.WriteFile(path, []byte(content), 0o644)
 }
+
+func TestDeduplicatesRepeatedDescriptors_DescriptorSets(t *testing.T) {
+	args := []string{
+		"--descriptor-set-in", "internal/testdata/a.protoset",
+		"--descriptor-set-in", "internal/testdata/b.protoset",
+		"a.proto",
+		"b.proto",
+	}
+
+	err := runCLI(args)
+
+	if err != nil && !errors.Is(err, ExitForLintFailure) {
+		if strings.Contains(err.Error(), "already defined") {
+			t.Errorf("Linter failed with unexpected 'symbol already defined' error: %v", err)
+		} else if strings.Contains(err.Error(), "file appears multiple times") {
+			t.Errorf("Linter failed with unexpected 'file appears multiple times' error: %v", err)
+		} else {
+			t.Fatalf("Linter failed with unexpected error: %v", err)
+		}
+	}
+}

--- a/cmd/api-linter/internal/testdata/a.proto
+++ b/cmd/api-linter/internal/testdata/a.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package test;
+
+import "common.proto";
+
+message A {
+  Common common = 1;
+}

--- a/cmd/api-linter/internal/testdata/a.protoset
+++ b/cmd/api-linter/internal/testdata/a.protoset
@@ -1,0 +1,8 @@
+
+&
+common.prototest"
+Commonbproto3
+P
+a.prototestcommon.proto")
+A$
+common (2.test.CommonRcommonbproto3

--- a/cmd/api-linter/internal/testdata/b.proto
+++ b/cmd/api-linter/internal/testdata/b.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package test;
+
+import "common.proto";
+
+message B {
+  Common common = 1;
+}

--- a/cmd/api-linter/internal/testdata/b.protoset
+++ b/cmd/api-linter/internal/testdata/b.protoset
@@ -1,0 +1,8 @@
+
+&
+common.prototest"
+Commonbproto3
+P
+b.prototestcommon.proto")
+B$
+common (2.test.CommonRcommonbproto3

--- a/cmd/api-linter/internal/testdata/common.proto
+++ b/cmd/api-linter/internal/testdata/common.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+package test;
+
+message Common {}


### PR DESCRIPTION
This PR fixes a bug that caused the linter to fail when processing multiple descriptor sets that contain the same imported file dependencies. When the linter is invoked with multiple descriptor set files (via the `--descriptor-set-in` flag), it would panic with a `"file appears multiple times"` error if those descriptor sets shared a common dependency. For example, if `a.protoset` and `b.protoset` both included the definitions from an imported `common.proto`, the linter would fail.