### PR TITLE
chore(deps): disable unused dep dashboard

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,7 @@
 {
   extends: [
     "config:base",
+    ":disableDependencyDashboard",
     "group:all",
     "schedule:weekly",
     ":semanticCommitTypeAll(chore)"
@@ -12,7 +13,6 @@
       matchPackageNames: [
         "bitbucket.org/creachadair/stringset",
         "dominikh/staticcheck-action",
-        "github.com/jhump/protoreflect",
         "github.com/olekukonko/tablewriter",
       ],
       enabled: false


### PR DESCRIPTION
Disables the renovate dependency dashboard, which we do not actively use, so that we can close #875.

Also remove mention of jhump/protoreflect from disabled dependencies b.c it is no longer a dependency.