### PR TITLE
chore(deps): disable ruby updates in renovate

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,6 +14,7 @@
         "bitbucket.org/creachadair/stringset",
         "dominikh/staticcheck-action",
         "github.com/olekukonko/tablewriter",
+        "ruby",
       ],
       enabled: false
     }


### PR DESCRIPTION
Disable Ruby updates in our local documentation server Dockerfile. This, like Go versions, should be done manually.