### PR TITLE
feat(cli): add support for linting descriptor sets only via --skip-compilation

### DIFF
--- a/cmd/api-linter/cli.go
+++ b/cmd/api-linter/cli.go
@@ -225,7 +225,7 @@ func (c *cli) getDescriptorsFromDescriptorSet() ([]protoreflect.FileDescriptor, 
 		for _, fd := range fileDescriptors {
 			filenames = append(filenames, fd.Path())
 		}
-		return nil, fmt.Errorf("files found in descriptors %v, files request for linting %v", filenames, c.ProtoFiles)
+		return nil, fmt.Errorf("files found in descriptors %v, files requested for linting %v", filenames, c.ProtoFiles)
 	}
 
 	return fileDescriptors, nil

--- a/cmd/api-linter/integration_test.go
+++ b/cmd/api-linter/integration_test.go
@@ -604,7 +604,7 @@ func TestSkipCompilation_Errors(t *testing.T) {
 				"dummy.proto",
 				"missing.proto",
 			},
-			wantErrString: "files found in descriptors [dummy.proto], files request for linting [dummy.proto missing.proto]",
+			wantErrString: "files found in descriptors",
 		},
 	}
 


### PR DESCRIPTION
Add the ability  to lint specific proto files directly from pre-compiled `FileDescriptorSet` files, bypassing the source compilation step.

## Key Changes
- **New Flag `--skip-compilation`**: Added a boolean flag that, when enabled, instructs the linter to look up requested files in the descriptor sets provided via `--descriptor-set-in` instead of compiling them from source.
- **Improved Descriptor Resolution**:
    - Refactored internal descriptor gathering logic into specialized methods: `getDescriptorsFromDescriptorSet` and `getDescriptorsFromSource`.
    - Consolidated descriptor set loading into a reusable helper `createRegistryFromDescriptorSets`, allowing for the aggregation of multiple descriptor sets.

## Integration Tests
Added comprehensive end-to-end tests in `cmd/api-linter/integration_test.go`:
- `TestSkipCompilation_Success`:
    - **SingleFile**: Verifies linting a single file from one descriptor set.
    - **MultipleDescriptorSets**: Verifies aggregating multiple descriptor sets and linting files from both.
- `TestSkipCompilation_Errors`:
    - **NoFileToLint**: Ensures the linter errors out if no files are specified with `--skip-compilation`.
    - **NoDescriptorSet**: Ensures the linter errors out if no descriptor sets are provided.

## Usage Example
To lint specific files using pre-compiled descriptors:
```bash
api-linter --descriptor-set-in=service.desc --skip-compilation google/api/service.proto
```

To aggregate multiple descriptor sets:
```bash
api-linter --descriptor-set-in=set1.desc --descriptor-set-in=set2.desc --skip-compilation file1.proto file2.proto
```

Update b/468026535