### PR TITLE
chore: replace old partner teams with new ones (Wave 2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
-# The API linter team owns this repository.
+# The API design team owns this repository.
 * @googleapis/api-design-team


### PR DESCRIPTION
Replacing old partner teams with new ones as part of Wave 2 migration. b/478003109