### PR TITLE
fix(AIP-192): limit spaces matched for header detection

### DIFF
--- a/rules/aip0192/no_markdown_headings.go
+++ b/rules/aip0192/no_markdown_headings.go
@@ -40,4 +40,4 @@ var noMarkdownHeadings = &lint.DescriptorRule{
 	},
 }
 
-var heading = regexp.MustCompile(`^\s*[#]+ `)
+var heading = regexp.MustCompile(`^\s?[#]+ `)


### PR DESCRIPTION
Limit the spaces matched when checking for markdown header syntax in comments to one or none.

We don't want to match a `#` used in an example of, say, YAML where it would be indented further.

This isn't a super clean fix b.c it could still match on `#` in code blocks that only have one leading space, but it should reduce the number of false positives. Ideally API Linter doesn't become a markdown parser...

Fixes #1587