### PR TITLE
fix: allow read_mask on standard method requests

### DIFF
--- a/rules/aip0133/request_unknown_fields.go
+++ b/rules/aip0133/request_unknown_fields.go
@@ -35,6 +35,7 @@ var unknownFields = &lint.MessageRule{
 		// Rule check: Establish that there are no unexpected fields.
 		allowedFields := stringset.New(
 			"parent",        // AIP-133
+			"read_mask",     // AIP-157
 			"request_id",    // AIP-155
 			"validate_only", // AIP-163
 			"view",          // AIP-157

--- a/rules/aip0133/request_unknown_fields_test.go
+++ b/rules/aip0133/request_unknown_fields_test.go
@@ -72,6 +72,14 @@ func TestUnknownFields(t *testing.T) {
 			"",
 		},
 		{
+			"ReadMaskField",
+			"CreateBookRequest",
+			"read_mask",
+			"google.protobuf.FieldMask",
+			testutils.Problems{},
+			"",
+		},
+		{
 			"ViewField",
 			"CreateBookRequest",
 			"view",
@@ -117,6 +125,7 @@ func TestUnknownFields(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				import "google/protobuf/field_mask.proto";
 				enum BookView {
 					BOOK_VIEW_UNSPECIFIED = 0;
 					BOOK_VIEW_BASIC = 1;

--- a/rules/aip0134/request_unknown_fields.go
+++ b/rules/aip0134/request_unknown_fields.go
@@ -35,6 +35,7 @@ var unknownFields = &lint.MessageRule{
 		allowedFields := stringset.New(
 			fieldNameFromResource(resource), // AIP-134
 			"allow_missing",                 // AIP-134
+			"read_mask",                     // AIP-157
 			"request_id",                    // AIP-155
 			"update_mask",                   // AIP-134
 			"validate_only",                 // AIP-163

--- a/rules/aip0134/request_unknown_fields_test.go
+++ b/rules/aip0134/request_unknown_fields_test.go
@@ -35,6 +35,11 @@ func TestUnknownFields(t *testing.T) {
 			testutils.Problems{},
 		},
 		{
+			"ReadMask", "UpdateBigBookRequest", "read_mask",
+			"google.protobuf.FieldMask",
+			testutils.Problems{},
+		},
+		{
 			"ValidateOnly", "UpdateBigBookRequest", "validate_only",
 			"bool",
 			testutils.Problems{},

--- a/rules/aip0135/request_unknown_fields.go
+++ b/rules/aip0135/request_unknown_fields.go
@@ -35,6 +35,7 @@ var unknownFields = &lint.MessageRule{
 			"force":         {}, // AIP-135
 			"allow_missing": {}, // AIP-135
 			"etag":          {}, // AIP-154
+			"read_mask":     {}, // AIP-157
 			"request_id":    {}, // AIP-155
 			"validate_only": {}, // AIP-163
 			"view":          {}, // AIP-157

--- a/rules/aip0135/request_unknown_fields_test.go
+++ b/rules/aip0135/request_unknown_fields_test.go
@@ -32,6 +32,7 @@ func TestUnknownFields(t *testing.T) {
 		{"Force", "DeleteBookRequest", "force", "bool", testutils.Problems{}},
 		{"Etag", "DeleteBookRequest", "etag", "string", testutils.Problems{}},
 		{"AllowMissing", "DeleteBookRequest", "allow_missing", "bool", testutils.Problems{}},
+		{"ReadMask", "DeleteBookRequest", "read_mask", "google.protobuf.FieldMask", testutils.Problems{}},
 		{"RequestId", "DeleteBookRequest", "request_id", "string", testutils.Problems{}},
 		{"ValidateOnly", "DeleteBookRequest", "validate_only", "bool", testutils.Problems{}},
 		{"ValidView", "DeleteBookRequest", "view", "BookView", testutils.Problems{}},
@@ -45,6 +46,7 @@ func TestUnknownFields(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.testName, func(t *testing.T) {
 			f := testutils.ParseProto3Tmpl(t, `
+				import "google/protobuf/field_mask.proto";
 				enum BookView {
 					BOOK_VIEW_UNSPECIFIED = 0;
 					BOOK_VIEW_BASIC = 1;


### PR DESCRIPTION
Fixes #1128.

This updates the standard method request unknown-field rules so AIP-157 read_mask request fields are accepted consistently beyond Get/List:

- allow read_mask on Create requests
- allow read_mask on Update requests
- allow read_mask on Delete requests
- add focused rule tests for each method family

Validation:

- gofmt
- GOCACHE=/Users/ubl/Documents/New project/oss-contributions/api-linter/.gocache GOMODCACHE=/Users/ubl/Documents/New project/oss-contributions/api-linter/.gomodcache go test ./rules/aip0133 ./rules/aip0134 ./rules/aip0135