### PR TITLE
chore(API-121): clarify mutable cycles error for IMMUTABLE fields

### DIFF
--- a/docs/rules/0121/no-mutable-cycles.md
+++ b/docs/rules/0121/no-mutable-cycles.md
@@ -18,6 +18,12 @@ references as mandated in [AIP-121][].
 This rule scans the fields of every resource and ensures that any references to
 other resources do not create a mutable cycle between them.
 
+A field is considered "mutable" in this context if it is client-settable. This
+includes fields marked as `IMMUTABLE`, because they can be set at creation time,
+which could effectively lead to a cycle when the resource is created. Only
+`OUTPUT_ONLY` fields (which are server-managed) are exempt from this rule as
+they break the mutation cycle.
+
 ## Examples
 
 **Incorrect** code for this rule:

--- a/rules/aip0121/no_mutable_cycles.go
+++ b/rules/aip0121/no_mutable_cycles.go
@@ -53,8 +53,12 @@ func findCycles(start string, node protoreflect.MessageDescriptor, seen stringse
 		}
 		if ref.GetType() == start {
 			cycle := strings.Join(append(chain, start), " > ")
+			msg := "mutable resource reference introduces a reference cycle:\n" + cycle
+			if utils.GetFieldBehavior(f).Contains("IMMUTABLE") {
+				msg += "\nNote: IMMUTABLE fields do not prevent cycles because they can be set at creation time, which could effectively lead to a cycle when the resource is created."
+			}
 			problems = append(problems, lint.Problem{
-				Message:    "mutable resource reference introduces a reference cycle:\n" + cycle,
+				Message:    msg,
 				Descriptor: f,
 				Location:   locations.FieldResourceReference(f),
 			})

--- a/rules/aip0121/no_mutable_cycles.go
+++ b/rules/aip0121/no_mutable_cycles.go
@@ -75,6 +75,11 @@ func findCycles(start string, node protoreflect.MessageDescriptor, seen stringse
 				p.Descriptor = f
 				p.Location = locations.FieldResourceReference(f)
 
+				// Ensure we don't overwrite the message if the field is IMMUTABLE
+				if utils.GetFieldBehavior(f).Contains("IMMUTABLE") && !strings.Contains(p.Message, "Note: IMMUTABLE") {
+					p.Message += "\nNote: IMMUTABLE fields do not prevent cycles because they can be set at creation time, which could effectively lead to a cycle when the resource is created."
+				}
+
 				problems = append(problems, p)
 			}
 		}

--- a/rules/aip0121/no_mutable_cycles_test.go
+++ b/rules/aip0121/no_mutable_cycles_test.go
@@ -81,6 +81,19 @@ func TestNoMutableCycles(t *testing.T) {
 			},
 		},
 		{
+			"InvalidImmutableCycle",
+			`[
+				(google.api.resource_reference).type = "library.googleapis.com/Publisher",
+				(google.api.field_behavior) = IMMUTABLE
+			]`,
+			`[(google.api.resource_reference).type = "library.googleapis.com/Book"]`,
+			"",
+			"",
+			testutils.Problems{{
+				Message: "Note: IMMUTABLE fields do not prevent cycles because they can be set at creation time",
+			}},
+		},
+		{
 			"ValidOutputOnlyCyclicReference",
 			`[(google.api.resource_reference).type = "library.googleapis.com/Publisher"]`,
 			`[

--- a/rules/aip0121/no_mutable_cycles_test.go
+++ b/rules/aip0121/no_mutable_cycles_test.go
@@ -94,6 +94,19 @@ func TestNoMutableCycles(t *testing.T) {
 			}},
 		},
 		{
+			"InvalidStartingImmutableCycle",
+			`[(google.api.resource_reference).type = "library.googleapis.com/Publisher"]`,
+			`[
+				(google.api.resource_reference).type = "library.googleapis.com/Book",
+				(google.api.field_behavior) = IMMUTABLE
+			]`,
+			"",
+			"",
+			testutils.Problems{{
+				Message: "Note: IMMUTABLE fields do not prevent cycles because they can be set at creation time",
+			}},
+		},
+		{
 			"ValidOutputOnlyCyclicReference",
 			`[(google.api.resource_reference).type = "library.googleapis.com/Publisher"]`,
 			`[


### PR DESCRIPTION
Clarify the error message and documentation for the `core::0121::no-mutable-cycles` rule to address user confusion when `IMMUTABLE` fields are flagged as forming a "mutable" cycle.

Because `IMMUTABLE` fields are still client-settable during resource creation, they can effectively form reference cycles upon creation. Only server-managed fields (`OUTPUT_ONLY`) are exempt from this rule as they break the mutation cycle. 


Fixes #1603

