### PR TITLE
chore(v2): catch up with main (again)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -20,7 +20,7 @@
   ],
   force: {
     constraints: {
-      go: "1.23"
+      go: "1.24"
     }
   }
 }

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - run: go test -race ./...
@@ -22,13 +22,13 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: staticcheck
         uses: dominikh/staticcheck-action@v1.3.1
         with:
-          version: "2024.1.1"
+          version: "2025.1.1"
           install-go: false
   quality-checker:
     runs-on: ubuntu-latest
@@ -36,7 +36,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 1
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       - name: run the quality checker (which catches obvious mistakes, missing docs, etc.)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.release.tag_name }}
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
       # The API linter does not use these,  but we need them to build the

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -248,7 +248,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.4)
     rouge (3.30.0)
     rubyzip (2.3.2)
     safe_yaml (1.0.5)

--- a/docs/rules/0133/http-uri-resource.md
+++ b/docs/rules/0133/http-uri-resource.md
@@ -31,7 +31,7 @@ return type contains the string `"{collection_identifier}/"` in each `pattern`.
 // Incorrect.
 rpc CreateBook(CreateBookRequest) returns (Book) {
   option (google.api.http) = {
-    // There collection identifier should appear after the final `/` in the URI.
+    // The collection identifier should appear after the final `/` in the URI.
     post: "/v1/"
     body: "book"
   };

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/googleapis/api-linter/v2
 
-go 1.23.0
+go 1.24.0
 
 require (
 	bitbucket.org/creachadair/stringset v0.0.12

--- a/rules/aip0140/uri_test.go
+++ b/rules/aip0140/uri_test.go
@@ -23,21 +23,29 @@ import (
 func TestURI(t *testing.T) {
 	for _, test := range []struct {
 		name     string
+		Comment  string
 		Field    string
 		problems testutils.Problems
 	}{
-		{"Valid", "uri", nil},
-		{"ValidPrefix", "uri_foo", nil},
-		{"ValidSuffix", "foo_uri", nil},
-		{"ValidIntermixed", "foo_uri_bar", nil},
-		{"Invalid", "url", testutils.Problems{{Message: "uri", Suggestion: "uri"}}},
-		{"InvalidPrefix", "url_foo", testutils.Problems{{Message: "uri", Suggestion: "uri_foo"}}},
-		{"InvalidSuffix", "foo_url", testutils.Problems{{Message: "uri", Suggestion: "foo_uri"}}},
-		{"InvalidIntermixed", "foo_url_bar", testutils.Problems{{Message: "uri", Suggestion: "foo_uri_bar"}}},
+		{"Valid", "", "uri", nil},
+		{"ValidPrefix", "", "uri_foo", nil},
+		{"ValidSuffix", "", "foo_uri", nil},
+		{"ValidIntermixed", "", "foo_uri_bar", nil},
+		{"ValidWithURIComment", "// A URI.", "uri", nil},
+		{"ValidURL", "", "url", nil},
+		{"ValidURLPrefix", "", "url_foo", nil},
+		{"ValidURLSuffix", "", "foo_url", nil},
+		{"ValidURLIntermixed", "", "foo_url_bar", nil},
+		{"ValidIntraWordURIComment", "// A URL to a curio.", "url", nil},
+		{"Invalid", "// A URI.", "url", testutils.Problems{{Message: "uri", Suggestion: "uri"}}},
+		{"InvalidPrefix", "// A uri.", "url_foo", testutils.Problems{{Message: "uri", Suggestion: "uri_foo"}}},
+		{"InvalidSuffix", "// A URI.", "foo_url", testutils.Problems{{Message: "uri", Suggestion: "foo_uri"}}},
+		{"InvalidIntermixed", "// A uri.", "foo_url_bar", testutils.Problems{{Message: "uri", Suggestion: "foo_uri_bar"}}},
 	} {
 		t.Run(test.name, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
 				message Foo {
+				  {{.Comment}}
 					string {{.Field}} = 1;
 				}
 			`, test)


### PR DESCRIPTION
This PR catches up the `v2` branch with recent changes on `main`. This includes:
* Go version update
* change to AIP-140 URI field name linting
* rule doc fix

Note: It looks like many more commits are being merged than there are changes in this PR b.c I previously caught up the branch with these changes in #1535, but it was squashed, so it looks like they weren't!