### PR TITLE
fix: Respect google.api.resource singular annotation in batch method rules

### DIFF
--- a/rules/aip0231/request_names_field.go
+++ b/rules/aip0231/request_names_field.go
@@ -16,10 +16,11 @@ package aip0231
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
 	"github.com/googleapis/api-linter/v2/locations"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -78,10 +79,10 @@ var namesField = &lint.MessageRule{
 		}
 
 		// Rule check: Ensure that the standard get request message field is the
-		// correct type. Note: Use m.Name()[8:len(m.Name())-7]) to retrieve
-		// the resource name from the batch get request, for example:
-		// "BatchGetBooksRequest" -> "Books"
-		rightTypeName := fmt.Sprintf("Get%sRequest", pluralize.NewClient().Singular(string(m.Name())[8:len(m.Name())-7]))
+		// correct type. Note: Retrieve the resource name from the batch get
+		// request, for example: "BatchGetBooksRequest" -> "Books"
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchGet")
+		rightTypeName := fmt.Sprintf("Get%sRequest", utils.ResourceSingular(pluralName, m))
 		if getReqMsg != nil && (getReqMsg.Message() == nil || getReqMsg.Message().Name() != protoreflect.Name(rightTypeName)) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Get Request should be a %q type`, rightTypeName),

--- a/rules/aip0231/request_names_field.go
+++ b/rules/aip0231/request_names_field.go
@@ -82,7 +82,7 @@ var namesField = &lint.MessageRule{
 		// correct type. Note: Retrieve the resource name from the batch get
 		// request, for example: "BatchGetBooksRequest" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchGet")
-		rightTypeName := fmt.Sprintf("Get%sRequest", utils.ResourceSingular(pluralName, m))
+		rightTypeName := fmt.Sprintf("Get%sRequest", utils.DeriveResourceSingular(pluralName, m))
 		if getReqMsg != nil && (getReqMsg.Message() == nil || getReqMsg.Message().Name() != protoreflect.Name(rightTypeName)) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Get Request should be a %q type`, rightTypeName),

--- a/rules/aip0231/request_names_field_test.go
+++ b/rules/aip0231/request_names_field_test.go
@@ -149,3 +149,72 @@ func TestNamesField(t *testing.T) {
 		})
 	}
 }
+
+func TestNamesFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		src         string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchGetImpressionMetadataRequest {
+					repeated GetImpressionMetadataRequest requests = 1;
+				}
+				message GetImpressionMetadataRequest {}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "Invalid-WrongTypeWithResourceSingular",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchGetImpressionMetadataRequest {
+					repeated string requests = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			problems: testutils.Problems{{Message: `The "requests" field on Batch Get Request should be a "GetImpressionMetadataRequest" type`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m.Fields().ByName("requests")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3String(t, test.src)
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := namesField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0231/response_resource_field.go
+++ b/rules/aip0231/response_resource_field.go
@@ -29,7 +29,7 @@ var resourceField = &lint.MessageRule{
 	OnlyIf: isBatchGetResponseMessage,
 	LintMessage: func(m protoreflect.MessageDescriptor) []lint.Problem {
 		// The singular form the resource message name; the first letter capitalized.
-		pluralName := strings.TrimSuffix(strings.TrimPrefix(string(m.Name()), "BatchGet"), "Response")
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchGet")
 		resourceMsgName := utils.ResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {

--- a/rules/aip0231/response_resource_field.go
+++ b/rules/aip0231/response_resource_field.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -29,8 +29,8 @@ var resourceField = &lint.MessageRule{
 	OnlyIf: isBatchGetResponseMessage,
 	LintMessage: func(m protoreflect.MessageDescriptor) []lint.Problem {
 		// The singular form the resource message name; the first letter capitalized.
-		plural := strings.TrimSuffix(strings.TrimPrefix(string(m.Name()), "BatchGet"), "Response")
-		resourceMsgName := pluralize.NewClient().Singular(plural)
+		pluralName := strings.TrimSuffix(strings.TrimPrefix(string(m.Name()), "BatchGet"), "Response")
+		resourceMsgName := utils.ResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0231/response_resource_field.go
+++ b/rules/aip0231/response_resource_field.go
@@ -30,7 +30,7 @@ var resourceField = &lint.MessageRule{
 	LintMessage: func(m protoreflect.MessageDescriptor) []lint.Problem {
 		// The singular form the resource message name; the first letter capitalized.
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchGet")
-		resourceMsgName := utils.ResourceSingular(pluralName, m)
+		resourceMsgName := utils.DeriveResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0231/response_resource_field_test.go
+++ b/rules/aip0231/response_resource_field_test.go
@@ -93,3 +93,58 @@ func TestResourceField(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		Field       string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Field:    "repeated ImpressionMetadata impression_metadata",
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "MissingField-ResourceSingularMetadata",
+			Field:    "string response",
+			problems: testutils.Problems{{Message: `no "ImpressionMetadata" type field`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message BatchGetImpressionMetadataResponse {
+					{{.Field}} = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m.Fields().Get(0)
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := resourceField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0233/request_requests_field.go
+++ b/rules/aip0233/request_requests_field.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
 	"github.com/googleapis/api-linter/v2/locations"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -52,8 +52,8 @@ var requestRequestsField = &lint.MessageRule{
 		// Rule check: Ensure that the standard create request message field is the
 		// correct type. Note: Retrieve the resource name from the the batch create
 		// request, for example: "BatchCreateBooksRequest" -> "Books"
-		rightTypeName := fmt.Sprintf("Create%sRequest",
-			pluralize.NewClient().Singular(strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchCreate")))
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchCreate")
+		rightTypeName := fmt.Sprintf("Create%sRequest", utils.ResourceSingular(pluralName, m))
 		if requests.Message() == nil || requests.Message().Name() != protoreflect.Name(rightTypeName) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Create Request should be a %q type`, rightTypeName),

--- a/rules/aip0233/request_requests_field.go
+++ b/rules/aip0233/request_requests_field.go
@@ -53,7 +53,7 @@ var requestRequestsField = &lint.MessageRule{
 		// correct type. Note: Retrieve the resource name from the the batch create
 		// request, for example: "BatchCreateBooksRequest" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchCreate")
-		rightTypeName := fmt.Sprintf("Create%sRequest", utils.ResourceSingular(pluralName, m))
+		rightTypeName := fmt.Sprintf("Create%sRequest", utils.DeriveResourceSingular(pluralName, m))
 		if requests.Message() == nil || requests.Message().Name() != protoreflect.Name(rightTypeName) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Create Request should be a %q type`, rightTypeName),

--- a/rules/aip0233/request_requests_field_test.go
+++ b/rules/aip0233/request_requests_field_test.go
@@ -98,3 +98,61 @@ func TestRequestRequestsField(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestRequestsFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		Field       string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Field:    "repeated CreateImpressionMetadataRequest requests = 1;",
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "Invalid-WrongTypeWithResourceSingular",
+			Field:    "repeated int32 requests = 1;",
+			problems: testutils.Problems{{
+				Suggestion: "CreateImpressionMetadataRequest",
+			}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m.Fields().ByName("requests")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message BatchCreateImpressionMetadataRequest {
+					{{.Field}}
+				}
+				message CreateImpressionMetadataRequest {}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := requestRequestsField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0233/response_resource_field.go
+++ b/rules/aip0233/response_resource_field.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -31,7 +31,8 @@ var responseResourceField = &lint.MessageRule{
 		// the singular form the resource name, the first letter is Capitalized.
 		// Note: Retrieve the resource name from the the batch create response,
 		// for example: "BatchCreateBooksResponse" -> "Books"
-		resourceMsgName := pluralize.NewClient().Singular(strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchCreate"))
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchCreate")
+		resourceMsgName := utils.ResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0233/response_resource_field.go
+++ b/rules/aip0233/response_resource_field.go
@@ -32,7 +32,7 @@ var responseResourceField = &lint.MessageRule{
 		// Note: Retrieve the resource name from the the batch create response,
 		// for example: "BatchCreateBooksResponse" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchCreate")
-		resourceMsgName := utils.ResourceSingular(pluralName, m)
+		resourceMsgName := utils.DeriveResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0233/response_resource_field_test.go
+++ b/rules/aip0233/response_resource_field_test.go
@@ -74,3 +74,58 @@ func TestResponseResourceField(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseResourceFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		Src         string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Src:      `repeated ImpressionMetadata impression_metadata = 1;`,
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "MissingField-ResourceSingularMetadata",
+			Src:      `string response = 1;`,
+			problems: testutils.Problems{{Message: `no "ImpressionMetadata" type field`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message BatchCreateImpressionMetadataResponse {
+					{{.Src}}
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m.Fields().Get(0)
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := responseResourceField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0234/request_requests_field.go
+++ b/rules/aip0234/request_requests_field.go
@@ -18,9 +18,9 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
 	"github.com/googleapis/api-linter/v2/locations"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -52,8 +52,8 @@ var requestRequestsField = &lint.MessageRule{
 		// Rule check: Ensure that the standard update request message field is the
 		// correct type. Note: Retrieve the resource name from the the batch update
 		// request, for example: "BatchUpdateBooksRequest" -> "Books"
-		rightTypeName := fmt.Sprintf("Update%sRequest",
-			pluralize.NewClient().Singular(strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchUpdate")))
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchUpdate")
+		rightTypeName := fmt.Sprintf("Update%sRequest", utils.ResourceSingular(pluralName, m))
 		if requests.Message() == nil || requests.Message().Name() != protoreflect.Name(rightTypeName) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Update Request should be a %q type`, rightTypeName),

--- a/rules/aip0234/request_requests_field.go
+++ b/rules/aip0234/request_requests_field.go
@@ -53,7 +53,7 @@ var requestRequestsField = &lint.MessageRule{
 		// correct type. Note: Retrieve the resource name from the the batch update
 		// request, for example: "BatchUpdateBooksRequest" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchUpdate")
-		rightTypeName := fmt.Sprintf("Update%sRequest", utils.ResourceSingular(pluralName, m))
+		rightTypeName := fmt.Sprintf("Update%sRequest", utils.DeriveResourceSingular(pluralName, m))
 		if requests.Message() == nil || requests.Message().Name() != protoreflect.Name(rightTypeName) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Update Request should be a %q type`, rightTypeName),

--- a/rules/aip0234/request_requests_field_test.go
+++ b/rules/aip0234/request_requests_field_test.go
@@ -87,3 +87,60 @@ func TestRequestRequestsField(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestRequestsFieldResourceAnnotation(t *testing.T) {
+	// Test that the rule respects google.api.resource singular annotation
+	// for words that go-pluralize would incorrectly singularize (e.g.
+	// "Metadata" -> "Metadatum").
+	tests := []struct {
+		testName string
+		Field    string
+		problems testutils.Problems
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Field:    "repeated UpdateImpressionMetadataRequest requests",
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "Invalid-WrongTypeWithResourceSingular",
+			Field:    "repeated int32 requests",
+			problems: testutils.Problems{{
+				Suggestion: "UpdateImpressionMetadataRequest",
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message BatchUpdateImpressionMetadataRequest {
+					{{.Field}} = 1;
+				}
+				message UpdateImpressionMetadataRequest {}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.googleapis.com/ImpressionMetadata"
+						pattern: "dataProviders/{data_provider}/impressionMetadata/{impression_metadata}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			var problemDesc protoreflect.Descriptor
+			if requests := file.Messages().Get(0).Fields().ByName("requests"); requests != nil {
+				problemDesc = requests
+			} else {
+				problemDesc = file.Messages().Get(0)
+			}
+
+			problems := requestRequestsField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0234/response_resource_field.go
+++ b/rules/aip0234/response_resource_field.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -31,7 +31,8 @@ var responseResourceField = &lint.MessageRule{
 		// the singular form the resource name, the first letter is Capitalized.
 		// Note: Retrieve the resource name from the the batch update response,
 		// for example: "BatchUpdateBooksResponse" -> "Books"
-		resourceMsgName := pluralize.NewClient().Singular(strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchUpdate"))
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchUpdate")
+		resourceMsgName := utils.ResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0234/response_resource_field.go
+++ b/rules/aip0234/response_resource_field.go
@@ -32,7 +32,7 @@ var responseResourceField = &lint.MessageRule{
 		// Note: Retrieve the resource name from the the batch update response,
 		// for example: "BatchUpdateBooksResponse" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchUpdate")
-		resourceMsgName := utils.ResourceSingular(pluralName, m)
+		resourceMsgName := utils.DeriveResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0234/response_resource_field_test.go
+++ b/rules/aip0234/response_resource_field_test.go
@@ -74,3 +74,60 @@ func TestResponseResourceField(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseResourceFieldResourceAnnotation(t *testing.T) {
+	// Test that the rule respects google.api.resource singular annotation
+	// for words that go-pluralize would incorrectly singularize.
+	tests := []struct {
+		testName    string
+		Field       string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Field:    "repeated ImpressionMetadata impression_metadata",
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "MissingField-ResourceSingularMetadata",
+			Field:    "string response",
+			problems: testutils.Problems{{Message: `no "ImpressionMetadata" type field`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message BatchUpdateImpressionMetadataResponse {
+					{{.Field}} = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.googleapis.com/ImpressionMetadata"
+						pattern: "dataProviders/{data_provider}/impressionMetadata/{impression_metadata}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m.Fields().Get(0)
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := responseResourceField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0235/request_names_field.go
+++ b/rules/aip0235/request_names_field.go
@@ -16,10 +16,11 @@ package aip0235
 
 import (
 	"fmt"
+	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
 	"github.com/googleapis/api-linter/v2/locations"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -78,10 +79,10 @@ var requestNamesField = &lint.MessageRule{
 		}
 
 		// Rule check: Ensure that the standard delete request message field is the
-		// correct type. Note: Use m.Name()[11:len(m.Name())-7]) to retrieve
-		// the resource name from the batch delete request, for example:
-		// "BatchDeleteBooksRequest" -> "Books"
-		rightTypeName := fmt.Sprintf("Delete%sRequest", pluralize.NewClient().Singular(string(m.Name())[11:len(m.Name())-7]))
+		// correct type. Note: Retrieve the resource name from the batch delete
+		// request, for example: "BatchDeleteBooksRequest" -> "Books"
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchDelete")
+		rightTypeName := fmt.Sprintf("Delete%sRequest", utils.ResourceSingular(pluralName, m))
 		if deleteReqMsg != nil && (deleteReqMsg.Message() == nil || deleteReqMsg.Message().Name() != protoreflect.Name(rightTypeName)) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Delete Request should be a %q type`, rightTypeName),

--- a/rules/aip0235/request_names_field.go
+++ b/rules/aip0235/request_names_field.go
@@ -82,7 +82,7 @@ var requestNamesField = &lint.MessageRule{
 		// correct type. Note: Retrieve the resource name from the batch delete
 		// request, for example: "BatchDeleteBooksRequest" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchDelete")
-		rightTypeName := fmt.Sprintf("Delete%sRequest", utils.ResourceSingular(pluralName, m))
+		rightTypeName := fmt.Sprintf("Delete%sRequest", utils.DeriveResourceSingular(pluralName, m))
 		if deleteReqMsg != nil && (deleteReqMsg.Message() == nil || deleteReqMsg.Message().Name() != protoreflect.Name(rightTypeName)) {
 			problems = append(problems, lint.Problem{
 				Message:    fmt.Sprintf(`The "requests" field on Batch Delete Request should be a %q type`, rightTypeName),

--- a/rules/aip0235/request_names_field_test.go
+++ b/rules/aip0235/request_names_field_test.go
@@ -149,3 +149,92 @@ func TestNamesField(t *testing.T) {
 		})
 	}
 }
+
+func TestNamesFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		src         string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-Names-ResourceSingularMetadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchDeleteImpressionMetadataRequest {
+					repeated string names = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "Valid-StandardDeleteReq-ResourceSingularMetadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchDeleteImpressionMetadataRequest {
+					repeated DeleteImpressionMetadataRequest requests = 1;
+				}
+				message DeleteImpressionMetadataRequest {}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "Invalid-DeleteReqFieldWrongType-ResourceSingularMetadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchDeleteImpressionMetadataRequest {
+					repeated string requests = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			problems: testutils.Problems{{Message: `should be a "DeleteImpressionMetadataRequest" type`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m.Fields().ByName("requests")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3String(t, test.src)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := requestNamesField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/aip0235/request_parent_field.go
+++ b/rules/aip0235/request_parent_field.go
@@ -30,7 +30,7 @@ var requestParentField = &lint.MessageRule{
 		// from the request name, then get the resource annotation from that,
 		// and then inspect the pattern there (oy!).
 		plural := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Request"), "BatchDelete")
-		singular := utils.ToSingular(plural)
+		singular := utils.DeriveResourceSingular(plural, m)
 		if msg := utils.FindMessage(m.ParentFile(), singular); msg != nil {
 			if !utils.HasParent(utils.GetResource(msg)) {
 				return false

--- a/rules/aip0235/response_resource_field.go
+++ b/rules/aip0235/response_resource_field.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/gertd/go-pluralize"
 	"github.com/googleapis/api-linter/v2/lint"
+	"github.com/googleapis/api-linter/v2/rules/internal/utils"
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
@@ -31,7 +31,8 @@ var responseResourceField = &lint.MessageRule{
 		// the singular form the resource name, the first letter is Capitalized.
 		// Note: Retrieve the resource name from the the batch update response,
 		// for example: "BatchDeleteBooksResponse" -> "Books"
-		resourceMsgName := pluralize.NewClient().Singular(strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchDelete"))
+		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchDelete")
+		resourceMsgName := utils.ResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0235/response_resource_field.go
+++ b/rules/aip0235/response_resource_field.go
@@ -32,7 +32,7 @@ var responseResourceField = &lint.MessageRule{
 		// Note: Retrieve the resource name from the the batch update response,
 		// for example: "BatchDeleteBooksResponse" -> "Books"
 		pluralName := strings.TrimPrefix(strings.TrimSuffix(string(m.Name()), "Response"), "BatchDelete")
-		resourceMsgName := utils.ResourceSingular(pluralName, m)
+		resourceMsgName := utils.DeriveResourceSingular(pluralName, m)
 
 		for i := 0; i < m.Fields().Len(); i++ {
 			fieldDesc := m.Fields().Get(i)

--- a/rules/aip0235/response_resource_field_test.go
+++ b/rules/aip0235/response_resource_field_test.go
@@ -84,3 +84,61 @@ func TestResponseResourceField(t *testing.T) {
 		})
 	}
 }
+
+func TestResponseResourceFieldResourceAnnotation(t *testing.T) {
+	tests := []struct {
+		testName    string
+		Message     string
+		Field       string
+		problems    testutils.Problems
+		problemDesc func(m protoreflect.MessageDescriptor) protoreflect.Descriptor
+	}{
+		{
+			testName: "Valid-ResourceSingularMetadata",
+			Message:  "BatchDeleteImpressionMetadataResponse",
+			Field:    "repeated ImpressionMetadata impression_metadata",
+			problems: testutils.Problems{},
+		},
+		{
+			testName: "MissingField-ResourceSingularMetadata",
+			Message:  "BatchDeleteImpressionMetadataResponse",
+			Field:    "string response",
+			problems: testutils.Problems{{Message: `no "ImpressionMetadata" type field`}},
+			problemDesc: func(m protoreflect.MessageDescriptor) protoreflect.Descriptor {
+				return m
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3Tmpl(t, `
+				import "google/api/resource.proto";
+
+				message {{.Message}} {
+					{{.Field}} = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+				`, test)
+
+			m := file.Messages().Get(0)
+
+			var problemDesc protoreflect.Descriptor = m.Fields().Get(0)
+			if test.problemDesc != nil {
+				problemDesc = test.problemDesc(m)
+			}
+
+			problems := responseResourceField.Lint(file)
+			if diff := test.problems.SetDescriptor(problemDesc).Diff(problems); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}

--- a/rules/internal/utils/string_pluralize.go
+++ b/rules/internal/utils/string_pluralize.go
@@ -1,4 +1,4 @@
-// Copyright 2019 Google LLC
+// Copyright 2026 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/rules/internal/utils/string_pluralize.go
+++ b/rules/internal/utils/string_pluralize.go
@@ -54,9 +54,8 @@ func ResourceSingular(pluralName string, m protoreflect.MessageDescriptor) strin
 		if s := findResourceSingularInFile(pluralName, f); s != "" {
 			return s
 		}
-		// Also search directly imported files, since the resource message
-		// is often defined in a separate file (e.g. impression_metadata.proto)
-		// from the service file (impression_metadata_service.proto).
+		// Search direct imports only (not transitive); sufficient for standard proto
+		// layouts where the resource is in a sibling file imported by the service file.
 		imports := f.Imports()
 		for i := 0; i < imports.Len(); i++ {
 			if s := findResourceSingularInFile(pluralName, imports.Get(i).FileDescriptor); s != "" {

--- a/rules/internal/utils/string_pluralize.go
+++ b/rules/internal/utils/string_pluralize.go
@@ -16,6 +16,8 @@ package utils
 
 import (
 	"github.com/gertd/go-pluralize"
+	"github.com/stoewer/go-strcase"
+	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
 var pluralizeClient = pluralize.NewClient()
@@ -31,4 +33,71 @@ func ToPlural(s string) string {
 // ToSingular converts a string to its singular form.
 func ToSingular(s string) string {
 	return pluralizeClient.Singular(s)
+}
+
+// ResourceSingular returns the singular form of a resource name extracted from
+// a batch method message name (e.g. "Books" from "BatchUpdateBooksRequest").
+//
+// It searches for a resource message with a google.api.resource annotation
+// whose singular matches the expected singular of pluralName. This search
+// covers messages in the same file as well as directly imported files, since
+// the resource message is commonly defined in a separate file from the service
+// and request/response messages.
+//
+// If a matching resource annotation is found, its singular is returned (in
+// UpperCamelCase). Otherwise, it falls back to the go-pluralize library.
+//
+// This avoids incorrect singularization of words like "Metadata" (which
+// go-pluralize converts to "Metadatum" using Latin grammar rules).
+func ResourceSingular(pluralName string, m protoreflect.MessageDescriptor) string {
+	if f := m.ParentFile(); f != nil {
+		if s := findResourceSingularInFile(pluralName, f); s != "" {
+			return s
+		}
+		// Also search directly imported files, since the resource message
+		// is often defined in a separate file (e.g. impression_metadata.proto)
+		// from the service file (impression_metadata_service.proto).
+		imports := f.Imports()
+		for i := 0; i < imports.Len(); i++ {
+			if s := findResourceSingularInFile(pluralName, imports.Get(i).FileDescriptor); s != "" {
+				return s
+			}
+		}
+	}
+
+	return pluralizeClient.Singular(pluralName)
+}
+
+// findResourceSingularInFile searches all messages in a file for a resource
+// whose singular annotation matches the given pluralName.
+func findResourceSingularInFile(pluralName string, f protoreflect.FileDescriptor) string {
+	if f == nil {
+		return ""
+	}
+	for i := 0; i < f.Messages().Len(); i++ {
+		msg := f.Messages().Get(i)
+		res := GetResource(msg)
+		if res == nil {
+			continue
+		}
+		s := GetResourceSingular(res)
+		if s == "" {
+			continue
+		}
+		// The singular from the annotation is typically lowerCamelCase
+		// (e.g. "impressionMetadata"). Convert to UpperCamelCase for
+		// comparison with the message name.
+		upperSingular := strcase.UpperCamelCase(s)
+		// Check if the pluralName matches: either the singular itself
+		// (for uncountable nouns like "Metadata" where plural == singular)
+		// or the go-pluralize plural of the singular.
+		if pluralName == upperSingular || pluralName == pluralizeClient.Plural(upperSingular) {
+			return upperSingular
+		}
+		// Also check if the message name matches the plural portion.
+		if string(msg.Name()) == pluralName {
+			return upperSingular
+		}
+	}
+	return ""
 }

--- a/rules/internal/utils/string_pluralize.go
+++ b/rules/internal/utils/string_pluralize.go
@@ -40,9 +40,9 @@ func ToSingular(s string) string {
 //
 // It searches for a resource message with a google.api.resource annotation
 // whose singular matches the expected singular of pluralName. This search
-// covers messages in the same file as well as directly imported files, since
-// the resource message is commonly defined in a separate file from the service
-// and request/response messages.
+// covers the file's entire import graph (recursively), since the resource
+// message may be defined in a separate file from the service and
+// request/response messages.
 //
 // If a matching resource annotation is found, its singular is returned (in
 // UpperCamelCase). Otherwise, it falls back to the go-pluralize library.
@@ -51,20 +51,31 @@ func ToSingular(s string) string {
 // go-pluralize converts to "Metadatum" using Latin grammar rules).
 func ResourceSingular(pluralName string, m protoreflect.MessageDescriptor) string {
 	if f := m.ParentFile(); f != nil {
-		if s := findResourceSingularInFile(pluralName, f); s != "" {
+		if s := findResourceSingularRecursive(pluralName, f, make(map[string]bool)); s != "" {
 			return s
 		}
-		// Search direct imports only (not transitive); sufficient for standard proto
-		// layouts where the resource is in a sibling file imported by the service file.
-		imports := f.Imports()
-		for i := 0; i < imports.Len(); i++ {
-			if s := findResourceSingularInFile(pluralName, imports.Get(i).FileDescriptor); s != "" {
-				return s
-			}
+	}
+	return pluralizeClient.Singular(pluralName)
+}
+
+// findResourceSingularRecursive searches a file and its transitive imports
+// for a resource whose singular annotation matches the given pluralName.
+func findResourceSingularRecursive(pluralName string, f protoreflect.FileDescriptor, visited map[string]bool) string {
+	if f == nil || visited[string(f.Path())] {
+		return ""
+	}
+	visited[string(f.Path())] = true
+
+	if s := findResourceSingularInFile(pluralName, f); s != "" {
+		return s
+	}
+	imports := f.Imports()
+	for i := 0; i < imports.Len(); i++ {
+		if s := findResourceSingularRecursive(pluralName, imports.Get(i).FileDescriptor, visited); s != "" {
+			return s
 		}
 	}
-
-	return pluralizeClient.Singular(pluralName)
+	return ""
 }
 
 // findResourceSingularInFile searches all messages in a file for a resource

--- a/rules/internal/utils/string_pluralize.go
+++ b/rules/internal/utils/string_pluralize.go
@@ -1,4 +1,4 @@
-// Copyright 2026 Google LLC
+// Copyright 2019 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -35,7 +35,7 @@ func ToSingular(s string) string {
 	return pluralizeClient.Singular(s)
 }
 
-// ResourceSingular returns the singular form of a resource name extracted from
+// DeriveResourceSingular returns the singular form of a resource name extracted from
 // a batch method message name (e.g. "Books" from "BatchUpdateBooksRequest").
 //
 // It searches for a resource message with a google.api.resource annotation
@@ -49,33 +49,18 @@ func ToSingular(s string) string {
 //
 // This avoids incorrect singularization of words like "Metadata" (which
 // go-pluralize converts to "Metadatum" using Latin grammar rules).
-func ResourceSingular(pluralName string, m protoreflect.MessageDescriptor) string {
+func DeriveResourceSingular(pluralName string, m protoreflect.MessageDescriptor) string {
 	if f := m.ParentFile(); f != nil {
-		if s := findResourceSingularRecursive(pluralName, f, make(map[string]bool)); s != "" {
-			return s
+		// GetAllDependencies walks the transitive import graph (with dedup), so
+		// the resource message is found even when it is defined in a separate
+		// file from the service and request/response messages.
+		for _, dep := range GetAllDependencies(f) {
+			if s := findResourceSingularInFile(pluralName, dep); s != "" {
+				return s
+			}
 		}
 	}
 	return pluralizeClient.Singular(pluralName)
-}
-
-// findResourceSingularRecursive searches a file and its transitive imports
-// for a resource whose singular annotation matches the given pluralName.
-func findResourceSingularRecursive(pluralName string, f protoreflect.FileDescriptor, visited map[string]bool) string {
-	if f == nil || visited[string(f.Path())] {
-		return ""
-	}
-	visited[string(f.Path())] = true
-
-	if s := findResourceSingularInFile(pluralName, f); s != "" {
-		return s
-	}
-	imports := f.Imports()
-	for i := 0; i < imports.Len(); i++ {
-		if s := findResourceSingularRecursive(pluralName, imports.Get(i).FileDescriptor, visited); s != "" {
-			return s
-		}
-	}
-	return ""
 }
 
 // findResourceSingularInFile searches all messages in a file for a resource

--- a/rules/internal/utils/string_pluralize_test.go
+++ b/rules/internal/utils/string_pluralize_test.go
@@ -16,6 +16,8 @@ package utils
 
 import (
 	"testing"
+
+	"github.com/googleapis/api-linter/v2/rules/internal/testutils"
 )
 
 func TestPluralize(t *testing.T) {
@@ -37,6 +39,107 @@ func TestPluralize(t *testing.T) {
 		t.Run(test.word, func(t *testing.T) {
 			if got := ToPlural(test.word); got != test.pluralizedWord {
 				t.Errorf("Plural(%s) got %s, but want %s", test.word, got, test.pluralizedWord)
+			}
+		})
+	}
+}
+
+func TestResourceSingular(t *testing.T) {
+	tests := []struct {
+		testName   string
+		pluralName string
+		src        string
+		want       string
+	}{
+		{
+			testName:   "AnnotationInSameFile",
+			pluralName: "ImpressionMetadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchUpdateImpressionMetadataRequest {
+					string parent = 1;
+				}
+				message ImpressionMetadata {
+					option (google.api.resource) = {
+						type: "example.com/ImpressionMetadata"
+						pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+						singular: "impressionMetadata"
+						plural: "impressionMetadata"
+					};
+				}
+			`,
+			want: "ImpressionMetadata",
+		},
+		{
+			testName:   "FallbackToGoPluralizeBooks",
+			pluralName: "Books",
+			src: `
+				message BatchUpdateBooksRequest {
+					string parent = 1;
+				}
+			`,
+			want: "Book",
+		},
+		{
+			testName:   "UncountableNounPluralEqualsSingular",
+			pluralName: "Metadata",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchUpdateMetadataRequest {
+					string parent = 1;
+				}
+				message Metadata {
+					option (google.api.resource) = {
+						type: "example.com/Metadata"
+						pattern: "items/{item}/metadata/{metadata}"
+						singular: "metadata"
+						plural: "metadata"
+					};
+				}
+			`,
+			want: "Metadata",
+		},
+		{
+			testName:   "MessageNameMatchesPluralName",
+			pluralName: "CursorData",
+			src: `
+				import "google/api/resource.proto";
+
+				message BatchUpdateCursorDataRequest {
+					string parent = 1;
+				}
+				message CursorData {
+					option (google.api.resource) = {
+						type: "example.com/CursorData"
+						pattern: "items/{item}/cursorData/{cursor_data}"
+						singular: "cursorDatum"
+						plural: "cursorData"
+					};
+				}
+			`,
+			want: "CursorDatum",
+		},
+		{
+			testName:   "NoAnnotationLatinWord",
+			pluralName: "Data",
+			src: `
+				message BatchUpdateDataRequest {
+					string parent = 1;
+				}
+			`,
+			want: "Datum",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.testName, func(t *testing.T) {
+			file := testutils.ParseProto3String(t, test.src)
+			m := file.Messages().Get(0)
+			got := ResourceSingular(test.pluralName, m)
+			if got != test.want {
+				t.Errorf("ResourceSingular(%q) = %q, want %q", test.pluralName, got, test.want)
 			}
 		})
 	}

--- a/rules/internal/utils/string_pluralize_test.go
+++ b/rules/internal/utils/string_pluralize_test.go
@@ -144,3 +144,38 @@ func TestResourceSingular(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceSingularImportedFile(t *testing.T) {
+	// Verify that ResourceSingular finds the resource annotation in a
+	// directly imported file, not just the same file.
+	files := testutils.ParseProtoStrings(t, map[string]string{
+		"resource.proto": `
+			syntax = "proto3";
+			import "google/api/resource.proto";
+
+			message ImpressionMetadata {
+				option (google.api.resource) = {
+					type: "example.com/ImpressionMetadata"
+					pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+					singular: "impressionMetadata"
+					plural: "impressionMetadata"
+				};
+			}
+		`,
+		"service.proto": `
+			syntax = "proto3";
+			import "resource.proto";
+
+			message BatchUpdateImpressionMetadataRequest {
+				string parent = 1;
+			}
+		`,
+	})
+
+	serviceFile := files["service.proto"]
+	m := serviceFile.Messages().Get(0)
+	got := ResourceSingular("ImpressionMetadata", m)
+	if got != "ImpressionMetadata" {
+		t.Errorf("ResourceSingular(\"ImpressionMetadata\") = %q, want \"ImpressionMetadata\"", got)
+	}
+}

--- a/rules/internal/utils/string_pluralize_test.go
+++ b/rules/internal/utils/string_pluralize_test.go
@@ -179,3 +179,46 @@ func TestResourceSingularImportedFile(t *testing.T) {
 		t.Errorf("ResourceSingular(\"ImpressionMetadata\") = %q, want \"ImpressionMetadata\"", got)
 	}
 }
+
+func TestResourceSingularTransitiveImport(t *testing.T) {
+	// Verify that ResourceSingular finds the resource annotation
+	// through transitive imports (service -> common -> resource).
+	files := testutils.ParseProtoStrings(t, map[string]string{
+		"resource.proto": `
+			syntax = "proto3";
+			import "google/api/resource.proto";
+
+			message ImpressionMetadata {
+				option (google.api.resource) = {
+					type: "example.com/ImpressionMetadata"
+					pattern: "dataProviders/{dp}/impressionMetadata/{im}"
+					singular: "impressionMetadata"
+					plural: "impressionMetadata"
+				};
+			}
+		`,
+		"common.proto": `
+			syntax = "proto3";
+			import "resource.proto";
+
+			message CommonFields {
+				string parent = 1;
+			}
+		`,
+		"service.proto": `
+			syntax = "proto3";
+			import "common.proto";
+
+			message BatchUpdateImpressionMetadataRequest {
+				string parent = 1;
+			}
+		`,
+	})
+
+	serviceFile := files["service.proto"]
+	m := serviceFile.Messages().Get(0)
+	got := ResourceSingular("ImpressionMetadata", m)
+	if got != "ImpressionMetadata" {
+		t.Errorf("ResourceSingular(\"ImpressionMetadata\") = %q, want \"ImpressionMetadata\"", got)
+	}
+}

--- a/rules/internal/utils/string_pluralize_test.go
+++ b/rules/internal/utils/string_pluralize_test.go
@@ -44,7 +44,7 @@ func TestPluralize(t *testing.T) {
 	}
 }
 
-func TestResourceSingular(t *testing.T) {
+func TestDeriveResourceSingular(t *testing.T) {
 	tests := []struct {
 		testName   string
 		pluralName string
@@ -137,16 +137,16 @@ func TestResourceSingular(t *testing.T) {
 		t.Run(test.testName, func(t *testing.T) {
 			file := testutils.ParseProto3String(t, test.src)
 			m := file.Messages().Get(0)
-			got := ResourceSingular(test.pluralName, m)
+			got := DeriveResourceSingular(test.pluralName, m)
 			if got != test.want {
-				t.Errorf("ResourceSingular(%q) = %q, want %q", test.pluralName, got, test.want)
+				t.Errorf("DeriveResourceSingular(%q) = %q, want %q", test.pluralName, got, test.want)
 			}
 		})
 	}
 }
 
-func TestResourceSingularImportedFile(t *testing.T) {
-	// Verify that ResourceSingular finds the resource annotation in a
+func TestDeriveResourceSingularImportedFile(t *testing.T) {
+	// Verify that DeriveResourceSingular finds the resource annotation in a
 	// directly imported file, not just the same file.
 	files := testutils.ParseProtoStrings(t, map[string]string{
 		"resource.proto": `
@@ -174,14 +174,15 @@ func TestResourceSingularImportedFile(t *testing.T) {
 
 	serviceFile := files["service.proto"]
 	m := serviceFile.Messages().Get(0)
-	got := ResourceSingular("ImpressionMetadata", m)
-	if got != "ImpressionMetadata" {
-		t.Errorf("ResourceSingular(\"ImpressionMetadata\") = %q, want \"ImpressionMetadata\"", got)
+	want := "ImpressionMetadata"
+	got := DeriveResourceSingular(want, m)
+	if got != want {
+		t.Errorf("DeriveResourceSingular(%q) = %q, want %q", want, got, want)
 	}
 }
 
-func TestResourceSingularTransitiveImport(t *testing.T) {
-	// Verify that ResourceSingular finds the resource annotation
+func TestDeriveResourceSingularTransitiveImport(t *testing.T) {
+	// Verify that DeriveResourceSingular finds the resource annotation
 	// through transitive imports (service -> common -> resource).
 	files := testutils.ParseProtoStrings(t, map[string]string{
 		"resource.proto": `
@@ -217,8 +218,9 @@ func TestResourceSingularTransitiveImport(t *testing.T) {
 
 	serviceFile := files["service.proto"]
 	m := serviceFile.Messages().Get(0)
-	got := ResourceSingular("ImpressionMetadata", m)
-	if got != "ImpressionMetadata" {
-		t.Errorf("ResourceSingular(\"ImpressionMetadata\") = %q, want \"ImpressionMetadata\"", got)
+	want := "ImpressionMetadata"
+	got := DeriveResourceSingular(want, m)
+	if got != want {
+		t.Errorf("DeriveResourceSingular(%q) = %q, want %q", want, got, want)
 	}
 }


### PR DESCRIPTION
## Summary

Batch method rules (AIP-0231, 0233, 0234, 0235) for `request-requests-field`, `request-names-field`, and `response-resource-field` used `go-pluralize` to singularize the resource name extracted from batch message names. This produced incorrect results for words like "Metadata", which `go-pluralize` singularizes to "Metadatum" using Latin grammar rules.

This PR adds a `DeriveResourceSingular()` helper that first checks for a `google.api.resource` annotation with a `singular` field on sibling or (transitively) imported resource messages before falling back to `go-pluralize`. This is analogous to the fix in #1573 for the `plural-method-name` rule.

When no `google.api.resource` annotation is found, the function falls back to `go-pluralize`, preserving existing behavior for all other resources.

## Affected Rules

- `core::0231::request-names-field`
- `core::0231::response-resource-field`
- `core::0233::request-requests-field`
- `core::0233::response-resource-field`
- `core::0234::request-requests-field`
- `core::0234::response-resource-field`
- `core::0235::request-names-field`
- `core::0235::response-resource-field`

## Changes

- **`rules/internal/utils/string_pluralize.go`**: Add `DeriveResourceSingular()`, which searches messages in the current file and its transitive imports (via the existing `utils.GetAllDependencies` helper) for a `google.api.resource` annotation with a matching `singular` value, converting it to UpperCamelCase. Falls back to `go-pluralize` if no annotation is found.
- **8 rule files across AIP-0231, 0233, 0234, 0235**: Replace `pluralize.NewClient().Singular()` calls with `utils.DeriveResourceSingular()`.
- **Rule tests across AIP-0231, 0233, 0234, 0235**: Add `...ResourceAnnotation` test cases for `ImpressionMetadata` with a `google.api.resource` annotation, verifying both the `request-*-field` and `response-resource-field` rules.

## Test plan

- Added resource annotation tests for all 8 affected rules across AIP-0231, 0233, 0234, and 0235
- Added unit tests for `DeriveResourceSingular()` covering: annotation in same file, annotation in imported file, fallback to go-pluralize, uncountable nouns, message name matching, and no-annotation Latin words
- Added multi-file import tests (`TestDeriveResourceSingularImportedFile` for a directly imported file, and `TestDeriveResourceSingularTransitiveImport` for a 3-file `service.proto -> common.proto -> resource.proto` chain) exercising the transitive import search path
- `go test -race ./...` passes (0 failures)
- `golangci-lint run ./...` reports 0 issues
- Verified against [cross-media-measurement](https://github.com/world-federation-of-advertisers/cross-media-measurement) protos: removing all 6 `Metadatum` disable comments produces zero false positives with the fixed linter

Issue: #1628
